### PR TITLE
typo-Update LightClient.t.sol

### DIFF
--- a/contracts/test/LightClient.t.sol
+++ b/contracts/test/LightClient.t.sol
@@ -109,7 +109,7 @@ contract LightClient_constructor_Test is LightClientCommonTest {
         lc = new LCMock(_genesis, _genesisStakeTableState, _stateHistoryRetentionPeriod);
     }
 
-    // test that initiazing the contract reverts when the stateHistoryRetentionPeriod is below the
+    // test that initializing the contract reverts when the stateHistoryRetentionPeriod is below the
     // required threshold
     function test_RevertWhen_InvalidStateHistoryRetentionPeriodOnSetUp() public {
         uint32 invalidRetentionPeriod = 10;


### PR DESCRIPTION
# Fix: Corrected typo in test file

## Changes
- `contracts/test/LightClient.t.sol:112`: "initiazing" corrected to "initializing".

## Purpose
- Improved code accuracy and ensured clarity in test file.
