### PR TITLE
fix docker demo: fund builder after deploying prover contracts

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
       - RUST_LOG
       - RUST_LOG_FORMAT
     depends_on:
-      deploy-sequencer-contracts:
+      deploy-prover-contracts:
         condition: service_completed_successfully
       sequencer1:
         condition: service_healthy


### PR DESCRIPTION
In native demo we fund builder after the prover contracts are deployed. However, this change has not been made for docker compose, which results in different light client contract address because builder is funded before prover contracts are deployed