### PR TITLE
refactor(types): restrict visibility of NsPayloadByteLen::from_usize

### DIFF
--- a/types/src/v0/impls/block/namespace_payload/types.rs
+++ b/types/src/v0/impls/block/namespace_payload/types.rs
@@ -138,8 +138,7 @@ impl NumTxs {
 }
 
 impl NsPayloadByteLen {
-    // TODO restrict visibility?
-    pub fn from_usize(n: usize) -> Self {
+    pub(crate) fn from_usize(n: usize) -> Self {
         Self(n)
     }
 }


### PR DESCRIPTION
Restrict the visibility of NsPayloadByteLen::from_usize method to crate-level
since it's only used internally within the crate. This improves encapsulation
and removes a TODO comment.

- Changed visibility from `pub` to `pub(crate)`
- Removed TODO comment about visibility restriction