### PR TITLE
add timeout to provider::connect() in l1 update loop

### DIFF
--- a/types/src/v0/v0_1/l1.rs
+++ b/types/src/v0/v0_1/l1.rs
@@ -60,6 +60,15 @@ pub struct L1ClientOptions {
     )]
     pub l1_retry_delay: Duration,
 
+    /// Timeout for connecting to the L1 provider.
+    #[clap(
+        long,
+        env = "ESPRESSO_SEQUENCER_L1_CONNECT_TIMEOUT",
+        default_value = "2s",
+        value_parser = parse_duration,
+    )]
+    pub connect_timeout: Duration,
+
     /// Request rate when polling L1.
     #[clap(
         long,


### PR DESCRIPTION
This PR adds a timeout to `provider::connect()` in the L1 update state loop to prevent hangs due to DNS resolution issues.