### PR TITLE
fix: fix deploy function comment

### DIFF
--- a/contracts/script/FeeContract.s.sol
+++ b/contracts/script/FeeContract.s.sol
@@ -68,7 +68,7 @@ contract UpgradeFeeContractScript is Script {
         // validate that the new implementation contract is upgrade safe
         Upgrades.validateUpgrade(upgradeContractName, opts);
 
-        // get the deployer to depley the new implementation contract
+        // get the deployer to deploy the new implementation contract
         address deployer;
         string memory ledgerCommand = vm.envString("USE_HARDWARE_WALLET");
         if (keccak256(bytes(ledgerCommand)) == keccak256(bytes("true"))) {


### PR DESCRIPTION
### This PR:
A typo in a comment where "depley" was used instead of "deploy."
This was in the section that refers to deploying the new implementation contract. It’s now properly spelled as "deploy."

[x] PR description is clear enough for reviewers. -->
[x] Documentation for changes (additions) has been updated (added).  -->
