### PR TITLE
Fix Typos and Grammar in Documentation and Code Comments

### DIFF
--- a/doc/smart-contract-upgrades.md
+++ b/doc/smart-contract-upgrades.md
@@ -200,7 +200,7 @@ contract V2 is V1 {
 
 The logic in existing functions can be overridden but be sure not to introduce breaking changes.
 
-Criteria for Overriding Functions::
+Criteria for Overriding Functions:
 
 - a function must be marked as `virtual` in the base contract so that it can be eligible to be overridden in a derived
   contract.

--- a/doc/zk-integration.md
+++ b/doc/zk-integration.md
@@ -167,7 +167,7 @@ The circuit depicted in Figure 2 operates as follows:
   With witnesses of all transactions to the rollup `ROLLUP_TXS` and proofs that they are complete and correctly filtered
   from finalized Espresso blocks since last update `TXS_NAMESPACE_PROOFS`, it checks that:
   - Namespace proofs `TXS_NAMESPACE_PROOFS` are valid, saying that `ROLLUP_TXS` are complete and correctly filtered from
-    Espresso blockscommited in a Merkle tree with root `blk_cm_root` since last update.
+    Espresso blocks commited in a Merkle tree with root `blk_cm_root` since last update.
   - Given `cm_txs_rollup` commits to the filtered transactions `ROLLUP_TXS`.
 - The _zkVM_ gadget is the original gadget of the rollup circuit that proves a correct transition from state
   `cm_state_vm i` to the next state `cm_state_vm i+1` when applying the transactions represented by the commitment value

--- a/hotshot-examples/push-cdn/all.rs
+++ b/hotshot-examples/push-cdn/all.rs
@@ -46,7 +46,7 @@ async fn main() {
     // use configfile args
     let (config, orchestrator_url) = read_orchestrator_init_config::<TestTypes>();
 
-    // Start the orhcestrator
+    // Start the orchestrator
     spawn(run_orchestrator::<TestTypes>(OrchestratorArgs {
         url: orchestrator_url.clone(),
         config: config.clone(),

--- a/hotshot-query-service/README.md
+++ b/hotshot-query-service/README.md
@@ -31,7 +31,7 @@ application).
 - Provides a query interface for validator status and metrics
 - Integrates with HotShot to populate the persistent database
 - Generic over application types (within a leaf, the block and block commitment can be any type the
-  application specifieds)
+  application specifies)
 - Transparently handles asynchronous data availability &mdash; block commitments are provided as
   soon as they are committed by consensus; block data is provided once it has disseminated from the
   data availability committee; missing data is fetched asynchronously from other nodes

--- a/hotshot-task/src/dependency.rs
+++ b/hotshot-task/src/dependency.rs
@@ -101,7 +101,7 @@ impl<T: Clone + Send + Sync> Dependency<T> for OrDependency<T> {
 }
 
 impl<T: Clone + Send + Sync + 'static> OrDependency<T> {
-    /// Creat an `OrDependency` from a vec of dependencies
+    /// Create an `OrDependency` from a vec of dependencies
     #[must_use]
     pub fn from_deps(deps: Vec<impl Dependency<T> + Send + 'static>) -> Self {
         let mut pinned = vec![];


### PR DESCRIPTION
"Criteria for Overriding Functions::" → "Criteria for Overriding Functions:"
"Espresso blockscommited" → "Espresso blocks committed"
"Start the orhcestrator" → "Start the orchestrator"
"application specifieds" → "application specifies"
"Creat an OrDependency" → "Create an OrDependency"