### PR TITLE
CI: use public runners for cargo features check

### DIFF
--- a/.github/workflows/cargo-features.yml
+++ b/.github/workflows/cargo-features.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   cargo-features:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/install-action@cargo-hack
 


### PR DESCRIPTION
This isn't a very important job and it's not required to merge so it's IMO fine if it's a bit slower. This frees up buildjet runners for other jobs.
