### PR TITLE
Fix decide logic in response to audit feedback

### DIFF
--- a/hotshot-task-impls/src/helpers.rs
+++ b/hotshot-task-impls/src/helpers.rs
@@ -324,10 +324,8 @@ pub async fn decide_from_proposal_2<TYPES: NodeType>(
         let epoch_height = consensus_reader.epoch_height;
         drop(consensus_reader);
 
-        if let Some(decided_leaf_info) = res.leaf_views.last() {
+        for decided_leaf_info in &res.leaf_views {
             decide_epoch_root(&decided_leaf_info.leaf, epoch_height, membership).await;
-        } else {
-            tracing::info!("No decided leaf while a view has been decided.");
         }
     }
 
@@ -482,10 +480,8 @@ pub async fn decide_from_proposal<TYPES: NodeType, V: Versions>(
     drop(consensus_reader);
 
     if with_epochs && res.new_decided_view_number.is_some() {
-        if let Some(decided_leaf_info) = res.leaf_views.last() {
+        for decided_leaf_info in &res.leaf_views {
             decide_epoch_root(&decided_leaf_info.leaf, epoch_height, membership).await;
-        } else {
-            tracing::info!("No decided leaf while a view has been decided.");
         }
     }
 


### PR DESCRIPTION
Fixes an issue identified during an audit where we might skip an `add_epoch_root` call depending on where in the chain a leaf was decided
