### PR TITLE
Avoid multiple binaries in nextest sharding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
         run: |
           cargo nextest run --archive-file nextest-archive-postgres.tar.zst  --verbose --no-fail-fast \
           --workspace-remap $PWD \
-          --partition hash:${{ matrix.partition }}/10
+          --partition count:${{ matrix.partition }}/10
         timeout-minutes: 20
 
   test-sqlite:
@@ -202,7 +202,7 @@ jobs:
         run: |
           cargo nextest run --archive-file nextest-archive-sqlite.tar.zst  --verbose --no-fail-fast \
           --workspace-remap $PWD \
-          --partition hash:${{ matrix.partition }}/10
+          --partition count:${{ matrix.partition }}/10
         timeout-minutes: 20
 
   test-integration:

--- a/hotshot.just
+++ b/hotshot.just
@@ -24,27 +24,27 @@ test-ci-5:
 
 test-ci-6-1:
   echo Running integration test group 6
-  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition hash:1/6
+  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition count:1/6
 
 test-ci-6-2:
   echo Running integration test group 6
-  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition hash:2/6
+  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition count:2/6
 
 test-ci-6-3:
   echo Running integration test group 6
-  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition hash:3/6
+  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition count:3/6
 
 test-ci-6-4:
   echo Running integration test group 6
-  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition hash:4/6
+  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition count:4/6
 
 test-ci-6-5:
   echo Running integration test group 6
-  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition hash:5/6
+  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition count:5/6
 
 test-ci-6-6:
   echo Running integration test group 6
-  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition hash:6/6
+  RUST_LOG=error cargo nextest run --profile hotshot --test tests_6 --no-fail-fast --partition count:6/6
 
 # Usage:
 #


### PR DESCRIPTION
This is a test PR to see if changing the nextest sharding to use `count` rather than `hash` helps with test compile times 
