### PR TITLE
CI: features cleanup

### DIFF
--- a/.github/workflows/cargo-features.yml
+++ b/.github/workflows/cargo-features.yml
@@ -20,8 +20,14 @@ concurrency:
 jobs:
   cargo-features:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        command:
+          - just check-features-ci
+          - just check-features-ci --tests
     steps:
       - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@just
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -29,25 +35,18 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
-          tool-cache: false
           android: true
-          dotnet: true
-          haskell: true
+          tool-cache: false
+          dotnet: false
+          haskell: false
           large-packages: false
           docker-images: false
           swap-storage: false
 
       # Note: this job doesn't use a cache on purpose because it mostly compiles
       # the crates in this repo over and over again with different feature
-      # combinations. Adding caching would not speed it up much and further
-      # contribute to our cache usage.
-
-      # Includes checks for `--no-default-features` and `--all-features` as well
-      # as each individual feature enabled.
-      - name: Check compilation for feature combinations
+      # combinations. The target directory gets really large. Adding caching
+      # would not speed it up much and further contribute to our cache usage.
+      - name: Check compilation feature combinations
         run: |
-          cargo hack check --feature-powerset --exclude hotshot --exclude hotshot-builder-api --exclude hotshot-task-impls --exclude hotshot-macros --exclude hotshot-events-service --exclude hotshot-utils --exclude hotshot-orchestrator --exclude hotshot-query-service --exclude hotshot-stake-table --exclude hotshot-state-prover --exclude hotshot-task --exclude hotshot-testing --exclude hotshot-types --exclude hotshot-libp2p-networking --exclude hotshot-contract-adapter --exclude hotshot-example-types --exclude vid
-
-      - name: Check compilation for feature combinations (--tests)
-        run: |
-          cargo hack check --feature-powerset --tests --exclude hotshot --exclude hotshot-builder-api --exclude hotshot-task-impls --exclude hotshot-macros --exclude hotshot-events-service --exclude hotshot-utils --exclude hotshot-orchestrator --exclude hotshot-query-service --exclude hotshot-stake-table --exclude hotshot-state-prover --exclude hotshot-task --exclude hotshot-testing --exclude hotshot-types --exclude hotshot-libp2p-networking --exclude hotshot-contract-adapter --exclude hotshot-example-types --exclude vid
+          ${{ maxtrix.command }}

--- a/.github/workflows/cargo-features.yml
+++ b/.github/workflows/cargo-features.yml
@@ -49,4 +49,4 @@ jobs:
       # would not speed it up much and further contribute to our cache usage.
       - name: Check compilation feature combinations
         run: |
-          ${{ maxtrix.command }}
+          ${{ matrix.command }}

--- a/flake.nix
+++ b/flake.nix
@@ -254,6 +254,9 @@
 
             # Add rust binaries to PATH for native demo
             export PATH="$PWD/$CARGO_TARGET_DIR/debug:$PATH"
+
+            # Needed to compile with the sqlite-unbundled feature
+            export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib";
           '' + self.checks.${system}.pre-commit-check.shellHook;
           RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
           FOUNDRY_SOLC = "${solc}/bin/solc";

--- a/justfile
+++ b/justfile
@@ -89,6 +89,31 @@ clippy:
 check-features *args:
     cargo hack check --each-feature {{args}}
 
+check-features-ci *args:
+    # check each pair of features plus `default` and `--no-default-features`
+    cargo hack check --feature-powerset \
+        --depth 2 \
+        --exclude contract-bindings-alloy \
+        --exclude contract-bindings-ethers \
+        --exclude hotshot \
+        --exclude hotshot-builder-api \
+        --exclude hotshot-contract-adapter \
+        --exclude hotshot-events-service \
+        --exclude hotshot-example-types \
+        --exclude hotshot-libp2p-networking \
+        --exclude hotshot-macros \
+        --exclude hotshot-orchestrator \
+        --exclude hotshot-query-service \
+        --exclude hotshot-stake-table \
+        --exclude hotshot-state-prover \
+        --exclude hotshot-task \
+        --exclude hotshot-task-impls \
+        --exclude hotshot-testing \
+        --exclude hotshot-types \
+        --exclude hotshot-utils \
+        --exclude vid \
+        {{args}}
+
 # Helpful shortcuts for local development
 dev-orchestrator:
     target/release/orchestrator -p 8080 -n 1


### PR DESCRIPTION
- Move commands to justfile
- Use matrix: run without `--tests` or with
- Only check pairs of features. This tests that each feature works with each other feature. This should cover most problems while hopefully keeping runtime reasable.
- Fix sqlite-unbundled feature in nix-shell.
