### PR TITLE
Always fetched finalized blocks by hash

### DIFF
--- a/types/src/v0/impls/l1.rs
+++ b/types/src/v0/impls/l1.rs
@@ -15,7 +15,7 @@ use alloy::{
     rpc::{
         client::RpcClient,
         json_rpc::{RequestPacket, ResponsePacket},
-        types::BlockTransactionsKind,
+        types::{Block, BlockTransactionsKind},
     },
     transports::{http::Http, RpcError, TransportErrorKind},
 };
@@ -49,7 +49,7 @@ use url::Url;
 use super::{
     v0_1::{SingleTransport, SingleTransportStatus, SwitchingTransport},
     v0_3::StakeTables,
-    L1BlockInfo, L1ClientMetrics, L1State, L1UpdateTask,
+    L1BlockInfo, L1BlockInfoWithParent, L1ClientMetrics, L1State, L1UpdateTask,
 };
 use crate::{FeeInfo, L1Client, L1ClientOptions, L1Event, L1Snapshot};
 
@@ -62,6 +62,25 @@ impl PartialOrd for L1BlockInfo {
 impl Ord for L1BlockInfo {
     fn cmp(&self, other: &Self) -> Ordering {
         self.number.cmp(&other.number)
+    }
+}
+
+impl From<&Block> for L1BlockInfo {
+    fn from(block: &Block) -> Self {
+        Self {
+            number: block.header.number,
+            timestamp: ethers::types::U256::from(block.header.timestamp),
+            hash: block.header.hash.to_ethers(),
+        }
+    }
+}
+
+impl From<&Block> for L1BlockInfoWithParent {
+    fn from(block: &Block) -> Self {
+        Self {
+            info: block.into(),
+            parent_hash: block.header.parent_hash,
+        }
     }
 }
 
@@ -526,17 +545,15 @@ impl L1Client {
                                     .await
                                     .ok();
                             }
-                            if finalized > state.snapshot.finalized {
-                                tracing::info!(
-                                    ?finalized,
-                                    old_finalized = ?state.snapshot.finalized,
-                                    "L1 finalized updated",
-                                );
-                                if let Some(finalized) = finalized {
-                                    metrics.finalized.set(finalized.number as usize);
-                                }
-                                state.snapshot.finalized = finalized;
-                                if let Some(finalized) = finalized {
+                            if let Some(finalized) = finalized {
+                                if Some(finalized.info) > state.snapshot.finalized {
+                                    tracing::info!(
+                                        ?finalized,
+                                        old_finalized = ?state.snapshot.finalized,
+                                        "L1 finalized updated",
+                                    );
+                                    metrics.finalized.set(finalized.info.number as usize);
+                                    state.snapshot.finalized = Some(finalized.info);
                                     sender
                                         .broadcast_direct(L1Event::NewFinalized { finalized })
                                         .await
@@ -636,12 +653,11 @@ impl L1Client {
                 let L1Event::NewFinalized { finalized } = event else {
                     continue;
                 };
-                if finalized.number >= number {
+                let mut state = self.state.lock().await;
+                state.put_finalized(finalized);
+                if finalized.info.number >= number {
                     tracing::info!(number, ?finalized, "got finalized L1 block");
-                    return self
-                        .get_finalized_block(self.state.lock().await, number)
-                        .await
-                        .1;
+                    return self.get_finalized_block(state, number).await.1;
                 }
                 tracing::debug!(number, ?finalized, "waiting for finalized L1 block");
             }
@@ -681,9 +697,9 @@ impl L1Client {
                 let L1Event::NewFinalized { finalized } = event else {
                     continue;
                 };
-                if finalized.timestamp >= timestamp.to_ethers() {
+                if finalized.info.timestamp >= timestamp.to_ethers() {
                     tracing::info!(%timestamp, ?finalized, "got finalized block");
-                    break 'outer (self.state.lock().await, finalized);
+                    break 'outer (self.state.lock().await, finalized.info);
                 }
                 tracing::debug!(%timestamp, ?finalized, "waiting for L1 finalized block");
             }
@@ -710,52 +726,85 @@ impl L1Client {
         mut state: MutexGuard<'a, L1State>,
         number: u64,
     ) -> (MutexGuard<'a, L1State>, L1BlockInfo) {
-        // Try to get the block from the finalized block cache.
+        let latest_finalized = state
+            .snapshot
+            .finalized
+            .expect("get_finalized_block called before any blocks are finalized");
         assert!(
-            state.snapshot.finalized.is_some()
-                && number <= state.snapshot.finalized.unwrap().number,
+            number <= latest_finalized.number,
             "requesting a finalized block {number} that isn't finalized; snapshot: {:?}",
             state.snapshot,
         );
-        if let Some(block) = state.finalized.get(&number) {
-            let block = *block;
-            return (state, block);
-        }
-        drop(state);
 
-        // If not in cache, fetch the block from the L1 provider.
-        let block = loop {
-            let block = match self
-                .provider
-                .get_block(BlockId::number(number), BlockTransactionsKind::Hashes)
-                .await
-            {
-                Ok(Some(block)) => block,
-                Ok(None) => {
-                    tracing::warn!(
-                        number,
-                        "provider error: finalized L1 block should always be available"
-                    );
-                    self.retry_delay().await;
-                    continue;
-                },
-                Err(err) => {
-                    tracing::warn!(number, "failed to get finalized L1 block: {err:#}");
-                    self.retry_delay().await;
-                    continue;
-                },
-            };
-            break L1BlockInfo {
-                number: block.header.number,
-                hash: block.header.hash.to_ethers(),
-                timestamp: ethers::types::U256::from(block.header.timestamp),
-            };
+        // To get this block and be sure we are getting the correct finalized block, we first need
+        // to find an equal or later block so we can find the expected hash of this block. If we
+        // were to just look up the block by number, there could be problems if we failed over to a
+        // different (lagging) L1 provider, which has yet to finalize this block and reports a
+        // different block with the same number.
+        let mut successor_number = number;
+        let mut successor = loop {
+            if let Some(block) = state.finalized.get(&successor_number) {
+                break *block;
+            }
+            successor_number += 1;
+            if successor_number > latest_finalized.number {
+                // We don't have any cached finalized block after the requested one; fetch the
+                // current finalized block from the network.
+                // Don't hold state lock while fetching from network.
+                drop(state);
+                let block = loop {
+                    match get_finalized_block(&self.provider).await {
+                        Ok(Some(block)) => {
+                            break block;
+                        },
+                        Ok(None) => {
+                            tracing::warn!("no finalized block even though finalized snapshot is Some; this can be caused by an L1 client failover");
+                            self.retry_delay().await;
+                        },
+                        Err(err) => {
+                            tracing::warn!("Error getting finalized block: {err:#}");
+                            self.retry_delay().await;
+                        },
+                    }
+                };
+                state = self.state.lock().await;
+                state.put_finalized(block);
+                break block;
+            }
         };
 
-        // After fetching, add the block to the cache.
-        let mut state = self.state.lock().await;
-        state.put_finalized(block);
-        (state, block)
+        // Work backwards from the known finalized successor, fetching blocks by parent hash so we
+        // know we are getting the correct block.
+        while successor.info.number > number {
+            drop(state);
+            successor = loop {
+                let block = match self
+                    .provider
+                    .get_block(successor.parent_hash.into(), BlockTransactionsKind::Hashes)
+                    .await
+                {
+                    Ok(Some(block)) => block,
+                    Ok(None) => {
+                        tracing::warn!(
+                            number,
+                            "provider error: finalized L1 block should always be available"
+                        );
+                        self.retry_delay().await;
+                        continue;
+                    },
+                    Err(err) => {
+                        tracing::warn!(number, "failed to get finalized L1 block: {err:#}");
+                        self.retry_delay().await;
+                        continue;
+                    },
+                };
+                break (&block).into();
+            };
+            state = self.state.lock().await;
+            state.put_finalized(successor);
+        }
+
+        (state, successor.info)
     }
 
     /// Get fee info for each `Deposit` occurring between `prev`
@@ -892,19 +941,19 @@ impl L1State {
         }
     }
 
-    fn put_finalized(&mut self, info: L1BlockInfo) {
+    fn put_finalized(&mut self, block: L1BlockInfoWithParent) {
         assert!(
             self.snapshot.finalized.is_some()
-                && info.number <= self.snapshot.finalized.unwrap().number,
-            "inserting a finalized block {info:?} that isn't finalized; snapshot: {:?}",
+                && block.info.number <= self.snapshot.finalized.unwrap().number,
+            "inserting a finalized block {block:?} that isn't finalized; snapshot: {:?}",
             self.snapshot,
         );
 
-        if let Some((old_number, old_info)) = self.finalized.push(info.number, info) {
-            if old_number == info.number {
+        if let Some((old_number, old_block)) = self.finalized.push(block.info.number, block) {
+            if old_number == block.info.number {
                 tracing::error!(
-                    ?old_info,
-                    ?info,
+                    ?old_block,
+                    ?block,
                     "got different info for the same finalized height; something has gone very wrong with the L1",
                 );
             }
@@ -914,7 +963,7 @@ impl L1State {
 
 async fn get_finalized_block(
     rpc: &RootProvider<SwitchingTransport>,
-) -> anyhow::Result<Option<L1BlockInfo>> {
+) -> anyhow::Result<Option<L1BlockInfoWithParent>> {
     let Some(block) = rpc
         .get_block(BlockId::finalized(), BlockTransactionsKind::Hashes)
         .await?
@@ -927,11 +976,7 @@ async fn get_finalized_block(
         return Ok(None);
     };
 
-    Ok(Some(L1BlockInfo {
-        number: block.header.number,
-        timestamp: ethers::types::U256::from(block.header.timestamp),
-        hash: block.header.hash.to_ethers(),
-    }))
+    Ok(Some((&block).into()))
 }
 
 #[cfg(test)]

--- a/types/src/v0/mod.rs
+++ b/types/src/v0/mod.rs
@@ -123,7 +123,7 @@ reexport_unchanged_types!(
     BlockSize,
 );
 
-pub(crate) use v0_3::{L1ClientMetrics, L1Event, L1State, L1UpdateTask};
+pub(crate) use v0_3::{L1BlockInfoWithParent, L1ClientMetrics, L1Event, L1State, L1UpdateTask};
 
 #[derive(
     Clone, Copy, Debug, Default, Hash, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize,

--- a/types/src/v0/v0_1/l1.rs
+++ b/types/src/v0/v0_1/l1.rs
@@ -1,4 +1,5 @@
 use alloy::{
+    primitives::FixedBytes,
     providers::RootProvider,
     transports::http::{Client, Http},
 };
@@ -27,6 +28,12 @@ pub struct L1BlockInfo {
     pub number: u64,
     pub timestamp: ethers::types::U256,
     pub hash: ethers::types::H256,
+}
+
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
+pub(crate) struct L1BlockInfoWithParent {
+    pub(crate) info: L1BlockInfo,
+    pub(crate) parent_hash: FixedBytes<32>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Hash, PartialEq, Eq)]
@@ -168,13 +175,13 @@ pub struct L1Client {
 #[derive(Debug)]
 pub(crate) struct L1State {
     pub(crate) snapshot: L1Snapshot,
-    pub(crate) finalized: LruCache<u64, L1BlockInfo>,
+    pub(crate) finalized: LruCache<u64, L1BlockInfoWithParent>,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) enum L1Event {
     NewHead { head: u64 },
-    NewFinalized { finalized: L1BlockInfo },
+    NewFinalized { finalized: L1BlockInfoWithParent },
 }
 
 #[derive(Debug, Default)]

--- a/types/src/v0/v0_3/mod.rs
+++ b/types/src/v0/v0_3/mod.rs
@@ -13,7 +13,9 @@ pub use super::v0_1::{
     BLOCK_MERKLE_TREE_HEIGHT, FEE_MERKLE_TREE_HEIGHT, NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN,
     NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, TX_OFFSET_BYTE_LEN,
 };
-pub(crate) use super::v0_1::{L1ClientMetrics, L1Event, L1State, L1UpdateTask};
+pub(crate) use super::v0_1::{
+    L1BlockInfoWithParent, L1ClientMetrics, L1Event, L1State, L1UpdateTask,
+};
 
 pub const VERSION: Version = Version { major: 0, minor: 3 };
 


### PR DESCRIPTION
We had an incident in mainnet caused by some nodes having different cached finalized L1 blocks for the same block number, which should not be possible. We theorize that this can happen due to fetching finalized blocks by number. We assume that if we no block `n` is finalized and we fetch block `n - k`, it must also be finalized. However, if we have an L1 client failover (or the L1 provider itself fails over to a different node, as we suspect happened with Infura) it is possible that we observed `n` was finalized from one RPC node, but then we try to fetch `n - k` from a different RPC node which hasn't finalized `n` yet, and returns an unfinalized block for `n - k` which is later uncled.

### This PR:
* Modifies `get_finalized_block` in the L1 client to start from a known finalized block (either one which is already cached or one which is explicitly fetched using the `finalized` block tag) and then work backwards by parent hashes, fetching blocks by hash so we know we get only blocks which are in the finalized chain, until reaching the desired block
* Adds `parent_hash` to the information we cache about each L1 block

Note that in the worst case, this could increase the number of blocks we fetch from the RPC. However, in the very common case, the latest finalized block (the one returned from fetching the `finalized` tag) is exactly the block we are trying to fetch, and we don't have to do anything else.