### PR TITLE
fix: enable retries for integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,10 +212,11 @@ jobs:
         version: [02,99]
         include:
           - version: 02
-            compose: "-f process-compose.yaml"
+            test-name: test_native_demo
 
           - version: 99
-            compose: "-f process-compose.yaml -f process-compose-mp.yml"
+            test-name: test_native_demo_upgrade
+
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -242,9 +243,6 @@ jobs:
       - name: Install process-compose
         run: nix profile install nixpkgs#process-compose
 
-      - name: Run Demo-Native ${{matrix.version}}
-        run: bash -x scripts/demo-native ${{matrix.compose}} --tui=false > ${{ env.PC_LOGS }} 2>&1 &
-
       - name: Test Integration
         env:
           RUST_LOG: debug
@@ -252,7 +250,7 @@ jobs:
           INTEGRATION_TEST_SEQUENCER_VERSION: ${{ matrix.version }}
         run: |
           cargo nextest run --archive-file nextest-archive-postgres.tar.zst --verbose --no-fail-fast --nocapture \
-          --workspace-remap $PWD $(if [ "${{ matrix.version }}" == "2" ]; then echo " smoke"; fi)
+          --workspace-remap $PWD ${{ matrix.test-name }}
         timeout-minutes: 10
 
       - name: Show end of logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,7 +212,7 @@ jobs:
         version: [02,99]
         include:
           - version: 02
-            test-name: test_native_demo
+            test-name: test_native_demo_basic
 
           - version: 99
             test-name: test_native_demo_upgrade

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11398,6 +11398,7 @@ dependencies = [
  "futures",
  "reqwest 0.12.12",
  "surf-disco",
+ "tempfile",
  "tokio",
  "vbs",
 ]

--- a/justfile
+++ b/justfile
@@ -75,11 +75,10 @@ test-all:
     cargo nextest run --locked --release --workspace --verbose --profile all
 
 test-integration:
-	@echo 'NOTE that demo-native must be running for this test to succeed.'
-	INTEGRATION_TEST_SEQUENCER_VERSION=2 cargo nextest run --all-features --nocapture --profile integration smoke
+	INTEGRATION_TEST_SEQUENCER_VERSION=2 cargo nextest run -p tests --nocapture --profile integration test_native_demo
+
 test-integration-mp:
-    @echo 'NOTE that demo-native-mp must be running for this test to succeed.'
-    INTEGRATION_TEST_SEQUENCER_VERSION=99 cargo nextest run --all-features --nocapture --profile integration
+    INTEGRATION_TEST_SEQUENCER_VERSION=99 cargo nextest run -p tests --nocapture --profile integration test_native_demo_upgrade
 
 clippy:
     @echo 'features: "embedded-db"'

--- a/justfile
+++ b/justfile
@@ -75,7 +75,7 @@ test-all:
     cargo nextest run --locked --release --workspace --verbose --profile all
 
 test-integration:
-	INTEGRATION_TEST_SEQUENCER_VERSION=2 cargo nextest run -p tests --nocapture --profile integration test_native_demo
+	INTEGRATION_TEST_SEQUENCER_VERSION=2 cargo nextest run -p tests --nocapture --profile integration test_native_demo_basic
 
 test-integration-mp:
     INTEGRATION_TEST_SEQUENCER_VERSION=99 cargo nextest run -p tests --nocapture --profile integration test_native_demo_upgrade

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,5 +18,6 @@ ethers = { workspace = true }
 futures = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 surf-disco = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true }
 vbs = { workspace = true }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -293,6 +293,12 @@ pub struct NativeDemo {
 
 impl Drop for NativeDemo {
     fn drop(&mut self) {
+        // It would be preferable to send a SIGINT or similar to the process that we started
+        // originally but despite quite some effort this never worked for the process-compose
+        // process started from within the scripts/demo-native script.
+        //
+        // Using `process-compose down` seems to pretty reliably stop the process-compose process
+        // and all the services it started.
         println!("Terminating process compose");
         let res = Command::new("process-compose")
             .arg("down")

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -318,8 +318,6 @@ impl NativeDemo {
             cmd.args(args.split(' '));
         }
 
-        println!("Running: {:?}", cmd);
-
         // Save output to file if PC_LOGS if that's set.
         let log_path = std::env::var("PC_LOGS").unwrap_or_else(|_| {
             tempfile::NamedTempFile::new()
@@ -331,12 +329,10 @@ impl NativeDemo {
 
         println!("Writing native demo logs to file: {}", log_path);
         let outputs = File::create(log_path).context("unable to create log file")?;
-        let errors = outputs
-            .try_clone()
-            .context("unable to clone log file handle")?;
-        cmd.stdout(outputs).stderr(errors);
+        cmd.stdout(outputs);
 
-        let mut child = cmd.spawn()?;
+        println!("Spawning: {:?}", cmd);
+        let mut child = cmd.spawn().context("failed to spawn command")?;
 
         // Wait for three seconds and check if process has already exited so we don't waste time
         // waiting for results later.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@ use std::{
     fmt,
     fs::File,
     io::{stderr, stdout},
-    path::Path,
+    path::PathBuf,
     process::{Child, Command},
     str::FromStr,
     time::Duration,
@@ -308,7 +308,15 @@ impl Drop for NativeDemo {
 
 impl NativeDemo {
     pub(crate) fn run(process_compose_extra_args: Option<String>) -> anyhow::Result<Self> {
-        let workspace_dir = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        // Because we use nextest with the archive feature on CI we need to use the **runtime**
+        // value of CARGO_MANIFEST_DIR.
+        let crate_dir = PathBuf::from(
+            std::env::var("CARGO_MANIFEST_DIR")
+                .expect("CARGO_MANIFEST_DIR is set")
+                .clone(),
+        );
+        let workspace_dir = crate_dir.parent().expect("crate_dir has a parent");
+
         let mut cmd = Command::new("bash");
         cmd.arg("scripts/demo-native")
             .current_dir(workspace_dir)

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -3,15 +3,14 @@ use std::time::Instant;
 use anyhow::Result;
 use futures::StreamExt;
 
-use crate::common::TestConfig;
+use crate::common::{NativeDemo, TestConfig};
 
 /// We allow for no change in state across this many consecutive iterations.
 const MAX_STATE_NOT_INCREMENTING: u8 = 1;
 /// We allow for no new transactions across this many consecutive iterations.
 const MAX_TXNS_NOT_INCREMENTING: u8 = 5;
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_smoke() -> Result<()> {
+pub async fn assert_native_demo_works() -> Result<()> {
     let start = Instant::now();
     dotenvy::dotenv()?;
 
@@ -21,7 +20,7 @@ async fn test_smoke() -> Result<()> {
     let _ = testing.readiness().await?;
 
     let initial = testing.test_state().await;
-    println!("Initial State:{}", initial);
+    println!("Initial State: {}", initial);
 
     let mut sub = testing
         .espresso
@@ -47,7 +46,9 @@ async fn test_smoke() -> Result<()> {
         }
 
         // test that we progress EXPECTED_BLOCK_HEIGHT blocks from where we started
-        if new.block_height.unwrap() >= testing.expected_block_height() + testing.initial_height {
+        if new.block_height.unwrap()
+            >= testing.expected_block_height() + initial.block_height.unwrap()
+        {
             println!("Reached {} block(s)!", testing.expected_block_height());
             if new.txn_count - initial.txn_count < 1 {
                 panic!("Did not receive transactions");
@@ -80,4 +81,10 @@ async fn test_smoke() -> Result<()> {
         last = new;
     }
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_native_demo() -> Result<()> {
+    let _child = NativeDemo::run(None);
+    assert_native_demo_works().await
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -84,7 +84,7 @@ pub async fn assert_native_demo_works() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_native_demo() -> Result<()> {
+async fn test_native_demo_basic() -> Result<()> {
     let _child = NativeDemo::run(None);
     assert_native_demo_works().await
 }

--- a/tests/upgrades.rs
+++ b/tests/upgrades.rs
@@ -3,12 +3,21 @@ use espresso_types::{FeeVersion, MarketplaceVersion};
 use futures::{future::join_all, StreamExt};
 use vbs::version::StaticVersionType;
 
-use crate::common::TestConfig;
+use crate::{
+    common::{NativeDemo, TestConfig},
+    smoke::assert_native_demo_works,
+};
 
 const SEQUENCER_BLOCKS_TIMEOUT: u64 = 200;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_upgrade() -> Result<()> {
+async fn test_native_demo_upgrade() -> Result<()> {
+    let _demo = NativeDemo::run(Some(
+        "-f process-compose.yaml -f process-compose-mp.yml".to_string(),
+    ))?;
+
+    assert_native_demo_works().await?;
+
     dotenvy::dotenv()?;
 
     let testing = TestConfig::new().await.unwrap();


### PR DESCRIPTION
Currently the retries don't work because we start the native demo once then retry the asserts. However if the tests fail it usually means the native demo is not working so we would have to restart it. This PR moves starts the native demo as part of the integration tests, thereby making the tests standalone.

Unfortunately the upgrade test currently never works for me locally, even on `main`. edit: it does work on CI though so it's probably me.