### PR TITLE
fix: use just installer to install just

### DIFF
--- a/doc/ubuntu.md
+++ b/doc/ubuntu.md
@@ -13,12 +13,9 @@ Refer to https://docs.docker.com/engine/install/ubuntu
 
 ## Install just
 
-Just is not available in the official ubuntu repos.
+Just is outdated in the official ubuntu repos.
 
-    curl --proto '=https' --tlsv1.2 -sSf 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
-    echo "deb [arch=all,$(dpkg --print-architecture) signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
-    sudo apt-get update
-    sudo apt-get install -y just
+    curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin/
 
 ## Install rust dependencies
 


### PR DESCRIPTION
This should fix the ubuntu installation instructions CI job.

CI run: https://github.com/EspressoSystems/espresso-network/actions/runs/13830450017