### PR TITLE
fix: pin diff-test-bn254 to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,7 +3457,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 [[package]]
 name = "diff-test-bn254"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/solidity-bn254.git#050a98a3b389862c50d0bbbea620d8dc278c275a"
+source = "git+https://github.com/EspressoSystems/solidity-bn254.git?tag=v0.2.0#050a98a3b389862c50d0bbbea620d8dc278c275a"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ circular-buffer = "0.1.9"
 clap = { version = "4.4", features = ["derive", "env", "string"] }
 cld = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
+diff-test-bn254 = { git = "https://github.com/EspressoSystems/solidity-bn254.git", tag = "v0.2.0" }
 either = "1"
 hex = "0.4"
 sha2 = "0.10"

--- a/contracts/rust/adapter/Cargo.toml
+++ b/contracts/rust/adapter/Cargo.toml
@@ -16,7 +16,7 @@ ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 contract-bindings-alloy = { workspace = true }
 contract-bindings-ethers = { path = "../../../contract-bindings-ethers" }
-diff-test-bn254 = { git = "https://github.com/EspressoSystems/solidity-bn254.git" }
+diff-test-bn254 = { workspace = true }
 ethers = { version = "2.0.4" }
 ethers-conv = { workspace = true }
 hotshot-types = { workspace = true }

--- a/contracts/rust/diff-test/Cargo.toml
+++ b/contracts/rust/diff-test/Cargo.toml
@@ -13,7 +13,7 @@ ark-ff = { workspace = true }
 ark-poly = { workspace = true }
 ark-std = { workspace = true }
 clap = { version = "^4.4", features = ["derive"] }
-diff-test-bn254 = { git = "https://github.com/EspressoSystems/solidity-bn254.git" }
+diff-test-bn254 = { workspace = true }
 ethers = { version = "2.0.4" }
 hotshot-contract-adapter = { path = "../adapter" }
 hotshot-state-prover = { workspace = true }

--- a/sequencer-sqlite/Cargo.lock
+++ b/sequencer-sqlite/Cargo.lock
@@ -3223,7 +3223,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 [[package]]
 name = "diff-test-bn254"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/solidity-bn254.git#050a98a3b389862c50d0bbbea620d8dc278c275a"
+source = "git+https://github.com/EspressoSystems/solidity-bn254.git?tag=v0.2.0#050a98a3b389862c50d0bbbea620d8dc278c275a"
 dependencies = [
  "ark-bn254",
  "ark-ec",


### PR DESCRIPTION
Crate has been renamed and migrated to alloy. Pin to previous tag until we update the crate. This should fix the workflow to build without committed lock file, or conversely using crates in this repo in new projects, where our lock file is ignored.