### PR TITLE
Remove undecided_state2 from Migrations

### DIFF
--- a/sequencer/api/migrations/postgres/V403__drop_undecided_state.sql
+++ b/sequencer/api/migrations/postgres/V403__drop_undecided_state.sql
@@ -1,0 +1,1 @@
+DROP TABLE undecided_state;

--- a/sequencer/api/migrations/postgres/V501__epoch_tables.sql
+++ b/sequencer/api/migrations/postgres/V501__epoch_tables.sql
@@ -41,4 +41,4 @@ CREATE TABLE epoch_migration (
     completed bool DEFAULT FALSE
 );
 
-INSERT INTO epoch_migration (table_name) VALUES ('anchor_leaf'), ('da_proposal'), ('vid_share'), ('undecided_state'), ('quorum_proposals'), ('quorum_certificate');
+INSERT INTO epoch_migration (table_name) VALUES ('anchor_leaf'), ('da_proposal'), ('vid_share'), ('quorum_proposals'), ('quorum_certificate');

--- a/sequencer/api/migrations/postgres/V501__epoch_tables.sql
+++ b/sequencer/api/migrations/postgres/V501__epoch_tables.sql
@@ -18,16 +18,6 @@ CREATE TABLE vid_share2 (
 );
 
 
-CREATE TABLE undecided_state2 (
-    -- The ID is always set to 0. Setting it explicitly allows us to enforce with every insert or
-    -- update that there is only a single entry in this table: the latest known state.
-    id INT PRIMARY KEY,
-
-    leaves BYTEA NOT NULL,
-    state  BYTEA NOT NULL
-);
-
-
 CREATE TABLE quorum_proposals2 (
     view BIGINT PRIMARY KEY,
     leaf_hash VARCHAR,

--- a/sequencer/api/migrations/postgres/V503__drop_undecided_state.sql
+++ b/sequencer/api/migrations/postgres/V503__drop_undecided_state.sql
@@ -1,3 +1,0 @@
-DROP TABLE undecided_state;
-
-DELETE FROM epoch_migration WHERE table_name = 'undecided_state';

--- a/sequencer/api/migrations/postgres/V503__drop_undecided_state.sql
+++ b/sequencer/api/migrations/postgres/V503__drop_undecided_state.sql
@@ -1,4 +1,3 @@
 DROP TABLE undecided_state;
-DROP TABLE undecided_state2;
 
 DELETE FROM epoch_migration WHERE table_name = 'undecided_state';

--- a/sequencer/api/migrations/sqlite/V204__drop_undecided_state.sql
+++ b/sequencer/api/migrations/sqlite/V204__drop_undecided_state.sql
@@ -1,0 +1,3 @@
+DROP TABLE undecided_state;
+
+DELETE FROM epoch_migration WHERE table_name = 'undecided_state';

--- a/sequencer/api/migrations/sqlite/V204__drop_undecided_state.sql
+++ b/sequencer/api/migrations/sqlite/V204__drop_undecided_state.sql
@@ -1,3 +1,1 @@
 DROP TABLE undecided_state;
-
-DELETE FROM epoch_migration WHERE table_name = 'undecided_state';

--- a/sequencer/api/migrations/sqlite/V301__epoch_tables.sql
+++ b/sequencer/api/migrations/sqlite/V301__epoch_tables.sql
@@ -18,16 +18,6 @@ CREATE TABLE vid_share2 (
 );
 
 
-CREATE TABLE undecided_state2 (
-    -- The ID is always set to 0. Setting it explicitly allows us to enforce with every insert or
-    -- update that there is only a single entry in this table: the latest known state.
-    id INT PRIMARY KEY,
-
-    leaves BLOB NOT NULL,
-    state  BLOB NOT NULL
-);
-
-
 CREATE TABLE quorum_proposals2 (
     view BIGINT PRIMARY KEY,
     leaf_hash VARCHAR,

--- a/sequencer/api/migrations/sqlite/V301__epoch_tables.sql
+++ b/sequencer/api/migrations/sqlite/V301__epoch_tables.sql
@@ -41,4 +41,4 @@ CREATE TABLE epoch_migration (
     completed bool NOT NULL DEFAULT FALSE
 );
 
-INSERT INTO epoch_migration (table_name) VALUES ('anchor_leaf'), ('da_proposal'), ('vid_share'), ('undecided_state'), ('quorum_proposals'), ('quorum_certificate');
+INSERT INTO epoch_migration (table_name) VALUES ('anchor_leaf'), ('da_proposal'), ('vid_share'), ('quorum_proposals'), ('quorum_certificate');

--- a/sequencer/api/migrations/sqlite/V303__drop_undecided_state.sql
+++ b/sequencer/api/migrations/sqlite/V303__drop_undecided_state.sql
@@ -1,3 +1,0 @@
-DROP TABLE undecided_state;
-
-DELETE FROM epoch_migration WHERE table_name = 'undecided_state';

--- a/sequencer/api/migrations/sqlite/V303__drop_undecided_state.sql
+++ b/sequencer/api/migrations/sqlite/V303__drop_undecided_state.sql
@@ -1,4 +1,3 @@
 DROP TABLE undecided_state;
-DROP TABLE undecided_state2;
 
 DELETE FROM epoch_migration WHERE table_name = 'undecided_state';


### PR DESCRIPTION

### This PR:

The migration to add this table never hit anything in production so we can just remove all references to it

### This PR does not:

Should not change anything functional.  

### Key places to review:

everything

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
