### PR TITLE
Add failover/retry to fee contract proxy validation in genesis.

### DIFF
--- a/sequencer/src/genesis.rs
+++ b/sequencer/src/genesis.rs
@@ -11,7 +11,6 @@ use espresso_types::{
 use ethers::types::H160;
 use ethers_conv::ToAlloy;
 use serde::{Deserialize, Serialize};
-use url::Url;
 use vbs::version::Version;
 
 /// Initial configuration of an Espresso stake table.
@@ -83,14 +82,12 @@ impl Genesis {
 }
 
 impl Genesis {
-    pub async fn validate_fee_contract(&self, l1_rpc_url: Url) -> anyhow::Result<()> {
-        let l1 = L1Client::new(vec![l1_rpc_url]).with_context(|| "failed to create L1 client")?;
-
+    pub async fn validate_fee_contract(&self, l1: &L1Client) -> anyhow::Result<()> {
         if let Some(fee_contract_address) = self.chain_config.fee_contract {
             tracing::info!("validating fee contract at {fee_contract_address:x}");
 
             if !l1
-                .is_proxy_contract(fee_contract_address.to_alloy())
+                .retry_on_all_providers(|| l1.is_proxy_contract(fee_contract_address.to_alloy()))
                 .await
                 .context("checking if fee contract is a proxy")?
             {
@@ -112,7 +109,9 @@ impl Genesis {
                 if fee_contract_address == H160::zero() {
                     anyhow::bail!("Fee contract cannot use the zero address");
                 } else if !l1
-                    .is_proxy_contract(fee_contract_address.to_alloy())
+                    .retry_on_all_providers(|| {
+                        l1.is_proxy_contract(fee_contract_address.to_alloy())
+                    })
                     .await
                     .context(format!(
                         "checking if fee contract is a proxy in upgrade {version}",
@@ -600,7 +599,7 @@ mod test {
 
         // validate the fee_contract address
         let result = genesis
-            .validate_fee_contract(anvil.endpoint().parse().unwrap())
+            .validate_fee_contract(&L1Client::anvil(&anvil).unwrap())
             .await;
 
         // check if the result from the validation is an error
@@ -648,7 +647,7 @@ mod test {
 
         // Call the validation logic for the fee_contract address
         let result = genesis
-            .validate_fee_contract(anvil.endpoint().parse().unwrap())
+            .validate_fee_contract(&L1Client::anvil(&anvil).unwrap())
             .await;
 
         assert!(
@@ -722,7 +721,7 @@ mod test {
 
         // Call the validation logic for the fee_contract address
         let result = genesis
-            .validate_fee_contract(anvil.endpoint().parse().unwrap())
+            .validate_fee_contract(&L1Client::anvil(&anvil).unwrap())
             .await;
 
         assert!(
@@ -796,7 +795,7 @@ mod test {
 
         // Call the validation logic for the fee_contract address
         let result = genesis
-            .validate_fee_contract(anvil.endpoint().parse().unwrap())
+            .validate_fee_contract(&L1Client::anvil(&anvil).unwrap())
             .await;
 
         // check if the result from the validation is an error
@@ -866,7 +865,7 @@ mod test {
 
         // validate the fee_contract address
         let result = genesis
-            .validate_fee_contract(rpc_url.parse().unwrap())
+            .validate_fee_contract(&L1Client::new(vec![rpc_url.parse().unwrap()]).unwrap())
             .await;
 
         // check if the result from the validation is an error
@@ -921,7 +920,7 @@ mod test {
 
         // validate the fee_contract address
         let result = genesis
-            .validate_fee_contract(rpc_url.parse().unwrap())
+            .validate_fee_contract(&L1Client::new(vec![rpc_url.parse().unwrap()]).unwrap())
             .await;
 
         // check if the result from the validation is an error
@@ -933,6 +932,53 @@ mod test {
         } else {
             panic!("Expected the fee contract to complain about the zero address but the validation succeeded");
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_genesis_fee_contract_l1_failover() -> anyhow::Result<()> {
+        setup_test();
+
+        let anvil = Anvil::new().spawn();
+        let (_wallet, proxy_contract) = deploy_fee_contract_as_proxy_for_test(&anvil).await?;
+
+        let toml = format!(
+            r#"
+            base_version = "0.1"
+            upgrade_version = "0.2"
+
+            [stake_table]
+            capacity = 10
+
+            [chain_config]
+            chain_id = 12345
+            max_block_size = 30000
+            base_fee = 1
+            fee_recipient = "0x0000000000000000000000000000000000000000"
+            fee_contract = "{:?}"
+
+            [header]
+            timestamp = 123456
+
+            [l1_finalized]
+            number = 42
+        "#,
+            proxy_contract.address()
+        )
+        .to_string();
+
+        let genesis: Genesis = toml::from_str(&toml).unwrap_or_else(|err| panic!("{err:#}"));
+        genesis
+            .validate_fee_contract(
+                &L1Client::new(vec![
+                    "http://notareall1provider".parse().unwrap(),
+                    anvil.endpoint().parse().unwrap(),
+                ])
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        Ok(())
     }
 
     #[test]

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -438,6 +438,7 @@ pub async fn init_node<P: SequencerPersistence + MembershipPersistence, V: Versi
         .with_metrics(metrics)
         .connect(l1_params.urls)
         .with_context(|| "failed to create L1 client")?;
+    genesis.validate_fee_contract(&l1_client).await?;
 
     l1_client.spawn_tasks().await;
     let l1_genesis = match genesis.l1_finalized {

--- a/sequencer/src/run.rs
+++ b/sequencer/src/run.rs
@@ -27,13 +27,6 @@ pub async fn main() -> anyhow::Result<()> {
     tracing::warn!(?modules, "sequencer starting up");
 
     let genesis = Genesis::from_file(&opt.genesis_file)?;
-
-    // validate that the fee contract is a proxy and panic otherwise
-    genesis
-        .validate_fee_contract(opt.l1_provider_url[0].clone())
-        .await
-        .unwrap();
-
     tracing::info!(?genesis, "genesis");
 
     let base = genesis.base_version;

--- a/types/src/v0/impls/l1.rs
+++ b/types/src/v0/impls/l1.rs
@@ -29,9 +29,10 @@ use contract_bindings_alloy::{
         PermissionedStakeTableInstance, StakersUpdated,
     },
 };
+use ethers::utils::AnvilInstance;
 use ethers_conv::ToEthers;
 use futures::{
-    future::Future,
+    future::{Future, TryFuture, TryFutureExt},
     stream::{self, StreamExt},
 };
 use hotshot_types::traits::metrics::Metrics;
@@ -219,18 +220,6 @@ impl SwitchingTransport {
 }
 
 impl SingleTransportStatus {
-    /// Create a new `SingleTransportStatus` at the given URL index
-    fn new(url_index: usize) -> Self {
-        Self {
-            url_index,
-            last_failure: None,
-            consecutive_failures: 0,
-            rate_limited_until: None,
-            // Whether or not this transport is being shut down (switching to the next transport)
-            shutting_down: false,
-        }
-    }
-
     /// Log a successful call to the inner transport
     fn log_success(&mut self) {
         self.consecutive_failures = 0;
@@ -279,10 +268,11 @@ impl SingleTransportStatus {
 
 impl SingleTransport {
     /// Create a new `SingleTransport` with the given URL
-    fn new(url: &Url, url_index: usize) -> Self {
+    fn new(url: &Url, generation: usize) -> Self {
         Self {
+            generation,
             client: Http::new(url.clone()),
-            status: Arc::new(RwLock::new(SingleTransportStatus::new(url_index))),
+            status: Default::default(),
         }
     }
 }
@@ -338,7 +328,7 @@ impl Service<RequestPacket> for SwitchingTransport {
                     if let Some(f) = self_clone
                         .metrics
                         .failures
-                        .get(current_transport.status.read().url_index)
+                        .get(current_transport.generation % self_clone.urls.len())
                     {
                         f.add(1);
                     }
@@ -369,12 +359,13 @@ impl Service<RequestPacket> for SwitchingTransport {
                         self_clone.metrics.failovers.add(1);
 
                         // Calculate the next URL index
-                        let next_index =
-                            current_transport.status.read().url_index + 1 % self_clone.urls.len();
+                        let next_gen = current_transport.generation + 1;
+                        let next_index = next_gen % self_clone.urls.len();
                         let url = self_clone.urls[next_index].clone();
+                        tracing::info!(%url, "failing over to next L1 transport");
 
                         // Create a new transport from the next URL and index
-                        let new_transport = SingleTransport::new(&url, next_index);
+                        let new_transport = SingleTransport::new(&url, next_gen);
 
                         // Switch to the next URL
                         *self_clone.current_transport.write() = new_transport;
@@ -410,6 +401,14 @@ impl L1Client {
     /// Construct a new L1 client with the default options.
     pub fn new(url: Vec<Url>) -> anyhow::Result<Self> {
         L1ClientOptions::default().connect(url)
+    }
+
+    pub fn anvil(anvil: &AnvilInstance) -> anyhow::Result<Self> {
+        L1ClientOptions {
+            l1_ws_provider: Some(vec![anvil.ws_endpoint().parse()?]),
+            ..Default::default()
+        }
+        .connect(vec![anvil.endpoint().parse()?])
     }
 
     /// Start the background tasks which keep the L1 client up to date.
@@ -918,6 +917,30 @@ impl L1Client {
 
         // when the implementation address is not equal to zero, it's a proxy
         Ok(implementation_address != Address::ZERO)
+    }
+
+    pub async fn retry_on_all_providers<Fut>(
+        &self,
+        op: impl Fn() -> Fut,
+    ) -> Result<Fut::Ok, Fut::Error>
+    where
+        Fut: TryFuture,
+    {
+        let transport = self.provider.client().transport();
+        let start = transport.current_transport.read().generation % transport.urls.len();
+        let end = start + transport.urls.len();
+        loop {
+            match op().into_future().await {
+                Ok(res) => return Ok(res),
+                Err(err) => {
+                    if transport.current_transport.read().generation >= end {
+                        return Err(err);
+                    } else {
+                        self.retry_delay().await;
+                    }
+                },
+            }
+        }
     }
 
     fn options(&self) -> &L1ClientOptions {
@@ -1450,15 +1473,8 @@ mod test {
 
     /// A helper function to get the index of the current provider in the failover list.
     fn get_failover_index(provider: &L1Client) -> usize {
-        provider
-            .provider
-            .client()
-            .transport()
-            .current_transport
-            .read()
-            .status
-            .read()
-            .url_index
+        let transport = provider.provider.client().transport();
+        transport.current_transport.read().generation % transport.urls.len()
     }
 
     async fn test_failover_update_task_helper(ws: bool) {

--- a/types/src/v0/v0_1/l1.rs
+++ b/types/src/v0/v0_1/l1.rs
@@ -215,14 +215,14 @@ pub struct SwitchingTransport {
 /// This is cloneable and returns a reference to the same underlying data.
 #[derive(Debug, Clone)]
 pub(crate) struct SingleTransport {
+    pub(crate) generation: usize,
     pub(crate) client: Http<Client>,
     pub(crate) status: Arc<RwLock<SingleTransportStatus>>,
 }
 
 /// The status of a single transport
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct SingleTransportStatus {
-    pub(crate) url_index: usize,
     pub(crate) last_failure: Option<Instant>,
     pub(crate) consecutive_failures: usize,
     pub(crate) rate_limited_until: Option<Instant>,


### PR DESCRIPTION
Without this, a sequencer node cannot restart if the first client in its list is faulty, even though our L1 client implementation supports failover.

Request from @Ancient123 

### This PR:
* using the configured L1 client for fee contract validation, rather than constructing a new one with only one provider URL
* adding retries in `validate_fee_contract` so that it succeeds as long as the L1 client eventually fails over to a healthy provider
