### PR TITLE
CI: docker, use output type image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
           # always export to file for testing in test-demo
           outputs: |
             ${{ github.event_name != 'pull_request' && 'type=registry' || '' }}
-            type=docker,dest=${{ runner.temp }}/${{ matrix.service }}.tar
+            type=image,dest=${{ runner.temp }}/${{ matrix.service }}.tar
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The output type docker doesn't work for multiarch, so failed on main.

Idea from: https://github.com/concourse/oci-build-task/issues/85

Triggered run with multiarch build: https://github.com/EspressoSystems/espresso-network/actions/runs/13971361023