### PR TITLE
Skip reward distribution for first two epochs

### DIFF
--- a/types/src/v0/impls/header.rs
+++ b/types/src/v0/impls/header.rs
@@ -32,7 +32,7 @@ use super::{
 use crate::{
     v0::{
         header::{EitherOrVersion, VersionedHeader},
-        impls::reward::{apply_rewards, catchup_missing_accounts},
+        impls::reward::{apply_rewards, catchup_missing_accounts, first_two_epochs},
         MarketplaceVersion,
     },
     v0_1, v0_2, v0_3,
@@ -524,8 +524,7 @@ impl Header {
         // when we deploy the permissionless contract in native demo
         // so that marketplace version also supports this,
         // and the marketplace integration test passes
-        if version == EpochVersion::version() {
-            let validator = validator.ok_or_else(|| anyhow::anyhow!("Missing validator"))?;
+        if let Some(validator) = validator {
             let reward_state = apply_rewards(state.reward_merkle_tree.clone(), validator)?;
             state.reward_merkle_tree = reward_state;
         }
@@ -1087,13 +1086,16 @@ impl BlockHeader<SeqTypes> for Header {
         // when we deploy the permissionless contract in native demo
         // so that marketplace version also supports this,
         // and the marketplace integration test passes
-        let leader_config = if version == EpochVersion::version() {
-            Some(
+        let mut leader_config = None;
+        // Rewards are distributed only if the current epoch is not the first or second epoch
+        // this is because we don't have stake table from the contract for the first two epochs
+        if version == EpochVersion::version()
+            && !first_two_epochs(parent_leaf.height(), instance_state).await?
+        {
+            leader_config = Some(
                 catchup_missing_accounts(instance_state, &mut validated_state, parent_leaf, view)
                     .await?,
-            )
-        } else {
-            None
+            );
         };
 
         Ok(Self::from_info(

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -302,6 +302,7 @@ pub struct EpochCommittees {
     /// Methods for stake table persistence.
     #[debug(skip)]
     persistence: Arc<dyn MembershipPersistence>,
+    first_epoch: Epoch,
 }
 
 /// Holds Stake table and da stake
@@ -339,6 +340,10 @@ pub struct EpochCommittee {
 }
 
 impl EpochCommittees {
+    pub fn first_epoch(&self) -> Epoch {
+        self.first_epoch
+    }
+
     /// Updates `Self.stake_table` with stake_table for
     /// `Self.contract_address` at `l1_block_height`. This is intended
     /// to be called before calling `self.stake()` so that
@@ -504,6 +509,7 @@ impl EpochCommittees {
             randomized_committees: BTreeMap::new(),
             peers,
             persistence: Arc::new(persistence),
+            first_epoch: Epoch::genesis(),
         }
     }
     fn get_stake_table(&self, epoch: &Option<Epoch>) -> Option<Vec<PeerConfig<PubKey>>> {
@@ -795,6 +801,8 @@ impl Membership<SeqTypes> for EpochCommittees {
     }
 
     fn set_first_epoch(&mut self, epoch: Epoch, initial_drb_result: DrbResult) {
+        self.first_epoch = epoch;
+
         let epoch_committee = self.state.get(&Epoch::genesis()).unwrap().clone();
         self.state.insert(epoch, epoch_committee.clone());
         self.state.insert(epoch + 1, epoch_committee);

--- a/types/src/v0/impls/state.rs
+++ b/types/src/v0/impls/state.rs
@@ -30,7 +30,7 @@ use super::{
     auction::ExecutionError,
     fee_info::FeeError,
     instance_state::NodeState,
-    reward::{apply_rewards, catchup_missing_accounts},
+    reward::{apply_rewards, catchup_missing_accounts, first_two_epochs},
     v0_1::{
         RewardAccount, RewardAmount, RewardMerkleCommitment, RewardMerkleTree,
         REWARD_MERKLE_TREE_HEIGHT,
@@ -885,7 +885,9 @@ impl ValidatedState {
         // when we deploy the permissionless contract in native demo
         // so that marketplace version also supports this,
         // and the marketplace integration test passes
-        if version == EpochVersion::version() {
+        if version == EpochVersion::version()
+            && !first_two_epochs(parent_leaf.height(), instance).await?
+        {
             let validator =
                 catchup_missing_accounts(instance, &mut validated_state, parent_leaf, parent_view)
                     .await?;


### PR DESCRIPTION
Stake table from the contract is built when add_epoch_root() is called. This is called only from epoch third. Therefore, we skip the reward distribution for the first epochs