### PR TITLE
fix reward tree migration and from_header()

### DIFF
--- a/sequencer/api/migrations/postgres/V504__reward_merkle_tree.sql
+++ b/sequencer/api/migrations/postgres/V504__reward_merkle_tree.sql
@@ -4,7 +4,7 @@ CREATE TABLE reward_merkle_tree (
   hash_id INT NOT NULL REFERENCES hash (id), 
   children JSONB, 
   children_bitvec BIT(256), 
-  index JSONB, 
+  idx JSONB, 
   entry JSONB
 );
 

--- a/types/src/v0/impls/state.rs
+++ b/types/src/v0/impls/state.rs
@@ -1062,13 +1062,12 @@ impl HotShotState<SeqTypes> for ValidatedState {
             BlockMerkleTree::from_commitment(block_header.block_merkle_tree_root())
         };
 
-        let reward_merkle_tree = if block_header.block_merkle_tree_root().size() == 0 {
-            // If the commitment tells us that the tree is supposed to be empty, it is convenient to
-            // just create an empty tree, rather than a commitment-only tree.
-            RewardMerkleTree::new(REWARD_MERKLE_TREE_HEIGHT)
-        } else {
-            RewardMerkleTree::from_commitment(block_header.block_merkle_tree_root())
-        };
+        let mut reward_merkle_tree = RewardMerkleTree::new(REWARD_MERKLE_TREE_HEIGHT);
+        if let Some(root) = block_header.reward_merkle_tree_root() {
+            if !root.size() == 0 {
+                reward_merkle_tree = RewardMerkleTree::from_commitment(root);
+            }
+        }
 
         Self {
             fee_merkle_tree,


### PR DESCRIPTION
- fixes the `index`  column name which is now `idx` as `Index` is a keyword in sqlite 
- fixes from_header() for reward merkle tree