### PR TITLE
Log error when header apply fails in `validate_and_apply_header`

### DIFF
--- a/hotshot-types/src/data.rs
+++ b/hotshot-types/src/data.rs
@@ -997,6 +997,10 @@ pub enum BlockError {
     /// The payload commitment does not match the block header's payload commitment
     #[error("Inconsistent payload commitment")]
     InconsistentPayloadCommitment,
+
+    /// The block header apply failed
+    #[error("Failed to apply block header: {0}")]
+    FailedHeaderApply(String),
 }
 
 /// Additional functions required to use a [`Leaf`] with hotshot-testing.

--- a/types/src/v0/impls/state.rs
+++ b/types/src/v0/impls/state.rs
@@ -1010,8 +1010,6 @@ impl HotShotState<SeqTypes> for ValidatedState {
         version: Version,
         view_number: u64,
     ) -> Result<(Self, Self::Delta), Self::Error> {
-        // Unwrapping here is okay as we retry in a loop
-        //so we should either get a validated state or until hotshot cancels the task
         let (validated_state, delta) = self
             // TODO We can add this logic to `ValidatedTransition` or do something similar to that here.
             .apply_header(
@@ -1022,7 +1020,7 @@ impl HotShotState<SeqTypes> for ValidatedState {
                 version,
             )
             .await
-            .unwrap();
+            .map_err(|e| BlockError::FailedHeaderApply(e.to_string()))?;
 
         // Validate the proposal.
         let validated_state = ValidatedTransition::new(


### PR DESCRIPTION
Very simple change, we were swallowing an error by unwrapping here.  I noticed this when I was debugging rewards.  

The comment says we called this in a loop, but that does not seem to be the case anymore