### PR TITLE
stake-for-demo: support more validators

### DIFF
--- a/.env
+++ b/.env
@@ -51,7 +51,7 @@ ESPRESSO_STATE_RELAY_SERVER_PORT=30011
 ESPRESSO_STATE_RELAY_SERVER_URL=http://state-relay-server:${ESPRESSO_STATE_RELAY_SERVER_PORT}
 ESPRESSO_BLOCK_EXPLORER_PORT=3000
 
-# Ethereum accounts (note 10 to 14 are used as validator staking accounts)
+# Ethereum accounts (note 20 onwards are used as validator staking accounts)
 ESPRESSO_SEQUENCER_STATE_PROVER_ACCOUNT_INDEX=7
 ESPRESSO_BUILDER_ETH_ACCOUNT_INDEX=8
 ESPRESSO_DEPLOYER_ACCOUNT_INDEX=9

--- a/staking-cli/src/lib.rs
+++ b/staking-cli/src/lib.rs
@@ -183,7 +183,13 @@ enum Commands {
         validator_address: Address,
     },
     /// Register the validators and delegates for the local demo.
-    StakeForDemo,
+    StakeForDemo {
+        /// The number of validators to register.
+        ///
+        /// The default (5) works for the local native and docker demos.
+        #[clap(long, default_value_t = 5)]
+        num_validators: u16,
+    },
 }
 
 fn exit_err(msg: impl AsRef<str>, err: impl core::fmt::Display) -> ! {
@@ -314,8 +320,8 @@ pub async fn main() -> Result<()> {
         Commands::ClaimValidatorExit { validator_address } => {
             claim_validator_exit(stake_table, validator_address).await
         },
-        Commands::StakeForDemo => {
-            stake_for_demo(&config).await.unwrap();
+        Commands::StakeForDemo { num_validators } => {
+            stake_for_demo(&config, num_validators).await.unwrap();
             return Ok(());
         },
         _ => unreachable!(),

--- a/staking-cli/tests/cli.rs
+++ b/staking-cli/tests/cli.rs
@@ -182,12 +182,26 @@ async fn test_cli_claim_validator_exit() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_cli_stake_for_demo() -> Result<()> {
+async fn test_cli_stake_for_demo_default_num_validators() -> Result<()> {
     let system = TestSystem::deploy().await?;
 
     system
         .cmd()
         .arg("stake-for-demo")
+        .output()?
+        .assert_success();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cli_stake_for_demo_three_validators() -> Result<()> {
+    let system = TestSystem::deploy().await?;
+
+    system
+        .cmd()
+        .arg("stake-for-demo")
+        .arg("--num-validators")
+        .arg("3")
         .output()?
         .assert_success();
     Ok(())


### PR DESCRIPTION
Allows specified the number of validators. Validators Eth account index is moved to index 20 and onwards.
