### PR TITLE
Fix false positive error log

### DIFF
--- a/types/src/v0/impls/l1.rs
+++ b/types/src/v0/impls/l1.rs
@@ -982,7 +982,7 @@ impl L1State {
         );
 
         if let Some((old_number, old_block)) = self.finalized.push(block.info.number, block) {
-            if old_number == block.info.number {
+            if old_number == block.info.number && block != old_block {
                 tracing::error!(
                     ?old_block,
                     ?block,


### PR DESCRIPTION
The scary log `got different info for the same finalized height; something has gone very wrong with the L1` was showing up in Decaf and Mainnet. However, the printed block info was actually the same for both blocks:

<img width="612" alt="image" src="https://github.com/user-attachments/assets/7243fda4-5270-4b3b-aaa8-a9ee7dde9c6b" />

The problem is we print this log any time we add a finalized block to cache and there was already a cached finalized block with the same number. The assumption was that we would only add a finalized block to cache if it was not already in cache. However, we release the lock before checking cache and fetching/adding the block. So it's possible for two threads to both fetch and add the same block simultaneously. The second one will print this log even if they correctly got the same block info.

### This PR:

Prevents the log from showing if two threads add consistent info for the same finalized block, by only printing the log if the block info being added is different from the info it is replacing.

### This PR does not:

Change any behavior of the node besides logging.
