### PR TITLE
Fix Catchup Leaf Fetching

### DIFF
--- a/hotshot-types/src/utils.rs
+++ b/hotshot-types/src/utils.rs
@@ -179,7 +179,10 @@ pub async fn verify_leaf_chain<T: NodeType, V: Versions>(
         }
         last_leaf = leaf;
     }
-    Err(anyhow!("Epoch Root was not found in the decided chain"))
+    Err(anyhow!(
+        "Leaf at height {} not found in the decided chain",
+        expected_height
+    ))
 }
 
 impl<TYPES: NodeType> ViewInner<TYPES> {

--- a/hotshot-types/src/utils.rs
+++ b/hotshot-types/src/utils.rs
@@ -103,11 +103,11 @@ pub type StateAndDelta<TYPES> = (
     Option<Arc<<<TYPES as NodeType>::ValidatedState as ValidatedState<TYPES>>::Delta>>,
 );
 
-pub async fn verify_epoch_root_chain<T: NodeType, V: Versions>(
+pub async fn verify_leaf_chain<T: NodeType, V: Versions>(
     leaf_chain: Vec<Leaf2<T>>,
     stake_table: Vec<PeerConfig<T>>,
     success_threshold: U256,
-    epoch_height: u64,
+    expected_height: u64,
     upgrade_lock: &crate::message::UpgradeLock<T, V>,
 ) -> anyhow::Result<Leaf2<T>> {
     // Check we actually have a chain long enough for deciding
@@ -174,7 +174,7 @@ pub async fn verify_epoch_root_chain<T: NodeType, V: Versions>(
                 upgrade_lock,
             )
             .await?;
-        if leaf.height() % epoch_height == epoch_height - 2 {
+        if leaf.height() == expected_height {
             return Ok(leaf.clone());
         }
         last_leaf = leaf;

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -805,13 +805,13 @@ impl Membership<SeqTypes> for EpochCommittees {
                 block_height,
                 stake_table.clone(),
                 success_threshold,
-                epoch_height,
+                block_height,
             )
             .await?;
         //DRB height is decided in the next epoch's last block
-        let drb_height = block_height + epoch_height + 3;
+        let drb_height = block_height + epoch_height + 5;
         let drb_leaf = peers
-            .fetch_leaf(drb_height, stake_table, success_threshold, epoch_height)
+            .fetch_leaf(drb_height, stake_table, success_threshold, drb_height)
             .await?;
 
         let Some(drb) = drb_leaf.next_drb_result else {

--- a/types/src/v0/traits.rs
+++ b/types/src/v0/traits.rs
@@ -28,7 +28,7 @@ use hotshot_types::{
         storage::Storage,
         ValidatedState as HotShotState,
     },
-    utils::{genesis_epoch_from_version, verify_epoch_root_chain},
+    utils::{genesis_epoch_from_version, verify_leaf_chain},
     PeerConfig,
 };
 use indexmap::IndexMap;
@@ -57,7 +57,7 @@ pub trait StateCatchup: Send + Sync {
         height: u64,
         stake_table: Vec<PeerConfig<SeqTypes>>,
         success_threshold: U256,
-        epoch_height: u64,
+        expected_height: u64,
     ) -> anyhow::Result<Leaf2> {
         self.backoff().retry(
             self, |provider, retry| {
@@ -66,11 +66,11 @@ pub trait StateCatchup: Send + Sync {
                     let mut chain = provider.try_fetch_leaves(retry, height).await?;
                     chain.sort_by_key(|l| l.view_number());
                     let leaf_chain = chain.into_iter().rev().collect();
-                    verify_epoch_root_chain(
+                    verify_leaf_chain(
                         leaf_chain,
                         stake_table_clone.clone(),
                         success_threshold,
-                        epoch_height,
+                        expected_height,
                         &UpgradeLock::<SeqTypes, SequencerVersions<EpochVersion, EpochVersion>>::new()).await
                 }.boxed()
             }).await
@@ -244,10 +244,10 @@ impl<T: StateCatchup + ?Sized> StateCatchup for Box<T> {
         height: u64,
         stake_table: Vec<PeerConfig<SeqTypes>>,
         success_threshold: U256,
-        epoch_height: u64,
+        expected_height: u64,
     ) -> anyhow::Result<Leaf2> {
         (**self)
-            .fetch_leaf(height, stake_table, success_threshold, epoch_height)
+            .fetch_leaf(height, stake_table, success_threshold, expected_height)
             .await
     }
     async fn try_fetch_accounts(
@@ -378,10 +378,10 @@ impl<T: StateCatchup + ?Sized> StateCatchup for Arc<T> {
         height: u64,
         stake_table: Vec<PeerConfig<SeqTypes>>,
         success_threshold: U256,
-        epoch_height: u64,
+        expected_height: u64,
     ) -> anyhow::Result<Leaf2> {
         (**self)
-            .fetch_leaf(height, stake_table, success_threshold, epoch_height)
+            .fetch_leaf(height, stake_table, success_threshold, expected_height)
             .await
     }
     async fn try_fetch_accounts(


### PR DESCRIPTION
I### This PR:
Fixes stake table catchup.

During catchup we were requesting the wrong DRB block height and our verification was explicitly checking for the epoch root block.  This would always faile when we asked for DRB because it's a different block number

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
