### PR TITLE
Fix catchup to not block on DRB where not needed

### DIFF
--- a/hotshot-task-impls/src/da.rs
+++ b/hotshot-task-impls/src/da.rs
@@ -148,7 +148,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                 let epoch_number = proposal.data.epoch;
                 let membership = self
                     .membership_coordinator
-                    .membership_for_epoch(epoch_number)
+                    .stake_table_for_epoch(epoch_number)
                     .await
                     .context(warn!("No stake table for epoch"))?;
 

--- a/hotshot-task-impls/src/helpers.rs
+++ b/hotshot-task-impls/src/helpers.rs
@@ -1220,7 +1220,7 @@ pub async fn validate_qc_and_next_epoch_qc<TYPES: NodeType, V: Versions>(
         if qc.view_number() != next_epoch_qc.view_number() || qc.data != *next_epoch_qc.data {
             bail!("Next epoch qc exists but it's not equal with qc.");
         }
-        epoch_membership = epoch_membership.next_epoch().await?;
+        epoch_membership = epoch_membership.next_epoch_stake_table().await?;
         let membership_next_stake_table = epoch_membership.stake_table().await;
         let membership_next_success_threshold = epoch_membership.success_threshold().await;
 

--- a/hotshot-task-impls/src/network.rs
+++ b/hotshot-task-impls/src/network.rs
@@ -1204,7 +1204,7 @@ impl<
         let committee_topic = Topic::Global;
         let Ok(mem) = self
             .membership_coordinator
-            .membership_for_epoch(self.epoch)
+            .stake_table_for_epoch(self.epoch)
             .await
         else {
             return;

--- a/hotshot-task-impls/src/quorum_proposal/mod.rs
+++ b/hotshot-task-impls/src/quorum_proposal/mod.rs
@@ -306,7 +306,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
                 .next_epoch()
                 .await
                 .context(warn!(
-                    "No Stake Table for Epoch = {:?}",
+                    "Missing the randomized stake table for epoch {:?}",
                     epoch_number.unwrap() + 1
                 ))?
                 .leader(view_number)
@@ -616,7 +616,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
                 let epoch_number = certificate.data.epoch;
                 let epoch_membership = self
                     .membership_coordinator
-                    .membership_for_epoch(epoch_number)
+                    .stake_table_for_epoch(epoch_number)
                     .await
                     .context(warn!("No Stake Table for Epoch = {:?}", epoch_number))?;
 

--- a/hotshot-task-impls/src/quorum_vote/handlers.rs
+++ b/hotshot-task-impls/src/quorum_vote/handlers.rs
@@ -104,7 +104,7 @@ async fn verify_drb_result<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Ver
     if let Some(epoch_val) = epoch {
         let has_stake_current_epoch = task_state
             .membership
-            .membership_for_epoch(epoch)
+            .stake_table_for_epoch(epoch)
             .await
             .context(warn!("No stake table for epoch"))?
             .has_stake(&task_state.public_key)
@@ -482,7 +482,11 @@ pub(crate) async fn submit_vote<TYPES: NodeType, I: NodeImplementation<TYPES>, V
     // in the next epoch, the node should vote to achieve the double quorum.
     let committee_member_in_next_epoch = leaf.with_epoch
         && is_epoch_transition(leaf.height(), epoch_height)
-        && membership.next_epoch().await?.has_stake(&public_key).await;
+        && membership
+            .next_epoch_stake_table()
+            .await?
+            .has_stake(&public_key)
+            .await;
 
     ensure!(
         committee_member_in_current_epoch || committee_member_in_next_epoch,

--- a/hotshot-task-impls/src/quorum_vote/mod.rs
+++ b/hotshot-task-impls/src/quorum_vote/mod.rs
@@ -244,6 +244,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
             self.epoch_height,
         );
 
+        // We use this `epoch_membership` to vote,
+        // meaning that we must know the leader for the current view in the current epoch
+        // and must therefore perform the full DRB catchup.
         let epoch_membership = match self
             .membership_coordinator
             .membership_for_epoch(cur_epoch)
@@ -549,7 +552,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
 
                 let cert_epoch = cert.data.epoch;
 
-                let epoch_membership = self.membership.membership_for_epoch(cert_epoch).await?;
+                let epoch_membership = self.membership.stake_table_for_epoch(cert_epoch).await?;
                 let membership_da_stake_table = epoch_membership.da_stake_table().await;
                 let membership_da_success_threshold = epoch_membership.da_success_threshold().await;
 

--- a/hotshot-task-impls/src/request.rs
+++ b/hotshot-task-impls/src/request.rs
@@ -119,11 +119,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState for NetworkRequest
                 // 2. we are part of the next epoch and this is a proposal for in transition.
                 let membership = self
                     .membership_coordinator
-                    .membership_for_epoch(prop_epoch)
+                    .stake_table_for_epoch(prop_epoch)
                     .await?;
                 if !membership.has_stake(&self.public_key).await
                     && (!membership
-                        .next_epoch()
+                        .next_epoch_stake_table()
                         .await?
                         .has_stake(&self.public_key)
                         .await

--- a/hotshot-task-impls/src/response.rs
+++ b/hotshot-task-impls/src/response.rs
@@ -209,7 +209,7 @@ impl<TYPES: NodeType, V: Versions> NetworkResponseState<TYPES, V> {
         sender: &TYPES::SignatureKey,
         epoch: Option<TYPES::Epoch>,
     ) -> bool {
-        let Ok(memb) = self.membership.membership_for_epoch(epoch).await else {
+        let Ok(memb) = self.membership.stake_table_for_epoch(epoch).await else {
             return false;
         };
         memb.has_stake(sender).await


### PR DESCRIPTION
This PR replaces some calls to `membership_for_epoch`/`next_epoch` which blocks on the full DRB result being available with calls to `stake_table_for_epoch`/`next_epoch_stake_table` which only requires that the stake table is available.

I have tried to be very thorough with this and checked every call to these methods in `hotshot-task-impls` (as well as looking at what exactly was needed in the subsequent logic), but it's possible I may have missed something.
