### PR TITLE
refactor: improve robustness of genesis file loading

### DIFF
--- a/docker/scripts/sequencer-awssecretsmanager.sh
+++ b/docker/scripts/sequencer-awssecretsmanager.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -eEu -o pipefail
 
-if [[ -v ESPRESSO_SEQUENCER_GENESIS_SECRET ]]; then
-  echo "Loading genesis file from AWS secrets manager"
-  aws secretsmanager  get-secret-value --secret-id ${ESPRESSO_SEQUENCER_GENESIS_SECRET} --query SecretString --output text | tee /genesis/injected.toml >/dev/null
+if [[ -n "${ESPRESSO_SEQUENCER_GENESIS_SECRET:-}" ]]; then
+  echo "Loading genesis file from AWS Secrets Manager..."
+  aws secretsmanager get-secret-value --secret-id "${ESPRESSO_SEQUENCER_GENESIS_SECRET}" \
+       --query SecretString --output text | tee /genesis/injected.toml > /dev/null
 fi
 
-/bin/sequencer "$@"
+exec /bin/sequencer "$@"


### PR DESCRIPTION
### **This PR:**  
- Ensures proper checking of `ESPRESSO_SEQUENCER_GENESIS_SECRET` using `[[ -n "${ESPRESSO_SEQUENCER_GENESIS_SECRET:-}" ]]`.  
- Wraps variable references in quotes to handle spaces and special characters correctly.  
- Removes explicit error handling for `aws secretsmanager`, relying on `set -e` to stop execution on failure.  
- Uses `exec /bin/sequencer "$@"` to replace the shell process instead of spawning a new one.  

### **Key places to review:**  
- The conditional check for `ESPRESSO_SEQUENCER_GENESIS_SECRET`.  
- Handling of `aws secretsmanager` output.  
- Replacement of `/bin/sequencer "$@"` with `exec /bin/sequencer "$@"`.