### PR TITLE
fix from header with rewards

### DIFF
--- a/types/src/v0/impls/state.rs
+++ b/types/src/v0/impls/state.rs
@@ -1062,9 +1062,7 @@ impl HotShotState<SeqTypes> for ValidatedState {
 
         let mut reward_merkle_tree = RewardMerkleTree::new(REWARD_MERKLE_TREE_HEIGHT);
         if let Some(root) = block_header.reward_merkle_tree_root() {
-            if !root.size() == 0 {
-                reward_merkle_tree = RewardMerkleTree::from_commitment(root);
-            }
+            reward_merkle_tree = RewardMerkleTree::from_commitment(root);
         }
 
         Self {


### PR DESCRIPTION
Sometimes hotshot doesn't have the full state and passes in just the root commitment of the rewards state to `validate_and_apply_header`.  This spares state comes from the `from_header` function.  The bug is that the reward root seems to always be have size==0 which is not correct.  This means when we apply the next rewards we were ending up applying them to an empty merkle tree because we don't think there are rewards accounts to fetch.  This gets us to a state where rewards at least appear to be working
