### PR TITLE
Get stake table contract address from `ChainConfig`

### DIFF
--- a/builder/src/non_permissioned.rs
+++ b/builder/src/non_permissioned.rs
@@ -7,7 +7,6 @@ use espresso_types::{
     eth_signature_key::EthKeyPair, v0_1::NoStorage, v0_99::ChainConfig, EpochCommittees, FeeAmount,
     NodeState, Payload, SeqTypes, ValidatedState,
 };
-use ethers_conv::ToAlloy;
 use hotshot::traits::BlockPayload;
 use hotshot_builder_core::{
     builder_state::{BuilderState, MessageType},
@@ -60,7 +59,7 @@ pub fn build_instance_state<V: Versions>(
             vec![],
             vec![],
             l1_client.clone(),
-            chain_config.stake_table_contract.map(|a| a.to_alloy()),
+            chain_config,
             peers.clone(),
             NoStorage,
         ))),

--- a/hotshot-macros/src/lib.rs
+++ b/hotshot-macros/src/lib.rs
@@ -16,7 +16,7 @@ use syn::{
     Expr, ExprArray, ExprPath, ExprTuple, Ident, LitBool, PathArguments, Token, TypePath,
 };
 
-/// Bracketed types, e.g. [A, B, C<D>]
+/// Bracketed types, e.g. [A, B, `C<D>`]
 /// These types can have generic parameters, whereas ExprArray items must be Expr.
 #[derive(derive_builder::Builder, Debug, Clone)]
 struct TypePathBracketedArray {

--- a/hotshot-types/src/utils.rs
+++ b/hotshot-types/src/utils.rs
@@ -237,7 +237,7 @@ impl<TYPES: NodeType> ViewInner<TYPES> {
     }
 
     /// Returns `Epoch` if possible
-    /// #3967 REVIEW NOTE: This type is kinda ugly, should we Result<Option<Epoch>> instead?
+    // #3967 REVIEW NOTE: This type is kinda ugly, should we Result<Option<Epoch>> instead?
     pub fn epoch(&self) -> Option<Option<TYPES::Epoch>> {
         match self {
             Self::Da { epoch, .. } | Self::Leaf { epoch, .. } => Some(*epoch),
@@ -364,7 +364,7 @@ pub fn transition_block_for_epoch(epoch: u64, epoch_height: u64) -> u64 {
     }
 }
 
-/// Returns an Option<Epoch> based on a boolean condition of whether or not epochs are enabled, a block number,
+/// Returns an `Option<Epoch>` based on a boolean condition of whether or not epochs are enabled, a block number,
 /// and the epoch height. If epochs are disabled or the epoch height is zero, returns None.
 #[must_use]
 pub fn option_epoch_from_block_number<TYPES: NodeType>(

--- a/marketplace-builder/src/builder.rs
+++ b/marketplace-builder/src/builder.rs
@@ -91,7 +91,7 @@ pub fn build_instance_state<V: Versions>(
                 vec![],
                 vec![],
                 l1_client,
-                chain_config.stake_table_contract.map(|a| a.to_alloy()),
+                chain_config,
                 peers,
                 NoStorage,
             ))),

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -483,10 +483,7 @@ pub async fn init_node<P: SequencerPersistence + MembershipPersistence, V: Versi
         network_config.config.known_nodes_with_stake.clone(),
         network_config.config.known_da_nodes.clone(),
         l1_client.clone(),
-        genesis
-            .chain_config
-            .stake_table_contract
-            .map(|a| a.to_alloy()),
+        genesis.chain_config,
         peers.clone(),
         persistence.clone(),
     );
@@ -999,7 +996,7 @@ pub mod testing {
                 config.known_nodes_with_stake.clone(),
                 config.known_da_nodes.clone(),
                 l1_client.clone(),
-                chain_config.stake_table_contract.map(|a| a.to_alloy()),
+                chain_config,
                 peers.clone(),
                 persistence.clone(),
             );

--- a/sequencer/src/message_compat_tests.rs
+++ b/sequencer/src/message_compat_tests.rs
@@ -73,10 +73,7 @@ async fn test_message_compat<Ver: StaticVersionType>(_ver: Ver) {
             committee.clone(),
             committee,
             node_state.l1_client,
-            node_state
-                .chain_config
-                .stake_table_contract
-                .map(|a| a.to_alloy()),
+            node_state.chain_config,
             node_state.peers,
             NoStorage,
         ))),

--- a/sequencer/src/message_compat_tests.rs
+++ b/sequencer/src/message_compat_tests.rs
@@ -45,7 +45,6 @@ async fn test_message_compat<Ver: StaticVersionType>(_ver: Ver) {
 
     use async_lock::RwLock;
     use espresso_types::{EpochCommittees, Leaf, Payload, SeqTypes, Transaction};
-    use ethers_conv::ToAlloy;
     use hotshot_example_types::node_types::TestVersions;
     use hotshot_types::{
         data::vid_disperse::{ADVZDisperse, ADVZDisperseShare},

--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -113,7 +113,6 @@ impl NodeState {
 
     #[cfg(any(test, feature = "testing"))]
     pub fn mock() -> Self {
-        use ethers_conv::ToAlloy;
         use vbs::version::StaticVersion;
 
         let chain_config = ChainConfig::default();
@@ -124,7 +123,7 @@ impl NodeState {
             vec![],
             vec![],
             l1.clone(),
-            chain_config.stake_table_contract.map(|a| a.to_alloy()),
+            chain_config,
             Arc::new(mock::MockStateCatchup::default()),
             NoStorage,
         )));
@@ -142,7 +141,6 @@ impl NodeState {
 
     #[cfg(any(test, feature = "testing"))]
     pub fn mock_v2() -> Self {
-        use ethers_conv::ToAlloy;
         use vbs::version::StaticVersion;
 
         let chain_config = ChainConfig::default();
@@ -153,7 +151,7 @@ impl NodeState {
             vec![],
             vec![],
             l1.clone(),
-            chain_config.stake_table_contract.map(|a| a.to_alloy()),
+            chain_config,
             Arc::new(mock::MockStateCatchup::default()),
             NoStorage,
         )));
@@ -171,7 +169,6 @@ impl NodeState {
 
     #[cfg(any(test, feature = "testing"))]
     pub fn mock_v3() -> Self {
-        use ethers_conv::ToAlloy;
         use vbs::version::StaticVersion;
 
         let chain_config = ChainConfig::default();
@@ -182,7 +179,7 @@ impl NodeState {
             vec![],
             vec![],
             l1.clone(),
-            chain_config.stake_table_contract.map(|a| a.to_alloy()),
+            chain_config,
             Arc::new(mock::MockStateCatchup::default()),
             NoStorage,
         )));
@@ -201,7 +198,6 @@ impl NodeState {
 
     #[cfg(any(test, feature = "testing"))]
     pub fn mock_v99() -> Self {
-        use ethers_conv::ToAlloy;
         use vbs::version::StaticVersion;
         let chain_config = ChainConfig::default();
         let l1 = L1Client::new(vec!["http://localhost:3331".parse().unwrap()])
@@ -211,7 +207,7 @@ impl NodeState {
             vec![],
             vec![],
             l1.clone(),
-            chain_config.stake_table_contract.map(|a| a.to_alloy()),
+            chain_config,
             Arc::new(mock::MockStateCatchup::default()),
             NoStorage,
         )));
@@ -263,7 +259,6 @@ impl NodeState {
 #[cfg(any(test, feature = "testing"))]
 impl Default for NodeState {
     fn default() -> Self {
-        use ethers_conv::ToAlloy;
         use vbs::version::StaticVersion;
         let chain_config = ChainConfig::default();
         let l1 = L1Client::new(vec!["http://localhost:3331".parse().unwrap()])
@@ -273,7 +268,7 @@ impl Default for NodeState {
             vec![],
             vec![],
             l1.clone(),
-            chain_config.stake_table_contract.map(|a| a.to_alloy()),
+            chain_config,
             Arc::new(mock::MockStateCatchup::default()),
             NoStorage,
         )));

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -10,10 +10,12 @@ use alloy::{
 };
 use anyhow::{bail, Context};
 use async_lock::RwLock;
+use committable::Committable;
 use contract_bindings_alloy::staketable::StakeTable::{
     ConsensusKeysUpdated, Delegated, Undelegated, ValidatorExit, ValidatorRegistered,
 };
-use ethers_conv::ToEthers;
+
+use ethers_conv::{ToAlloy, ToEthers};
 use hotshot::types::{BLSPubKey, SignatureKey as _};
 use hotshot_contract_adapter::stake_table::{bls_alloy_to_jf2, edward_bn254point_to_state_ver};
 use hotshot_types::{
@@ -38,6 +40,7 @@ use thiserror::Error;
 use super::{
     traits::{MembershipPersistence, StateCatchup},
     v0_3::{DAMembers, Validator},
+    v0_99::ChainConfig,
     Header, L1Client, Leaf2, PubKey, SeqTypes,
 };
 use crate::{EpochVersion, SequencerVersions};
@@ -321,8 +324,8 @@ pub struct EpochCommittees {
     /// L1 provider
     l1_client: L1Client,
 
-    /// Address of Stake Table Contract
-    contract_address: Option<Address>,
+    /// Verifiable `ChainConfig` holding contract address
+    chain_config: ChainConfig,
 
     /// Randomized committees, filled when we receive the DrbResult
     randomized_committees: BTreeMap<Epoch, RandomizedCommittee<StakeTableEntry<PubKey>>>,
@@ -458,7 +461,7 @@ impl EpochCommittees {
         committee_members: Vec<PeerConfig<SeqTypes>>,
         da_members: Vec<PeerConfig<SeqTypes>>,
         l1_client: L1Client,
-        contract_address: Option<Address>,
+        chain_config: ChainConfig,
         peers: Arc<dyn StateCatchup>,
         persistence: impl MembershipPersistence,
     ) -> Self {
@@ -538,7 +541,7 @@ impl EpochCommittees {
             non_epoch_committee: members,
             state: map,
             l1_client,
-            contract_address,
+            chain_config,
             randomized_committees: BTreeMap::new(),
             peers,
             persistence: Arc::new(persistence),
@@ -764,19 +767,22 @@ impl Membership<SeqTypes> for EpochCommittees {
         epoch: Epoch,
         block_header: Header,
     ) -> Option<Box<dyn FnOnce(&mut Self) + Send>> {
-        let Some(address) = self.contract_address else {
-            tracing::debug!("`add_epoch_root` called with `self.contract_address` value of `None`");
+        let chain_config = get_chain_config(self.chain_config, &self.peers, &block_header)
+            .await
+            .ok()?;
+
+        let Some(address) = chain_config.stake_table_contract else {
+            tracing::error!("No stake table contract address found in Chain config");
             return None;
         };
 
         let Some(l1_finalized_block_info) = block_header.l1_finalized() else {
             tracing::error!("The epoch root for epoch {} is missing the L1 finalized block info. This is a fatal error. Consensus is blocked and will not recover.", epoch);
-
             return None;
         };
 
         let stake_tables = self
-            .get_stake_table_by_epoch(epoch, address, l1_finalized_block_info.number())
+            .get_stake_table_by_epoch(epoch, address.to_alloy(), l1_finalized_block_info.number())
             .await
             .inspect_err(|e| {
                 tracing::error!(?e, "`add_epoch_root`, error retrieving stake table");
@@ -895,6 +901,31 @@ impl Membership<SeqTypes> for EpochCommittees {
         self.add_drb_result(epoch, initial_drb_result);
         self.add_drb_result(epoch + 1, initial_drb_result);
     }
+}
+/// Retrieve and verify `ChainConfig`
+// TODO move to appropriate object (Header?)
+pub(crate) async fn get_chain_config(
+    chain_config: ChainConfig,
+    peers: &impl StateCatchup,
+    header: &Header,
+) -> anyhow::Result<ChainConfig> {
+    let header_cf = header.chain_config();
+    if chain_config.commit() == header_cf.commit() {
+        return Ok(chain_config);
+    }
+
+    let cf = match header_cf.resolve() {
+        Some(cf) => cf,
+        None => peers
+            .fetch_chain_config(header_cf.commit())
+            .await
+            .map_err(|err| {
+                tracing::error!("failed to get chain_config from peers. err: {err:?}");
+                err
+            })?,
+    };
+
+    Ok(cf)
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -14,7 +14,6 @@ use committable::Committable;
 use contract_bindings_alloy::staketable::StakeTable::{
     ConsensusKeysUpdated, Delegated, Undelegated, ValidatorExit, ValidatorRegistered,
 };
-
 use ethers_conv::{ToAlloy, ToEthers};
 use hotshot::types::{BLSPubKey, SignatureKey as _};
 use hotshot_contract_adapter::stake_table::{bls_alloy_to_jf2, edward_bn254point_to_state_ver};


### PR DESCRIPTION
When we upgrade from fee version, stake table contract address will *not* have been passed in to `EpochCommitee::new_stake` on instantiation. So when `add_epoch_root` tries to query stake table, address will always be `None`. 

FYI this has been sitting around in some other branches for a while. This PR just splits this out in order to get it on main.