### PR TITLE
Fix log level

### DIFF
--- a/crates/hotshot/task-impls/src/quorum_vote/mod.rs
+++ b/crates/hotshot/task-impls/src/quorum_vote/mod.rs
@@ -279,25 +279,24 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
             .await;
         }
 
-        if let Err(e) = submit_vote::<TYPES, I, V>(
-            self.sender.clone(),
-            epoch_membership,
-            self.public_key.clone(),
-            self.private_key.clone(),
-            self.upgrade_lock.clone(),
-            self.view_number,
-            Arc::clone(&self.storage),
-            leaf,
-            vid_share,
-            is_vote_leaf_extended,
-            is_vote_epoch_root,
-            self.epoch_height,
-            &self.state_private_key,
+        log!(
+            submit_vote::<TYPES, I, V>(
+                self.sender.clone(),
+                epoch_membership,
+                self.public_key.clone(),
+                self.private_key.clone(),
+                self.upgrade_lock.clone(),
+                self.view_number,
+                Arc::clone(&self.storage),
+                leaf,
+                vid_share,
+                is_vote_leaf_extended,
+                is_vote_epoch_root,
+                self.epoch_height,
+                &self.state_private_key,
+            )
+            .await
         )
-        .await
-        {
-            tracing::debug!("Failed to vote; error = {e:#}");
-        }
     }
 }
 


### PR DESCRIPTION
Fixes a log level. Now uses `log!` from `hotshot-utils`, which logs at the level propagated up from the `submit_vote` function
