### PR TITLE
Use simple loop for proposal fetch

### DIFF
--- a/hotshot-task-impls/src/helpers.rs
+++ b/hotshot-task-impls/src/helpers.rs
@@ -55,7 +55,7 @@ use crate::{events::HotShotEvent, quorum_proposal_recv::ValidationInfo, request:
 #[instrument(skip_all)]
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn fetch_proposal<TYPES: NodeType, V: Versions>(
-    view_number: TYPES::View,
+    qc: &QuorumCertificate2<TYPES>,
     event_sender: Sender<Arc<HotShotEvent<TYPES>>>,
     event_receiver: Receiver<Arc<HotShotEvent<TYPES>>>,
     membership_coordinator: EpochMembershipCoordinator<TYPES>,
@@ -65,6 +65,8 @@ pub(crate) async fn fetch_proposal<TYPES: NodeType, V: Versions>(
     upgrade_lock: &UpgradeLock<TYPES, V>,
     epoch_height: u64,
 ) -> Result<(Leaf2<TYPES>, View<TYPES>)> {
+    let view_number = qc.view_number();
+    let leaf_commit = qc.data.leaf_commit;
     // We need to be able to sign this request before submitting it to the network. Compute the
     // payload first.
     let signed_proposal_request = ProposalRequestPayload {
@@ -87,7 +89,6 @@ pub(crate) async fn fetch_proposal<TYPES: NodeType, V: Versions>(
     )
     .await;
 
-    let mem_coordinator = membership_coordinator.clone();
     let mut rx = event_receiver.clone();
     // Make a background task to await the arrival of the event data.
     let Ok(Some(proposal)) =
@@ -96,18 +97,8 @@ pub(crate) async fn fetch_proposal<TYPES: NodeType, V: Versions>(
             // We want to iterate until the proposal is not None, or until we reach the timeout.
             while let Ok(event) = rx.recv_direct().await {
                 if let HotShotEvent::QuorumProposalResponseRecv(quorum_proposal) = event.as_ref() {
-                    if quorum_proposal.data.view_number() != view_number {
-                        continue;
-                    }
-
-                        let proposal_epoch = option_epoch_from_block_number::<TYPES>(
-                            quorum_proposal.data.proposal.epoch().is_some(),
-                            quorum_proposal.data.block_header().block_number(),
-                            epoch_height,
-                        );
-                        let epoch_membership = mem_coordinator.membership_for_epoch(proposal_epoch).await.ok()?;
-                        // Make sure that the quorum_proposal is valid
-                    if quorum_proposal.validate_signature(&epoch_membership).await.is_ok() {
+                    let leaf = Leaf2::from_quorum_proposal(&quorum_proposal.data);
+                    if leaf.view_number() == view_number && leaf.commit() == leaf_commit {
                         return Some(quorum_proposal.clone());
                     }
                 }
@@ -588,18 +579,18 @@ pub(crate) async fn parent_leaf_and_state<TYPES: NodeType, V: Versions>(
     private_key: <TYPES::SignatureKey as SignatureKey>::PrivateKey,
     consensus: OuterConsensus<TYPES>,
     upgrade_lock: &UpgradeLock<TYPES, V>,
-    parent_view_number: TYPES::View,
+    parent_qc: &QuorumCertificate2<TYPES>,
     epoch_height: u64,
 ) -> Result<(Leaf2<TYPES>, Arc<<TYPES as NodeType>::ValidatedState>)> {
     let consensus_reader = consensus.read().await;
     let vsm_contains_parent_view = consensus_reader
         .validated_state_map()
-        .contains_key(&parent_view_number);
+        .contains_key(&parent_qc.view_number());
     drop(consensus_reader);
 
     if !vsm_contains_parent_view {
         let _ = fetch_proposal(
-            parent_view_number,
+            parent_qc,
             event_sender.clone(),
             event_receiver.clone(),
             membership,
@@ -615,8 +606,8 @@ pub(crate) async fn parent_leaf_and_state<TYPES: NodeType, V: Versions>(
 
     let consensus_reader = consensus.read().await;
     //let parent_view_number = consensus_reader.high_qc().view_number();
-    let parent_view = consensus_reader.validated_state_map().get(&parent_view_number).context(
-        debug!("Couldn't find parent view in state map, waiting for replica to see proposal; parent_view_number: {}", *parent_view_number)
+    let parent_view = consensus_reader.validated_state_map().get(&parent_qc.view_number()).context(
+        debug!("Couldn't find parent view in state map, waiting for replica to see proposal; parent_view_number: {}", *parent_qc.view_number())
     )?;
 
     let (leaf_commitment, state) = parent_view.leaf_and_state().context(

--- a/hotshot-task-impls/src/helpers.rs
+++ b/hotshot-task-impls/src/helpers.rs
@@ -116,7 +116,7 @@ pub(crate) async fn fetch_proposal<TYPES: NodeType, V: Versions>(
     let justify_qc_epoch = justify_qc.data.epoch();
 
     let epoch_membership = membership_coordinator
-        .membership_for_epoch(justify_qc_epoch)
+        .stake_table_for_epoch(justify_qc_epoch)
         .await?;
     let membership_stake_table = epoch_membership.stake_table().await;
     let membership_success_threshold = epoch_membership.success_threshold().await;

--- a/hotshot-task-impls/src/quorum_proposal/handlers.rs
+++ b/hotshot-task-impls/src/quorum_proposal/handlers.rs
@@ -425,7 +425,7 @@ impl<TYPES: NodeType, V: Versions> ProposalDependencyHandle<TYPES, V> {
             self.private_key.clone(),
             OuterConsensus::new(Arc::clone(&self.consensus.inner_consensus)),
             &self.upgrade_lock,
-            parent_qc.view_number(),
+            &parent_qc,
             self.epoch_height,
         )
         .await?;

--- a/hotshot-task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/hotshot-task-impls/src/quorum_proposal_recv/handlers.rs
@@ -52,7 +52,7 @@ use crate::{
 /// Spawn a task which will fire a request to get a proposal, and store it.
 #[allow(clippy::too_many_arguments)]
 fn spawn_fetch_proposal<TYPES: NodeType, V: Versions>(
-    view: TYPES::View,
+    qc: &QuorumCertificate2<TYPES>,
     event_sender: Sender<Arc<HotShotEvent<TYPES>>>,
     event_receiver: Receiver<Arc<HotShotEvent<TYPES>>>,
     membership: EpochMembershipCoordinator<TYPES>,
@@ -62,11 +62,12 @@ fn spawn_fetch_proposal<TYPES: NodeType, V: Versions>(
     upgrade_lock: UpgradeLock<TYPES, V>,
     epoch_height: u64,
 ) {
+    let qc = qc.clone();
     spawn(async move {
         let lock = upgrade_lock;
 
         let _ = fetch_proposal(
-            view,
+            &qc,
             event_sender,
             event_receiver,
             membership,
@@ -331,7 +332,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
 
     if parent_leaf.is_none() {
         spawn_fetch_proposal(
-            justify_qc.view_number(),
+            &justify_qc,
             event_sender.clone(),
             event_receiver.clone(),
             validation_info.membership.coordinator.clone(),

--- a/hotshot-task-impls/src/quorum_vote/handlers.rs
+++ b/hotshot-task-impls/src/quorum_vote/handlers.rs
@@ -390,7 +390,7 @@ pub(crate) async fn update_shared_state<
         Some(p) => Some(p),
         None => {
             match fetch_proposal(
-                justify_qc.view_number(),
+                justify_qc,
                 sender.clone(),
                 receiver.activate_cloned(),
                 membership.clone(),

--- a/sequencer/src/network/cdn.rs
+++ b/sequencer/src/network/cdn.rs
@@ -80,7 +80,7 @@ impl<T: SignatureKey> SignatureScheme for WrappedSignatureKey<T> {
         };
 
         todo_by!(
-            "2025-4-4",
+            "2025-5-5",
             "Only accept the namespaced message once everyone has upgraded"
         );
         public_key.0.validate(&signature, message)
@@ -112,7 +112,7 @@ impl<TYPES: NodeType> RunDef for ProductionDef<TYPES> {
 }
 
 todo_by!(
-    "2025-4-4",
+    "2025-5-5",
     "Remove this, switching to TCP+TLS singularly when everyone has updated"
 );
 /// The user definition for the Push CDN.


### PR DESCRIPTION
There was a bug in this code where if you received one bad proposal response you'd be stuck looping on it because we cloned the receiver before collecting events.

Instead we just use a simple loop to do the same thing