### PR TITLE
`epoch_start_block` from genesis file

### DIFF
--- a/sequencer/src/genesis.rs
+++ b/sequencer/src/genesis.rs
@@ -52,6 +52,7 @@ pub struct Genesis {
     #[serde(with = "version_ser")]
     pub upgrade_version: Version,
     pub epoch_height: Option<u64>,
+    pub epoch_start_block: Option<u64>,
     pub chain_config: ChainConfig,
     pub stake_table: StakeTableConfig,
     #[serde(default)]

--- a/sequencer/src/genesis.rs
+++ b/sequencer/src/genesis.rs
@@ -1070,8 +1070,8 @@ mod test {
     #[test]
     fn test_marketplace_upgrade_toml() {
         let toml = toml! {
-            base_version = "0.1"
-            upgrade_version = "0.2"
+            base_version = "0.3"
+            upgrade_version = "0.99"
 
             [stake_table]
             capacity = 10
@@ -1116,7 +1116,7 @@ mod test {
     }
 
     #[test]
-    fn test_marketplace_and_fee_upgrade_toml() {
+    fn test_fee_and_epoch_upgrade_toml() {
         let toml = toml! {
             base_version = "0.1"
             upgrade_version = "0.2"
@@ -1148,6 +1148,67 @@ mod test {
             start_proposing_view = 1
             stop_proposing_view = 10
 
+            [upgrade.epoch]
+            [upgrade.epoch.chain_config]
+            chain_id = 12345
+            max_block_size = 30000
+            base_fee = 1
+            fee_recipient = "0x0000000000000000000000000000000000000000"
+            fee_contract = "0x0000000000000000000000000000000000000000"
+            stake_table_contract = "0x0000000000000000000000000000000000000000"
+
+            [[upgrade]]
+            version = "0.2"
+            start_proposing_view = 1
+            stop_proposing_view = 15
+
+            [upgrade.fee]
+
+            [upgrade.fee.chain_config]
+            chain_id = 12345
+            max_block_size = 30000
+            base_fee = 1
+            fee_recipient = "0x0000000000000000000000000000000000000000"
+            fee_contract = "0x0000000000000000000000000000000000000000"
+        }
+        .to_string();
+
+        toml::from_str::<Genesis>(&toml).unwrap();
+    }
+
+    #[test]
+    fn test_fee_and_epoch_and_marketplace_upgrade_toml() {
+        let toml = toml! {
+            base_version = "0.1"
+            upgrade_version = "0.2"
+
+            [stake_table]
+            capacity = 10
+
+            [chain_config]
+            chain_id = 12345
+            max_block_size = 30000
+            base_fee = 1
+            fee_recipient = "0x0000000000000000000000000000000000000000"
+            fee_contract = "0x0000000000000000000000000000000000000000"
+
+            [header]
+            timestamp = 123456
+
+            [accounts]
+            "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f" = 100000
+            "0x0000000000000000000000000000000000000000" = 42
+
+            [l1_finalized]
+            number = 64
+            timestamp = "0x123def"
+            hash = "0x80f5dd11f2bdda2814cb1ad94ef30a47de02cf28ad68c89e104c00c4e51bb7a5"
+
+            [[upgrade]]
+            version = "0.99"
+            start_proposing_view = 1
+            stop_proposing_view = 10
+
             [upgrade.marketplace]
             [upgrade.marketplace.chain_config]
             chain_id = 12345
@@ -1156,6 +1217,22 @@ mod test {
             fee_recipient = "0x0000000000000000000000000000000000000000"
             bid_recipient = "0x0000000000000000000000000000000000000000"
             fee_contract = "0x0000000000000000000000000000000000000000"
+            stake_table_contract = "0x0000000000000000000000000000000000000000"
+
+            [[upgrade]]
+            version = "0.3"
+            start_proposing_view = 1
+            stop_proposing_view = 10
+
+            [upgrade.epoch]
+            [upgrade.epoch.chain_config]
+            chain_id = 12345
+            max_block_size = 30000
+            base_fee = 1
+            fee_recipient = "0x0000000000000000000000000000000000000000"
+            bid_recipient = "0x0000000000000000000000000000000000000000"
+            fee_contract = "0x0000000000000000000000000000000000000000"
+            stake_table_contract = "0x0000000000000000000000000000000000000000"
 
             [[upgrade]]
             version = "0.2"

--- a/sequencer/src/genesis.rs
+++ b/sequencer/src/genesis.rs
@@ -1120,6 +1120,8 @@ mod test {
         let toml = toml! {
             base_version = "0.1"
             upgrade_version = "0.2"
+            epoch_height = 20
+            epoch_start_block = 1
 
             [stake_table]
             capacity = 10
@@ -1181,6 +1183,8 @@ mod test {
         let toml = toml! {
             base_version = "0.1"
             upgrade_version = "0.2"
+            epoch_height = 20
+            epoch_start_block = 1
 
             [stake_table]
             capacity = 10

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -365,8 +365,12 @@ pub async fn init_node<P: SequencerPersistence + MembershipPersistence, V: Versi
     }
 
     let epoch_height = genesis.epoch_height.unwrap_or_default();
-    tracing::info!("setting epoch height={epoch_height:?}");
+    let epoch_start_block = genesis.epoch_start_block.unwrap_or_default();
+
+    tracing::info!("setting epoch_height={epoch_height:?}");
+    tracing::info!("setting epoch_start_block={epoch_start_block:?}");
     network_config.config.epoch_height = epoch_height;
+    network_config.config.epoch_start_block = epoch_start_block;
 
     // If the `Libp2p` bootstrap nodes were supplied via the command line, override those
     // present in the config file.

--- a/sequencer/src/restart_tests.rs
+++ b/sequencer/src/restart_tests.rs
@@ -545,7 +545,7 @@ impl TestNetwork {
             base_version: Version { major: 0, minor: 1 },
             upgrade_version: Version { major: 0, minor: 2 },
             epoch_height: None,
-
+            epoch_start_block: None,
             // Start with a funded account, so we can test catchup after restart.
             accounts: [(builder_account(), 1000000000.into())]
                 .into_iter()

--- a/sequencer/src/run.rs
+++ b/sequencer/src/run.rs
@@ -318,6 +318,7 @@ mod test {
             base_version: Version { major: 0, minor: 1 },
             upgrade_version: Version { major: 0, minor: 2 },
             epoch_height: None,
+            epoch_start_block: None,
         };
         genesis.to_file(&genesis_file).unwrap();
 


### PR DESCRIPTION
`epoch_start_block` needs to be configurable, so we take it from genesis file. 

Also adds a test for epoch version genesis file.

Plucked from https://github.com/EspressoSystems/espresso-network/commit/b0cd03ad7883dd256319a6e9af271a515e7546cd