### PR TITLE
staking-cli: support JSON logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11361,6 +11361,7 @@ dependencies = [
  "portpicker",
  "rand 0.8.5",
  "rust_decimal",
+ "sequencer-utils",
  "serde",
  "sysinfo",
  "tagged-base64",

--- a/sequencer-sqlite/Cargo.lock
+++ b/sequencer-sqlite/Cargo.lock
@@ -10668,6 +10668,7 @@ dependencies = [
  "portpicker",
  "rand 0.8.5",
  "rust_decimal",
+ "sequencer-utils",
  "serde",
  "sysinfo",
  "tagged-base64",

--- a/staking-cli/Cargo.toml
+++ b/staking-cli/Cargo.toml
@@ -28,6 +28,7 @@ jf-signature = { workspace = true, features = ["bls", "schnorr"] }
 portpicker = { workspace = true }
 rand = { workspace = true }
 rust_decimal = "1.36.0"
+sequencer-utils = { version = "0.1.0", path = "../utils" }
 serde = { workspace = true }
 sysinfo = "0.33.1"
 tagged-base64 = { workspace = true }

--- a/staking-cli/src/bin/staking-cli.rs
+++ b/staking-cli/src/bin/staking-cli.rs
@@ -86,10 +86,6 @@ fn exit_err(msg: impl AsRef<str>, err: impl core::fmt::Display) -> ! {
 
 #[tokio::main]
 pub async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
-
     let mut cli = Args::parse();
     let config_path = cli.config_path();
     // Get config file
@@ -107,6 +103,7 @@ pub async fn main() -> Result<()> {
         // If there is no config file return only config parsed from clap
         Config::from(&mut cli.config)
     };
+    config.logging.init();
 
     // Run the init command first because config values required by other
     // commands are not present.

--- a/staking-cli/src/lib.rs
+++ b/staking-cli/src/lib.rs
@@ -7,6 +7,7 @@ pub(crate) use hotshot_types::{
 };
 pub(crate) use jf_signature::bls_over_bn254::KeyPair as BLSKeyPair;
 use parse::Commission;
+use sequencer_utils::logging;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -44,6 +45,10 @@ pub struct Config {
     /// Deployed stake table contract address.
     #[clap(long, env = "STAKE_TABLE_ADDRESS")]
     pub stake_table_address: Address,
+
+    #[clap(flatten)]
+    #[serde(skip)]
+    pub logging: logging::Config,
 
     #[command(subcommand)]
     #[serde(skip)]


### PR DESCRIPTION
```
anvil &
env RUST_LOG_FORMAT=json cargo run --bin staking-cli -p staking-cli -- stake-for-demo

   Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.52s
     Running `target/nix/debug/staking-cli stake-for-demo`
{"timestamp":"2025-04-08T07:36:08.548174Z","level":"INFO","fields":{"message":"Staking for demo with 5 validators"},"target":"staking_cli"}
{"timestamp":"2025-04-08T07:36:08.548218Z","level":"INFO","fields":{"message":"staking to stake table contract for demo"},"target":"staking_cli::demo"}
{"timestamp":"2025-04-08T07:36:08.613124Z","level":"INFO","fields":{"message":"grant recipient account for token funding: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},"target":"staking_cli::demo"}
{"timestamp":"2025-04-08T07:36:08.613170Z","level":"INFO","fields":{"message":"ESP token address: 0x0000000000000000000000000000000000000000"},"target":"staking_cli::demo"}
{"timestamp":"2025-04-08T07:36:08.613200Z","level":"INFO","fields":{"message":"stake table address: 0x0000000000000000000000000000000000000000"},"target":"staking_cli::demo"}
{"timestamp":"2025-04-08T07:36:08.676955Z","level":"INFO","fields":{"message":"fund val 0 address: 0x09DB0a93B389bEF724429898f539AEB7ac2Dd55f, 1000 ETH"},"target":"staking_cli::demo"}
....
```