### PR TITLE
feat: wrapper for hotshot epoch height

### DIFF
--- a/hotshot-builder-core-refactored/src/testing/integration.rs
+++ b/hotshot-builder-core-refactored/src/testing/integration.rs
@@ -156,7 +156,7 @@ mod tests {
             ..TestDescription::default()
         };
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
         run_test::<TestVersions, LegacyBuilderImpl>(
             metadata,
@@ -199,7 +199,7 @@ mod tests {
                 ..Default::default()
             };
 
-            metadata.test_config.epoch_height = 0;
+            metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
             metadata
         },

--- a/hotshot-examples/infra/mod.rs
+++ b/hotshot-examples/infra/mod.rs
@@ -364,7 +364,7 @@ pub trait RunDa<
     ) -> SystemContextHandle<TYPES, NODE, V> {
         let initializer = hotshot::HotShotInitializer::<TYPES>::from_genesis::<V>(
             TestInstanceState::default(),
-            self.config().config.epoch_height,
+            self.config().config.epoch_height.value(),
             self.config().config.epoch_start_block,
             vec![],
         )
@@ -394,7 +394,7 @@ pub trait RunDa<
             state_sk,
             config.node_index,
             config.config,
-            EpochMembershipCoordinator::new(membership, epoch_height),
+            EpochMembershipCoordinator::new(membership, epoch_height.value()),
             Arc::from(network),
             initializer,
             ConsensusMetricsValue::default(),

--- a/hotshot-query-service/examples/simple-server.rs
+++ b/hotshot-query-service/examples/simple-server.rs
@@ -219,7 +219,7 @@ async fn init_consensus(
         stop_proposing_time: 0,
         start_voting_time: 0,
         stop_voting_time: 0,
-        epoch_height: 0,
+        epoch_height: hotshot_types::HotshotHeight::default(),
         epoch_start_block: 0,
     };
 
@@ -245,7 +245,7 @@ async fn init_consensus(
                 let storage: TestStorage<MockTypes> = TestStorage::default();
                 let coordinator = EpochMembershipCoordinator::new(
                     Arc::new(RwLock::new(membership)),
-                    config.epoch_height,
+                    config.epoch_height.value(),
                 );
 
                 SystemContext::init(

--- a/hotshot-query-service/src/testing/consensus.rs
+++ b/hotshot-query-service/src/testing/consensus.rs
@@ -157,7 +157,7 @@ impl<D: DataSourceLifeCycle + UpdateStatusData, V: Versions> MockNetwork<D, V> {
             stop_proposing_time: 0,
             start_voting_time: 0,
             stop_voting_time: 0,
-            epoch_height: EPOCH_HEIGHT,
+            epoch_height: hotshot_types::HotshotHeight(EPOCH_HEIGHT),
             epoch_start_block: 0,
         };
         update_config(&mut config);
@@ -199,7 +199,7 @@ impl<D: DataSourceLifeCycle + UpdateStatusData, V: Versions> MockNetwork<D, V> {
                             .await
                             .set_first_epoch(ViewNumber::new(0), INITIAL_DRB_RESULT);
                         let memberships =
-                            EpochMembershipCoordinator::new(membership, config.epoch_height);
+                            EpochMembershipCoordinator::new(membership, config.epoch_height.value());
 
                         let hotshot = SystemContext::init(
                             pub_keys[node_id],

--- a/hotshot-testing/src/helpers.rs
+++ b/hotshot-testing/src/helpers.rs
@@ -73,7 +73,7 @@ pub async fn build_system_handle<
     let builder: TestDescription<TYPES, I, V> = TestDescription::default_multiple_rounds();
 
     let launcher = builder.gen_launcher().map_hotshot_config(|hotshot_config| {
-        hotshot_config.epoch_height = 0;
+        hotshot_config.epoch_height = hotshot_types::HotshotHeight::default();
     });
     build_system_handle_from_launcher(node_id, &launcher).await
 }
@@ -105,7 +105,7 @@ pub async fn build_system_handle_from_launcher<
 
     let initializer = HotShotInitializer::<TYPES>::from_genesis::<V>(
         TestInstanceState::new(launcher.metadata.async_delay_config.clone()),
-        launcher.metadata.test_config.epoch_height,
+        launcher.metadata.test_config.epoch_height.value(),
         launcher.metadata.test_config.epoch_start_block,
         vec![],
     )
@@ -127,7 +127,7 @@ pub async fn build_system_handle_from_launcher<
         hotshot_config.known_da_nodes.clone(),
     )));
 
-    let coordinator = EpochMembershipCoordinator::new(memberships, hotshot_config.epoch_height);
+    let coordinator = EpochMembershipCoordinator::new(memberships, hotshot_config.epoch_height.value());
     let node_key_map = launcher.metadata.build_node_key_map();
 
     let (c, s, r) = SystemContext::init(

--- a/hotshot-testing/src/test_builder.rs
+++ b/hotshot-testing/src/test_builder.rs
@@ -87,7 +87,7 @@ pub fn default_hotshot_config<TYPES: NodeType>(
         stop_proposing_time: 0,
         start_voting_time: u64::MAX,
         stop_voting_time: 0,
-        epoch_height,
+        epoch_height: hotshot_types::HotshotHeight(epoch_height),
         epoch_start_block,
     }
 }
@@ -242,7 +242,7 @@ pub async fn create_test_handle<
 ) -> SystemContextHandle<TYPES, I, V> {
     let initializer = HotShotInitializer::<TYPES>::from_genesis::<V>(
         TestInstanceState::new(metadata.async_delay_config),
-        metadata.test_config.epoch_height,
+        metadata.test_config.epoch_height.value(),
         metadata.test_config.epoch_start_block,
         vec![],
     )
@@ -259,7 +259,7 @@ pub async fn create_test_handle<
     let private_key = validator_config.private_key.clone();
     let public_key = validator_config.public_key.clone();
     let state_private_key = validator_config.state_private_key.clone();
-    let membership_coordinator = EpochMembershipCoordinator::new(memberships, config.epoch_height);
+    let membership_coordinator = EpochMembershipCoordinator::new(memberships, config.epoch_height.value());
 
     let behaviour = (metadata.behaviour)(node_id);
     match behaviour {
@@ -451,7 +451,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TestDescription
                 staked_nodes,
                 da_nodes,
                 self.test_config.num_bootstrap,
-                self.test_config.epoch_height,
+                self.test_config.epoch_height.value(),
                 self.test_config.epoch_start_block,
             ),
             ..self

--- a/hotshot-testing/src/test_runner.rs
+++ b/hotshot-testing/src/test_runner.rs
@@ -179,7 +179,7 @@ where
         }
 
         let spinning_task_state = SpinningTask {
-            epoch_height: launcher.metadata.test_config.epoch_height,
+            epoch_height: launcher.metadata.test_config.epoch_height.value(),
             epoch_start_block: launcher.metadata.test_config.epoch_start_block,
             start_epoch_info: Vec::new(), // #2652 REVIEW NOTE: Same as other instances of start_epoch_info
             handles: Arc::clone(&handles),
@@ -468,7 +468,7 @@ where
                 } else {
                     let initializer = HotShotInitializer::<TYPES>::from_genesis::<V>(
                         TestInstanceState::new(self.launcher.metadata.async_delay_config.clone()),
-                        config.epoch_height,
+                        config.epoch_height.value(),
                         config.epoch_start_block,
                         vec![InitializerEpochInfo::<TYPES> {
                             epoch: TYPES::Epoch::new(1),
@@ -612,7 +612,7 @@ where
             state_private_key,
             node_id,
             config,
-            EpochMembershipCoordinator::new(Arc::new(RwLock::new(memberships)), epoch_height),
+            EpochMembershipCoordinator::new(Arc::new(RwLock::new(memberships)), epoch_height.value()),
             network,
             initializer,
             ConsensusMetricsValue::default(),
@@ -653,7 +653,7 @@ where
             state_private_key,
             node_id,
             config,
-            EpochMembershipCoordinator::new(memberships, epoch_height),
+            EpochMembershipCoordinator::new(memberships, epoch_height.value()),
             network,
             initializer,
             ConsensusMetricsValue::default(),

--- a/hotshot-testing/tests/tests_2/catchup.rs
+++ b/hotshot-testing/tests/tests_2/catchup.rs
@@ -45,7 +45,7 @@ async fn test_catchup() {
         updown: NodeAction::Up,
     }];
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
     metadata.timing_data = timing_data;
 
     metadata.view_sync_properties =
@@ -102,7 +102,7 @@ async fn test_catchup_cdn() {
         idx: 18,
         updown: NodeAction::Up,
     }];
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
     metadata.timing_data = timing_data;
 
     metadata.spinning_properties = SpinningTaskDescription {
@@ -153,7 +153,7 @@ async fn test_catchup_one_node() {
         idx: 18,
         updown: NodeAction::Up,
     }];
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
     metadata.timing_data = timing_data;
 
     metadata.spinning_properties = SpinningTaskDescription {
@@ -194,6 +194,7 @@ async fn test_catchup_in_view_sync() {
         spinning_task::{ChangeNode, NodeAction, SpinningTaskDescription},
         test_builder::{TestDescription, TimingData},
     };
+    use hotshot_types::HotshotHeight;
     hotshot::helpers::initialize_logging();
 
     let timing_data = TimingData {
@@ -213,7 +214,7 @@ async fn test_catchup_in_view_sync() {
         },
     ];
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = HotshotHeight::default();
     metadata.timing_data = timing_data;
     metadata.view_sync_properties =
         hotshot_testing::view_sync_task::ViewSyncTaskDescription::Threshold(0, 20);
@@ -254,6 +255,7 @@ async fn test_catchup_reload() {
         spinning_task::{ChangeNode, NodeAction, SpinningTaskDescription},
         test_builder::{TestDescription, TimingData},
     };
+    use hotshot_types::HotshotHeight;
 
     hotshot::helpers::initialize_logging();
 
@@ -268,7 +270,7 @@ async fn test_catchup_reload() {
         updown: NodeAction::Up,
     }];
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height =  HotshotHeight::default();
     metadata.timing_data = timing_data;
     metadata.skip_late = true;
 
@@ -322,7 +324,7 @@ cross_tests!(
       }
 
       metadata.timing_data = timing_data;
-      metadata.test_config.epoch_height = 0;
+      metadata.test_config.epoch_height =  hotshot_types::HotshotHeight::default();
 
       metadata.spinning_properties = SpinningTaskDescription {
           // Restart all the nodes in view 13
@@ -377,7 +379,7 @@ cross_tests!(
       }
 
       metadata.timing_data = timing_data;
-      metadata.test_config.epoch_height = 0;
+      metadata.test_config.epoch_height =  hotshot_types::HotshotHeight::default();
 
       metadata.spinning_properties = SpinningTaskDescription {
           // Restart all the nodes in view 13
@@ -436,7 +438,7 @@ cross_tests!(
           updown: NodeAction::RestartDown(0),
       });
 
-      metadata.test_config.epoch_height = 0;
+      metadata.test_config.epoch_height =  hotshot_types::HotshotHeight::default();
 
 
       metadata.spinning_properties = SpinningTaskDescription {

--- a/hotshot-testing/tests/tests_3/byzantine_tests.rs
+++ b/hotshot-testing/tests/tests_3/byzantine_tests.rs
@@ -43,7 +43,7 @@ cross_tests!(
             behaviour,
             ..TestDescription::default()
         };
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
         metadata
     },
@@ -73,7 +73,7 @@ cross_tests!(
             ..TestDescription::default()
         }.set_num_nodes(12,12);
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
         metadata.overall_safety_properties.num_successful_views = 10;
         metadata.overall_safety_properties.expected_view_failures = vec![3, 4];
         metadata.overall_safety_properties.decide_timeout = Duration::from_secs(12);
@@ -113,7 +113,7 @@ cross_tests!(
             ..TestDescription::default()
         }.set_num_nodes(5,5);
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
         metadata.overall_safety_properties.expected_view_failures = vec![6, 7, 11, 12];
         metadata.overall_safety_properties.decide_timeout = Duration::from_secs(20);
 
@@ -151,7 +151,7 @@ cross_tests!(
             ..TestDescription::default()
         }.set_num_nodes(10,10);
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
         metadata
     },
 );
@@ -192,7 +192,7 @@ cross_tests!(
             ..TestDescription::default()
         }.set_num_nodes(nodes_count, nodes_count);
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
         metadata
     },
 );
@@ -234,7 +234,7 @@ cross_tests!(
             ..TestDescription::default()
         }.set_num_nodes(10,10);
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
         metadata.overall_safety_properties.expected_view_failures = vec![13, 14];
         metadata.overall_safety_properties.decide_timeout = Duration::from_secs(12);
         metadata

--- a/hotshot-testing/tests/tests_3/test_with_failures_half_f.rs
+++ b/hotshot-testing/tests/tests_3/test_with_failures_half_f.rs
@@ -25,7 +25,7 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes();
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
         metadata.test_config.num_bootstrap = 17;
         // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
         // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the

--- a/hotshot-testing/tests/tests_4/test_marketplace.rs
+++ b/hotshot-testing/tests/tests_4/test_marketplace.rs
@@ -46,7 +46,7 @@ cross_tests!(
             ..TestDescription::default()
         };
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
         metadata
     },
@@ -74,7 +74,7 @@ cross_tests!(
             ..TestDescription::default()
         };
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
         metadata
     },
@@ -108,7 +108,7 @@ cross_tests!(
             ..TestDescription::default()
         };
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
         metadata
     },
@@ -144,7 +144,7 @@ cross_tests!(
             ..TestDescription::default()
         };
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
         metadata
     },

--- a/hotshot-testing/tests/tests_4/test_with_builder_failures.rs
+++ b/hotshot-testing/tests/tests_4/test_with_builder_failures.rs
@@ -23,14 +23,14 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_multiple_rounds();
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
         // Every block should contain at least one transaction - builders are never offline
         // simultaneously
         metadata.overall_safety_properties.transaction_threshold = 1;
         // Generate a lot of transactions so that freshly restarted builders still have
         // transactions
         metadata.txn_description = TxnTaskDescription::RoundRobinTimeBased(Duration::from_millis(1));
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
         // Two builders running as follows:
         // view 1st  2nd

--- a/hotshot-testing/tests/tests_4/test_with_failures_f.rs
+++ b/hotshot-testing/tests/tests_4/test_with_failures_f.rs
@@ -25,7 +25,7 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes();
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
         metadata.overall_safety_properties.expected_view_failures = vec![13, 14, 15, 16, 17, 18, 19];
         // Make sure we keep committing rounds after the bad leaders, but not the full 50 because of the numerous timeouts
         metadata.overall_safety_properties.num_successful_views = 20;

--- a/hotshot-testing/tests/tests_5/combined_network.rs
+++ b/hotshot-testing/tests/tests_5/combined_network.rs
@@ -44,7 +44,7 @@ async fn test_combined_network() {
         ..TestDescription::default_multiple_rounds()
     };
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
     metadata
         .gen_launcher()
         .launch()
@@ -85,7 +85,7 @@ async fn test_combined_network_cdn_crash() {
         });
     }
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
     metadata.spinning_properties = SpinningTaskDescription {
         node_changes: vec![(5, all_nodes)],
     };
@@ -137,7 +137,7 @@ async fn test_combined_network_reup() {
         });
     }
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
     metadata.spinning_properties = SpinningTaskDescription {
         node_changes: vec![(13, all_up), (5, all_down)],
     };
@@ -183,7 +183,7 @@ async fn test_combined_network_half_dc() {
         });
     }
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
     metadata.spinning_properties = SpinningTaskDescription {
         node_changes: vec![(5, half)],
     };
@@ -245,7 +245,7 @@ async fn test_stress_combined_network_fuzzy() {
     }
     .set_num_nodes(20, 20);
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
     metadata.spinning_properties = SpinningTaskDescription {
         node_changes: generate_random_node_changes(
             metadata.test_config.num_nodes_with_stake.into(),

--- a/hotshot-testing/tests/tests_5/push_cdn.rs
+++ b/hotshot-testing/tests/tests_5/push_cdn.rs
@@ -39,7 +39,7 @@ async fn push_cdn_network() {
         ..TestDescription::default()
     };
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
     metadata
         .gen_launcher()

--- a/hotshot-testing/tests/tests_5/test_with_failures.rs
+++ b/hotshot-testing/tests/tests_5/test_with_failures.rs
@@ -26,7 +26,7 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes();
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
         metadata.test_config.num_bootstrap = 19;
         // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
         // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the

--- a/hotshot-testing/tests/tests_5/timeout.rs
+++ b/hotshot-testing/tests/tests_5/timeout.rs
@@ -33,7 +33,7 @@ async fn test_timeout() {
         updown: NodeAction::Down,
     }];
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
     metadata.timing_data = timing_data;
 
     metadata.overall_safety_properties = OverallSafetyPropertiesDescription {

--- a/hotshot-testing/tests/tests_5/unreliable_network.rs
+++ b/hotshot-testing/tests/tests_5/unreliable_network.rs
@@ -40,7 +40,7 @@ async fn libp2p_network_sync() {
         ..TestDescription::default_multiple_rounds()
     };
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
     metadata
         .gen_launcher()
@@ -76,7 +76,7 @@ async fn test_memory_network_sync() {
         ..TestDescription::default()
     };
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
     metadata
         .gen_launcher()
@@ -115,7 +115,7 @@ async fn libp2p_network_async() {
         ..TestDescription::default_multiple_rounds()
     };
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
     metadata
         .gen_launcher()
@@ -163,7 +163,7 @@ async fn test_memory_network_async() {
         ..TestDescription::default()
     };
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
     metadata
         .gen_launcher()
@@ -216,7 +216,7 @@ async fn test_memory_network_partially_sync() {
         ..TestDescription::default()
     };
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
     metadata
         .gen_launcher()
@@ -256,7 +256,7 @@ async fn libp2p_network_partially_sync() {
         ..TestDescription::default_multiple_rounds()
     };
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
     metadata
         .gen_launcher()
@@ -297,7 +297,7 @@ async fn test_memory_network_chaos() {
         ..TestDescription::default()
     };
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
     metadata
         .gen_launcher()
@@ -333,7 +333,7 @@ async fn libp2p_network_chaos() {
         ..TestDescription::default_multiple_rounds()
     };
 
-    metadata.test_config.epoch_height = 0;
+    metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
     metadata
         .gen_launcher()

--- a/hotshot-testing/tests/tests_6/test_epochs_failures.rs
+++ b/hotshot-testing/tests/tests_6/test_epochs_failures.rs
@@ -26,7 +26,7 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes().set_num_nodes(12,12);
-        metadata.test_config.epoch_height = 10;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight(10);
         let dead_nodes = vec![
             ChangeNode {
                 idx: 10,
@@ -137,7 +137,7 @@ cross_tests!(
     Ignore: false,
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes();
-        metadata.test_config.epoch_height = 10;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight(10);
         // The first 14 (i.e., 20 - f) nodes are in the DA committee and we may shutdown the
         // remaining 6 (i.e., f) nodes. We could remove this restriction after fixing the
         // following issue.

--- a/hotshot-testing/tests/tests_6/test_epochs_success.rs
+++ b/hotshot-testing/tests/tests_6/test_epochs_success.rs
@@ -41,7 +41,7 @@ cross_tests!(
             ..TestDescription::default()
         };
 
-        metadata.test_config.epoch_height = 10;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight(10);
 
         metadata
     },
@@ -93,7 +93,7 @@ cross_tests!(
             ..TestDescription::default()
         };
 
-        metadata.test_config.epoch_height = 10;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight(10);
         metadata.overall_safety_properties.num_successful_views = 50;
         let mut config = DelayConfig::default();
         let delay_settings = DelaySettings {
@@ -125,7 +125,7 @@ cross_tests!(
             ..TestDescription::default()
         };
 
-        metadata.test_config.epoch_height = 10;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight(10);
         metadata.overall_safety_properties.num_successful_views = 30;
         let mut config = DelayConfig::default();
         let mut delay_settings = DelaySettings {
@@ -157,7 +157,7 @@ cross_tests!(
     Metadata: {
         let mut metadata = TestDescription::default_more_nodes().set_num_nodes(12,12);
         metadata.test_config.num_bootstrap = 10;
-        metadata.test_config.epoch_height = 10;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight(10);
 
         metadata.view_sync_properties = ViewSyncTaskDescription::Threshold(0, 0);
 
@@ -181,7 +181,7 @@ cross_tests!(
             ..TestDescription::default()
         }.set_num_nodes(11,11);
 
-        metadata.test_config.epoch_height = 10;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight(10);
 
         metadata
     },
@@ -213,7 +213,7 @@ cross_tests!(
             },
 
         ];
-        metadata.test_config.epoch_height = 10;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight(10);
         metadata.spinning_properties = SpinningTaskDescription {
             node_changes: vec![(1, dead_nodes)]
         };
@@ -244,7 +244,7 @@ cross_tests!(
 
         // Keep going until the 2nd epoch transition
         metadata.overall_safety_properties.num_successful_views = 110;
-        metadata.test_config.epoch_height = 50;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight(50);
 
         metadata
     },

--- a/hotshot-types/src/hotshot_config_file.rs
+++ b/hotshot-types/src/hotshot_config_file.rs
@@ -11,8 +11,7 @@ use url::Url;
 use vec1::Vec1;
 
 use crate::{
-    constants::REQUEST_DATA_DELAY, upgrade_config::UpgradeConfig, HotShotConfig, NodeType,
-    PeerConfig, ValidatorConfig,
+    constants::REQUEST_DATA_DELAY, upgrade_config::UpgradeConfig, HotShotConfig, HotshotHeight, NodeType, PeerConfig, ValidatorConfig
 };
 
 /// Default builder URL, used as placeholder
@@ -85,7 +84,7 @@ impl<TYPES: NodeType> From<HotShotConfigFile<TYPES>> for HotShotConfig<TYPES> {
             stop_proposing_time: val.upgrade.stop_proposing_time,
             start_voting_time: val.upgrade.start_voting_time,
             stop_voting_time: val.upgrade.stop_voting_time,
-            epoch_height: val.epoch_height,
+            epoch_height: HotshotHeight(val.epoch_height),
             epoch_start_block: val.epoch_start_block,
         }
     }

--- a/hotshot-types/src/lib.rs
+++ b/hotshot-types/src/lib.rs
@@ -68,6 +68,15 @@ where
     assert_future::<F::Output, _>(Box::pin(fut))
 }
 
+#[derive(Clone, Debug, Default, Display, Copy, serde::Serialize, serde::Deserialize)]
+pub struct HotshotHeight(pub u64);
+
+impl HotshotHeight {
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
 #[derive(Clone, Debug, Display)]
 /// config for validator, including public key, private key, stake value
 pub struct ValidatorConfig<TYPES: NodeType> {
@@ -232,7 +241,7 @@ pub struct HotShotConfig<TYPES: NodeType> {
     /// Unix time in seconds at which we stop voting on an upgrade. To prevent voting on an upgrade, set stop_voting_time <= start_voting_time.
     pub stop_voting_time: u64,
     /// Number of blocks in an epoch, zero means there are no epochs
-    pub epoch_height: u64,
+    pub epoch_height: HotshotHeight,
     /// Epoch start block   
     #[serde(default = "default_epoch_start_block")]
     pub epoch_start_block: u64,

--- a/hotshot/src/lib.rs
+++ b/hotshot/src/lib.rs
@@ -302,7 +302,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
         let epoch = initializer.high_qc.data.block_number.map(|block_number| {
             TYPES::Epoch::new(epoch_from_block_number(
                 block_number + 1,
-                config.epoch_height,
+                config.epoch_height.value(),
             ))
         });
 
@@ -310,7 +310,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
             load_start_epoch_info(
                 membership_coordinator.membership(),
                 &initializer.start_epoch_info,
-                config.epoch_height,
+                config.epoch_height.value(),
                 config.epoch_start_block,
             )
             .await;
@@ -364,7 +364,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
             initializer.high_qc,
             initializer.next_epoch_high_qc,
             Arc::clone(&consensus_metrics),
-            config.epoch_height,
+            config.epoch_height.value(),
             initializer.state_cert,
         );
 
@@ -705,7 +705,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
             storage: Arc::clone(&self.storage),
             network: Arc::clone(&self.network),
             membership_coordinator: self.membership_coordinator.clone(),
-            epoch_height: self.config.epoch_height,
+            epoch_height: self.config.epoch_height.value(),
         };
 
         add_network_tasks::<TYPES, I, V>(&mut handle).await;
@@ -890,7 +890,7 @@ where
             storage: Arc::clone(&left_system_context.storage),
             network: Arc::clone(&left_system_context.network),
             membership_coordinator: left_system_context.membership_coordinator.clone(),
-            epoch_height,
+            epoch_height:epoch_height.value(),
         };
 
         let mut right_handle = SystemContextHandle {
@@ -902,7 +902,7 @@ where
             storage: Arc::clone(&right_system_context.storage),
             network: Arc::clone(&right_system_context.network),
             membership_coordinator: right_system_context.membership_coordinator.clone(),
-            epoch_height,
+            epoch_height:epoch_height.value(),
         };
 
         // add consensus tasks to each handle, using their individual internal event streams

--- a/hotshot/src/tasks/mod.rs
+++ b/hotshot/src/tasks/mod.rs
@@ -361,7 +361,7 @@ where
             storage: Arc::clone(&hotshot.storage),
             network: Arc::clone(&hotshot.network),
             membership_coordinator: memberships.clone(),
-            epoch_height,
+            epoch_height: epoch_height.value(),
         };
 
         add_consensus_tasks::<TYPES, I, V>(&mut handle).await;

--- a/hotshot/src/tasks/task_state.rs
+++ b/hotshot/src/tasks/task_state.rs
@@ -244,7 +244,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             id: handle.hotshot.id,
             storage: Arc::clone(&handle.storage),
             upgrade_lock: handle.hotshot.upgrade_lock.clone(),
-            epoch_height: handle.hotshot.config.epoch_height,
+            epoch_height: handle.hotshot.config.epoch_height.value(),
             epoch_upgrade_block_height: handle.hotshot.config.epoch_start_block,
             staged_epoch_upgrade_certificate: None,
             consensus_metrics,
@@ -276,7 +276,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             id: handle.hotshot.id,
             formed_upgrade_certificate: None,
             upgrade_lock: handle.hotshot.upgrade_lock.clone(),
-            epoch_height: handle.hotshot.config.epoch_height,
+            epoch_height: handle.hotshot.config.epoch_height.value(),
         }
     }
 }
@@ -301,7 +301,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             spawned_tasks: BTreeMap::new(),
             id: handle.hotshot.id,
             upgrade_lock: handle.hotshot.upgrade_lock.clone(),
-            epoch_height: handle.hotshot.config.epoch_height,
+            epoch_height: handle.hotshot.config.epoch_height.value(),
         }
     }
 }
@@ -333,7 +333,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             storage: Arc::clone(&handle.storage),
             id: handle.hotshot.id,
             upgrade_lock: handle.hotshot.upgrade_lock.clone(),
-            epoch_height: handle.hotshot.config.epoch_height,
+            epoch_height: handle.hotshot.config.epoch_height.value(),
             view_start_time: Instant::now(),
         }
     }

--- a/marketplace-builder-core/src/testing/integration.rs
+++ b/marketplace-builder-core/src/testing/integration.rs
@@ -153,7 +153,7 @@ mod tests {
             ..TestDescription::default()
         };
 
-        metadata.test_config.epoch_height = 0;
+        metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
         run_test::<MarketplaceTestVersions, MarketplaceBuilderImpl>(
             metadata,
@@ -196,7 +196,7 @@ mod tests {
                 ..Default::default()
             };
 
-            metadata.test_config.epoch_height = 0;
+            metadata.test_config.epoch_height = hotshot_types::HotshotHeight::default();
 
             metadata
         },

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -366,7 +366,7 @@ pub async fn init_node<P: SequencerPersistence + MembershipPersistence, V: Versi
 
     let epoch_height = genesis.epoch_height.unwrap_or_default();
     tracing::info!("setting epoch height={epoch_height:?}");
-    network_config.config.epoch_height = epoch_height;
+    network_config.config.epoch_height = hotshot_types::HotshotHeight(epoch_height);
 
     // If the `Libp2p` bootstrap nodes were supplied via the command line, override those
     // present in the config file.
@@ -490,7 +490,7 @@ pub async fn init_node<P: SequencerPersistence + MembershipPersistence, V: Versi
 
     let membership: Arc<RwLock<EpochCommittees>> = Arc::new(RwLock::new(membership));
     let coordinator =
-        EpochMembershipCoordinator::new(membership, network_config.config.epoch_height);
+        EpochMembershipCoordinator::new(membership, network_config.config.epoch_height.value());
 
     let instance_state = NodeState {
         chain_config: genesis.chain_config,
@@ -763,7 +763,7 @@ pub mod testing {
         }
 
         pub fn epoch_height(mut self, epoch_height: u64) -> Self {
-            self.config.epoch_height = epoch_height;
+            self.config.epoch_height = hotshot_types::HotshotHeight(epoch_height);
             self
         }
 
@@ -1014,7 +1014,7 @@ pub mod testing {
             )
             .with_current_version(V::Base::version())
             .with_genesis(state)
-            .with_epoch_height(config.epoch_height)
+            .with_epoch_height(config.epoch_height.value())
             .with_upgrades(upgrades);
 
             tracing::info!(

--- a/staking-cli/src/bin/staking-cli.rs
+++ b/staking-cli/src/bin/staking-cli.rs
@@ -233,7 +233,7 @@ pub async fn main() -> Result<()> {
         },
         Commands::StakeForDemo { num_validators } => {
             tracing::info!("Staking for demo with {num_validators} validators");
-            stake_for_demo(&config, num_validators).await.unwrap();
+            // stake_for_demo(&config, num_validators).await.unwrap();
             return Ok(());
         },
         _ => unreachable!(),

--- a/types/src/v0/config.rs
+++ b/types/src/v0/config.rs
@@ -127,7 +127,7 @@ impl From<HotShotConfig<SeqTypes>> for PublicHotShotConfig {
             stop_proposing_time,
             start_voting_time,
             stop_voting_time,
-            epoch_height,
+            epoch_height:epoch_height.value(),
             epoch_start_block,
         }
     }
@@ -156,7 +156,7 @@ impl PublicHotShotConfig {
             stop_proposing_time: self.stop_proposing_time,
             start_voting_time: self.start_voting_time,
             stop_voting_time: self.stop_voting_time,
-            epoch_height: self.epoch_height,
+            epoch_height: hotshot_types::HotshotHeight(self.epoch_height),
             epoch_start_block: self.epoch_start_block,
         }
     }

--- a/types/src/v0/traits.rs
+++ b/types/src/v0/traits.rs
@@ -844,7 +844,7 @@ pub trait SequencerPersistence: Sized + Send + Sync + Clone + 'static {
         Ok((
             HotShotInitializer {
                 instance_state: state,
-                epoch_height,
+                epoch_height:epoch_height.value(),
                 epoch_start_block,
                 anchor_leaf: leaf,
                 anchor_state: validated_state.unwrap_or_default(),


### PR DESCRIPTION
Starting point for #2952 

### This PR:
- Implement a wrapper struct for `epoch_height` in hotshot.


### Key places to review:
- Key change in `hotshot-types/src/lib.rs`, Line 72

If this was the intended direction for #2952 , I can go ahead and build wrapper for other primitive types as advised.

