### PR TITLE
staking-cli: improve info command

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -11,5 +11,6 @@ extend-exclude = [
   "contracts/rust/adapter/src/bindings",
   "node-metrics/src/api/node_validator/v0/example_prometheus_metrics_output.txt",
   "hotshot-orchestrator/run-config.toml",
-  "hotshot-macros/src/lib.rs"
+  "hotshot-macros/src/lib.rs",
+  "staking-cli/tests/cli.rs",
 ]

--- a/staking-cli/src/bin/staking-cli.rs
+++ b/staking-cli/src/bin/staking-cli.rs
@@ -193,7 +193,10 @@ pub async fn main() -> Result<()> {
     let token = EspToken::new(config.token_address, &provider);
 
     let result = match config.commands {
-        Commands::Info { l1_block_number } => {
+        Commands::Info {
+            l1_block_number,
+            compact,
+        } => {
             let query_block = l1_block_number.unwrap_or(BlockId::latest());
             let l1_block = provider.get_block(query_block).await?.unwrap_or_else(|| {
                 exit_err("Failed to get block {query_block}", "Block not found");
@@ -206,7 +209,7 @@ pub async fn main() -> Result<()> {
                 l1_block_resolved,
             )
             .await?;
-            display_stake_table(stake_table)?;
+            display_stake_table(stake_table, compact)?;
             return Ok(());
         },
         Commands::RegisterValidator {

--- a/staking-cli/src/deploy.rs
+++ b/staking-cli/src/deploy.rs
@@ -13,6 +13,7 @@ use alloy::{
 };
 use anyhow::Result;
 use hotshot_contract_adapter::sol_types::{ERC1967Proxy, EspToken, StakeTable};
+use rand::{rngs::StdRng, SeedableRng as _};
 use url::Url;
 
 use crate::{parse::Commission, registration::register_validator, BLSKeyPair, DEV_MNEMONIC};
@@ -86,8 +87,9 @@ impl TestSystem {
             .await?;
         assert!(receipt.status());
 
-        let bls_key_pair = BLSKeyPair::generate(&mut rand::thread_rng());
-        let schnorr_key_pair = SchnorrKeyPair::generate(&mut rand::thread_rng());
+        let mut rng = StdRng::from_seed([42u8; 32]);
+        let bls_key_pair = BLSKeyPair::generate(&mut rng);
+        let schnorr_key_pair = SchnorrKeyPair::generate(&mut rng);
         Ok(Self {
             provider,
             deployer_address,

--- a/staking-cli/src/info.rs
+++ b/staking-cli/src/info.rs
@@ -31,7 +31,7 @@ pub fn display_stake_table(stake_table: Vec<Validator<BLSPubKey>>, compact: bool
         let bls_key = validator.stake_table_key.to_string();
         let key_str = if compact {
             let end = bls_key.chars().map(|c| c.len_utf8()).take(40).sum();
-            format!("{}..", bls_key[..end].to_string())
+            format!("{}..", &bls_key[..end])
         } else {
             bls_key.to_string()
         };
@@ -48,7 +48,7 @@ pub fn display_stake_table(stake_table: Vec<Validator<BLSPubKey>>, compact: bool
 
         // sort delegators by address for easier reading
         let mut delegators = validator.delegators.iter().collect::<Vec<_>>();
-        delegators.sort_by(|a, b| a.0.cmp(&b.0));
+        delegators.sort_by(|a, b| a.0.cmp(b.0));
         for (delegator, stake) in delegators {
             tracing::info!(
                 " - Delegator {delegator}: stake={} ESP",

--- a/staking-cli/src/info.rs
+++ b/staking-cli/src/info.rs
@@ -12,30 +12,49 @@ pub async fn stake_table_info(
     l1_block_number: u64,
 ) -> Result<Vec<Validator<BLSPubKey>>> {
     let l1 = L1Client::new(vec![l1_url])?;
-    let st = l1
-        .get_stake_table(stake_table_address, l1_block_number)
+    let validators = l1
+        .fetch_all_validators(stake_table_address, l1_block_number)
         .await?;
-    Ok(st
+
+    Ok(validators
         .into_iter()
         .map(|(_address, validator)| validator)
         .collect())
 }
 
-pub fn display_stake_table(stake_table: Vec<Validator<BLSPubKey>>) -> Result<()> {
+pub fn display_stake_table(stake_table: Vec<Validator<BLSPubKey>>, compact: bool) -> Result<()> {
     let mut stake_table = stake_table.clone();
     stake_table.sort_by(|a, b| a.stake.cmp(&b.stake));
 
     for validator in stake_table.iter() {
         let comm: Commission = validator.commission.try_into()?;
         let bls_key = validator.stake_table_key.to_string();
-        let end = bls_key.chars().map(|c| c.len_utf8()).take(40).sum();
+        let key_str = if compact {
+            let end = bls_key.chars().map(|c| c.len_utf8()).take(40).sum();
+            format!("{}..", bls_key[..end].to_string())
+        } else {
+            bls_key.to_string()
+        };
         tracing::info!(
-            "Validator {}: {}... comm={} stake={} ESP",
+            "Validator {}: {key_str} comm={comm} stake={} ESP",
             validator.account,
-            &bls_key[..end],
-            comm,
             format_ether(validator.stake),
         );
+
+        if validator.delegators.is_empty() {
+            tracing::info!(" - No delegators");
+            continue;
+        }
+
+        // sort delegators by address for easier reading
+        let mut delegators = validator.delegators.iter().collect::<Vec<_>>();
+        delegators.sort_by(|a, b| a.0.cmp(&b.0));
+        for (delegator, stake) in delegators {
+            tracing::info!(
+                " - Delegator {delegator}: stake={} ESP",
+                format_ether(*stake)
+            );
+        }
     }
     Ok(())
 }

--- a/staking-cli/src/lib.rs
+++ b/staking-cli/src/lib.rs
@@ -64,6 +64,7 @@ impl Default for Commands {
     fn default() -> Self {
         Commands::Info {
             l1_block_number: None,
+            compact: false,
         }
     }
 }
@@ -109,6 +110,10 @@ pub enum Commands {
         /// Defaults to the latest block for convenience.
         #[clap(long)]
         l1_block_number: Option<BlockId>,
+
+        /// Abbreviate the very long BLS public keys.
+        #[clap(long)]
+        compact: bool,
     },
     /// Register to become a validator.
     RegisterValidator {

--- a/staking-cli/tests/cli.rs
+++ b/staking-cli/tests/cli.rs
@@ -324,7 +324,7 @@ async fn test_cli_transfer() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_cli_info() -> Result<()> {
+async fn test_cli_info_full() -> Result<()> {
     let system = TestSystem::deploy().await?;
     system.register_validator().await?;
 
@@ -333,8 +333,38 @@ async fn test_cli_info() -> Result<()> {
 
     let out = system.cmd().arg("info").output()?.assert_success().utf8();
 
-    assert!(out.contains(&system.deployer_address.to_string()));
-    assert!(out.contains("0.123"));
+    // Print output to fix test more easily.
+    println!("{}", out);
+    out.contains("Validator 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266: BLS_VER_KEY~ksjrqSN9jEvKOeCNNySv9Gcg7UjZvROpOm99zHov8SgxfzhLyno8IUfE1nxOBhGnajBmeTbchVI94ZUg5VLgAT2DBKXBnIC6bY9y2FBaK1wPpIQVgx99-fAzWqbweMsiXKFYwiT-0yQjJBXkWyhtCuTHT4l3CRok68mkobI09q0c comm=12.34 % stake=0.123000000000000000 ESP");
+    out.contains(
+        " - Delegator 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266: stake=0.123000000000000000 ESP",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cli_info_compact() -> Result<()> {
+    let system = TestSystem::deploy().await?;
+    system.register_validator().await?;
+
+    let amount = parse_ether("0.123")?;
+    system.delegate(amount).await?;
+
+    let out = system
+        .cmd()
+        .arg("info")
+        .arg("--compact")
+        .output()?
+        .assert_success()
+        .utf8();
+
+    // Print output to fix test more easily.
+    println!("{}", out);
+    out.contains("Validator 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266: BLS_VER_KEY~ksjrqSN9jEvKOeCNNySv9Gcg7UjZ.. comm=12.34 % stake=0.123000000000000000 ESP");
+    out.contains(
+        " - Delegator 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266: stake=0.123000000000000000 ESP",
+    );
 
     Ok(())
 }

--- a/types/src/v0/impls/l1.rs
+++ b/types/src/v0/impls/l1.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::{min, Ordering},
+    collections::BTreeMap,
     num::NonZeroUsize,
     pin::Pin,
     result::Result as StdResult,
@@ -43,10 +44,11 @@ use tracing::Instrument;
 use url::Url;
 
 use super::{
-    from_l1_events,
+    select_validators_with_stake,
     v0_1::{SingleTransport, SingleTransportStatus, SwitchingTransport},
     v0_3::Validator,
-    L1BlockInfo, L1BlockInfoWithParent, L1ClientMetrics, L1State, L1UpdateTask, StakeTableEvent,
+    validators_from_l1_events, L1BlockInfo, L1BlockInfoWithParent, L1ClientMetrics, L1State,
+    L1UpdateTask, StakeTableEvent,
 };
 use crate::{FeeInfo, L1Client, L1ClientOptions, L1Event, L1Snapshot};
 
@@ -870,16 +872,12 @@ impl L1Client {
             .await
     }
 
-    /// Get `StakeTable` at specific l1 block height.
-    /// This function fetches and processes various events (ValidatorRegistered, ValidatorExit,
-    /// Delegated, Undelegated, and ConsensusKeysUpdated) within the block range from the
-    /// contract's initialization block to the provided `to_block` value.
-    /// Events are fetched in chunks to and retries are implemented for failed requests.
-    pub async fn get_stake_table(
+    /// Fetch all stake table events from L1
+    pub async fn fetch_stake_table_events(
         &self,
         contract: Address,
         to_block: u64,
-    ) -> anyhow::Result<IndexMap<Address, Validator<BLSPubKey>>> {
+    ) -> anyhow::Result<BTreeMap<(u64, u64), StakeTableEvent>> {
         let stake_table_contract = StakeTable::new(contract, self.provider.clone());
 
         // get the block number when the contract was initialized
@@ -1042,16 +1040,38 @@ impl L1Client {
         let keys_update = keys_update_events.flatten().collect().await;
 
         // Sort all events by log index and log block number for correct order.
-        let events = StakeTableEvent::sort_events(
+        StakeTableEvent::sort_events(
             registered,
             deregistered,
             delegated,
             undelegated,
             keys_update,
-        )?;
+        )
+    }
 
+    /// Get `StakeTable` at specific l1 block height.
+    /// This function fetches and processes various events (ValidatorRegistered, ValidatorExit,
+    /// Delegated, Undelegated, and ConsensusKeysUpdated) within the block range from the
+    /// contract's initialization block to the provided `to_block` value.
+    /// Events are fetched in chunks to and retries are implemented for failed requests.
+    pub async fn fetch_stake_table(
+        &self,
+        contract: Address,
+        to_block: u64,
+    ) -> anyhow::Result<IndexMap<Address, Validator<BLSPubKey>>> {
+        let mut validators = self.fetch_all_validators(contract, to_block).await?;
+        select_validators_with_stake(&mut validators)?;
+        Ok(validators)
+    }
+
+    pub async fn fetch_all_validators(
+        &self,
+        contract: Address,
+        to_block: u64,
+    ) -> anyhow::Result<IndexMap<Address, Validator<BLSPubKey>>> {
+        let events = self.fetch_stake_table_events(contract, to_block).await?;
         // Process the sorted events and return the resulting stake table.
-        from_l1_events(events.values().cloned())
+        validators_from_l1_events(events.values().cloned())
     }
 
     /// Check if the given address is a proxy contract.

--- a/types/src/v0/impls/l1.rs
+++ b/types/src/v0/impls/l1.rs
@@ -44,7 +44,7 @@ use tracing::Instrument;
 use url::Url;
 
 use super::{
-    select_validators_with_stake,
+    active_validator_set_from_l1_events,
     v0_1::{SingleTransport, SingleTransportStatus, SwitchingTransport},
     v0_3::Validator,
     validators_from_l1_events, L1BlockInfo, L1BlockInfoWithParent, L1ClientMetrics, L1State,
@@ -1059,9 +1059,8 @@ impl L1Client {
         contract: Address,
         to_block: u64,
     ) -> anyhow::Result<IndexMap<Address, Validator<BLSPubKey>>> {
-        let mut validators = self.fetch_all_validators(contract, to_block).await?;
-        select_validators_with_stake(&mut validators)?;
-        Ok(validators)
+        let events = self.fetch_stake_table_events(contract, to_block).await?;
+        active_validator_set_from_l1_events(events.values().cloned())
     }
 
     pub async fn fetch_all_validators(

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -46,15 +46,8 @@ use crate::{EpochVersion, SequencerVersions};
 
 type Epoch = <SeqTypes as NodeType>::Epoch;
 
-/// Create the consensus and DA stake tables from L1 events
-///
-/// This is a pure function, to make it easily testable.
-///
-/// We expect have at most a few hundred EVM events in the
-/// PermissionedStakeTable contract over the liftetime of the contract so it
-/// should not significantly affect performance to fetch all events and
-/// perform the computation in this functions once per epoch.
-pub fn validators_from_l1_events<I: Iterator<Item = StakeTableEvent>>(
+/// Extract all validators from L1 stake table events.
+pub(crate) fn validators_from_l1_events<I: Iterator<Item = StakeTableEvent>>(
     events: I,
 ) -> anyhow::Result<IndexMap<Address, Validator<BLSPubKey>>> {
     let mut validators = IndexMap::new();
@@ -179,7 +172,10 @@ pub fn validators_from_l1_events<I: Iterator<Item = StakeTableEvent>>(
     Ok(validators)
 }
 
-pub(crate) fn select_validators_with_stake(
+/// Select active validators
+///
+/// Removes the validators without stake and selects the top 100 staked validators.
+pub(crate) fn select_active_validator_set(
     validators: &mut IndexMap<Address, Validator<BLSPubKey>>,
 ) -> anyhow::Result<()> {
     // Remove invalid validators first
@@ -232,6 +228,15 @@ pub(crate) fn select_validators_with_stake(
     validators.retain(|address, _| selected_addresses.contains(address));
 
     Ok(())
+}
+
+/// Extract the active validator set from the L1 stake table events.
+pub(crate) fn active_validator_set_from_l1_events<I: Iterator<Item = StakeTableEvent>>(
+    events: I,
+) -> anyhow::Result<IndexMap<Address, Validator<BLSPubKey>>> {
+    let mut validators = validators_from_l1_events(events)?;
+    select_active_validator_set(&mut validators)?;
+    Ok(validators)
 }
 
 #[derive(Clone, derive_more::From)]
@@ -1062,7 +1067,7 @@ mod tests {
         ]
         .to_vec();
 
-        let st = validators_from_l1_events(events.iter().cloned())?;
+        let st = active_validator_set_from_l1_events(events.iter().cloned())?;
         let st_val = st.get(&val.account).unwrap();
         // final staked amount should be 10 (delegated) - 7 (undelegated) + 5 (Delegated)
         assert_eq!(st_val.stake, U256::from(8));
@@ -1079,7 +1084,7 @@ mod tests {
         );
 
         // This should fail because the validator has exited and no longer exists in the stake table.
-        assert!(validators_from_l1_events(events.iter().cloned()).is_err());
+        assert!(active_validator_set_from_l1_events(events.iter().cloned()).is_err());
 
         Ok(())
     }
@@ -1130,7 +1135,7 @@ mod tests {
         ];
 
         for events in cases.iter() {
-            let res = validators_from_l1_events(events.iter().cloned());
+            let res = active_validator_set_from_l1_events(events.iter().cloned());
             assert!(
                 res.is_err(),
                 "events {:?}, not a valid sequencer of events",
@@ -1156,7 +1161,7 @@ mod tests {
 
         let minimum_stake = highest_stake / U256::from(VID_TARGET_TOTAL_STAKE);
 
-        select_validators_with_stake(&mut validators).expect("Failed to select validators");
+        select_active_validator_set(&mut validators).expect("Failed to select validators");
         assert!(
             validators.len() <= 100,
             "validators len is {}, expected at most 100",


### PR DESCRIPTION
- Include all validators, not just the ones with stake.
- Show delegators.
- Test info command against fix output.
- Make TestSystem keys deterministic.
- Allow compact and full BLS key output.