### PR TITLE
enable config module for devnode

### DIFF
--- a/sequencer/src/bin/espresso-dev-node.rs
+++ b/sequencer/src/bin/espresso-dev-node.rs
@@ -457,6 +457,7 @@ async fn main() -> anyhow::Result<()> {
         max_connections: sequencer_api_max_connections,
     })
     .submit(Default::default())
+    .config(Default::default())
     .query_sql(Default::default(), sql);
 
     let config = TestNetworkConfigBuilder::<NUM_NODES, _, _>::with_num_nodes()


### PR DESCRIPTION
prover service requires config module to fetch hotshot config. This PR enables the config module in the devnode to make prover work