### PR TITLE
Fix tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,7 +17,7 @@ retries  = 10
 
 [[profile.default.overrides]]
 filter = 'test(test_hotshot_event_streaming_epoch_progression)'
-slow-timeout = { period = "4m", terminate-after = 4 }
+slow-timeout = { period = "8m", terminate-after = 4 }
 
 # The restart tests run an entire sequencing network, and so are quite resource intensive.
 [[profile.default.overrides]]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -28,7 +28,6 @@ threads-required = 'num-cpus'
 [[profile.default.overrides]]
 filter = 'package(request-response)'
 threads-required = 'num-cpus'
-retries  = 20
 
 # HotShot integration tests
 [profile.hotshot]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,7 +18,13 @@ retries  = 10
 # The restart tests run an entire sequencing network, and so are quite resource intensive.
 [[profile.default.overrides]]
 filter = 'test(slow_test_restart)'
+slow-timeout = { period = "1m", terminate-after = 3 }
 threads-required = 'num-cpus'
+
+[[profile.default.overrides]]
+filter = 'package(request-response)'
+threads-required = 'num-cpus'
+retries  = 20
 
 # HotShot integration tests
 [profile.hotshot]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,7 +17,7 @@ retries  = 10
 
 [[profile.default.overrides]]
 filter = 'test(test_hotshot_event_streaming_epoch_progression)'
-slow-timeout = { period = "2m", terminate-after = 4 }
+slow-timeout = { period = "4m", terminate-after = 4 }
 
 # The restart tests run an entire sequencing network, and so are quite resource intensive.
 [[profile.default.overrides]]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,6 +15,10 @@ test(test_process_client_handling_stream_subscribe_voters)
 slow-timeout = { period = "2s", terminate-after = 1 }
 retries  = 10
 
+[[profile.default.overrides]]
+filter = 'test(test_hotshot_event_streaming_epoch_progression)'
+slow-timeout = { period = "2m", terminate-after = 4 }
+
 # The restart tests run an entire sequencing network, and so are quite resource intensive.
 [[profile.default.overrides]]
 filter = 'test(slow_test_restart)'

--- a/request-response/src/lib.rs
+++ b/request-response/src/lib.rs
@@ -896,7 +896,7 @@ mod tests {
         // Build a config
         let config = IntegrationTestConfig {
             request_response_config: default_protocol_config(),
-            num_participants: 100,
+            num_participants: 50,
             num_participants_with_data: 1,
             request_timeout: Duration::from_secs(40),
             data_available_delay: Duration::from_secs(2),

--- a/request-response/src/lib.rs
+++ b/request-response/src/lib.rs
@@ -896,7 +896,7 @@ mod tests {
         // Build a config
         let config = IntegrationTestConfig {
             request_response_config: default_protocol_config(),
-            num_participants: 50,
+            num_participants: 100,
             num_participants_with_data: 1,
             request_timeout: Duration::from_secs(40),
             data_available_delay: Duration::from_secs(2),


### PR DESCRIPTION
Fix broken test. Test passes locally. 

First guess is limited resources on CI. So trying spawning less tasks. Another possibility might be more retries, w/ the idea that when other tests finish there will be more bandwidth and retry might succeed.