### PR TITLE
fix: run request-response tests serially

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,6 +20,10 @@ retries  = 10
 filter = 'test(slow_test_restart)'
 threads-required = 'num-cpus'
 
+[[profile.default.overrides]]
+filter = 'package(request-response)'
+threads-required = 'num-cpus'
+
 # HotShot integration tests
 [profile.hotshot]
 retries = 2


### PR DESCRIPTION
Unable to reproduce failure locally, not sure this will help.
