### PR TITLE
Make nodes start up with the right state

### DIFF
--- a/types/src/v0/traits.rs
+++ b/types/src/v0/traits.rs
@@ -786,11 +786,11 @@ pub trait SequencerPersistence: Sized + Send + Sync + Clone + 'static {
         };
         let validated_state = if leaf.block_header().height() == 0 {
             // If we are starting from genesis, we can provide the full state.
-            Some(Arc::new(genesis_validated_state))
+            genesis_validated_state
         } else {
             // Otherwise, we will have to construct a sparse state and fetch missing data during
             // catchup.
-            None
+            ValidatedState::from_header(leaf.block_header())
         };
 
         // If we are not starting from genesis, we start from the view following the maximum view
@@ -847,7 +847,7 @@ pub trait SequencerPersistence: Sized + Send + Sync + Clone + 'static {
                 epoch_height,
                 epoch_start_block,
                 anchor_leaf: leaf,
-                anchor_state: validated_state.unwrap_or_default(),
+                anchor_state: Arc::new(validated_state),
                 anchor_state_delta: None,
                 start_view: view,
                 start_epoch: epoch,


### PR DESCRIPTION
`unwrap_or_default` means that when we startup and `ValidatedState` is `None` (i.e. we are not already starting from the genesis state) we will use the `Default` `ValidatedState` which is...the genesis state.

If a quorum of nodes restart at the same time in this way, they will form a QC on a proposal with the incorrect (genesis) state.

### This PR:

Changes `load_consensus_state` to initialize HotShot with the state corresponding to the anchor leaf.
