### PR TITLE
Move contract deployment into test network

### DIFF
--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -961,13 +961,6 @@ pub mod test_helpers {
             let mut cfg = cfg;
             let mut marketplace_builder_url = "http://example.com".parse().unwrap();
             let mut builder_tasks = Vec::new();
-            // Self::version_hooks(
-            //     &mut cfg,
-            //     &mut marketplace_builder_url,
-            //     &mut builder_tasks,
-            //     bind_version,
-            // )
-            // .await;
 
             if <V as Versions>::Base::VERSION < MarketplaceVersion::VERSION {
                 let chain_config = cfg.state[0].chain_config.resolve();

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -837,6 +837,8 @@ pub mod test_helpers {
             self
         }
 
+        /// Setup for POS testing. Deploys contracts and adds the
+        /// stake table address to state. Must be called before `build()`.
         pub async fn pos_hook<V: Versions>(self) -> anyhow::Result<Self> {
             if <V as Versions>::Upgrade::VERSION < EpochVersion::VERSION
                 && <V as Versions>::Base::VERSION < EpochVersion::VERSION
@@ -3068,7 +3070,7 @@ mod test {
     // TODO when `EpochVersion` becomes base version we can merge this
     // w/ above test.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_hotshot_event_streaming_epoch_progression() -> anyhow::Result<()> {
+    async fn test_hotshot_event_streaming_epoch_progression() {
         setup_test();
         let epoch_height = 35;
         let wanted_epochs = 4;
@@ -3159,7 +3161,5 @@ mod test {
             epochs.contains(&wanted_epochs),
             "Epochs are not progressing"
         );
-
-        Ok(())
     }
 }

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -3014,6 +3014,7 @@ mod test {
 
         let network_config = TestConfigBuilder::default()
             .l1_url(l1_url.clone())
+            .signer(signer.clone())
             .epoch_height(epoch_height)
             .build();
 

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -3118,7 +3118,7 @@ mod test {
             .await
             .unwrap();
 
-        let wanted_views = epoch_height * wanted_epochs; // TODO not sure about this
+        let wanted_views = epoch_height * wanted_epochs;
 
         let mut views = HashSet::new();
         let mut epochs = HashSet::new();

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -3104,9 +3104,10 @@ mod test {
 
         let config = TestNetworkConfigBuilder::default()
             .api_config(options)
-            // .states(std::array::from_fn(|_| state.clone()))
             .network_config(network_config.clone())
-            .pos_hook::<PosVersion>().await.expect("Pos Deployment")
+            .pos_hook::<PosVersion>()
+            .await
+            .expect("Pos Deployment")
             .build();
 
         let _network = TestNetwork::new(config, PosVersion::new()).await;

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -583,7 +583,10 @@ pub mod testing {
 
     use alloy::{
         primitives::U256,
-        signers::{k256::ecdsa::SigningKey, local::PrivateKeySigner},
+        signers::{
+            k256::{ecdsa::SigningKey, Secp256k1},
+            local::{LocalSigner, PrivateKeySigner},
+        },
     };
     use async_lock::RwLock;
     use catchup::NullStateCatchup;
@@ -807,6 +810,7 @@ pub mod testing {
         state_key_pairs: Vec<StateKeyPair>,
         master_map: Arc<MasterMap<PubKey>>,
         l1_url: Url,
+        signer: Option<LocalSigner<SigningKey>>,
         state_relay_url: Option<Url>,
         builder_port: Option<u16>,
         marketplace_builder_port: Option<u16>,
@@ -831,6 +835,11 @@ pub mod testing {
 
         pub fn l1_url(mut self, l1_url: Url) -> Self {
             self.l1_url = l1_url;
+            self
+        }
+
+        pub fn signer(mut self, signer: LocalSigner<SigningKey>) -> Self {
+            self.signer = Some(signer);
             self
         }
 
@@ -922,6 +931,7 @@ pub mod testing {
                 state_key_pairs,
                 master_map,
                 l1_url: "http://localhost:8545".parse().unwrap(),
+                signer: None,
                 state_relay_url: None,
                 builder_port: None,
                 marketplace_builder_port: None,

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -584,7 +584,7 @@ pub mod testing {
     use alloy::{
         primitives::U256,
         signers::{
-            k256::{ecdsa::SigningKey, Secp256k1},
+            k256::ecdsa::SigningKey,
             local::{LocalSigner, PrivateKeySigner},
         },
     };
@@ -810,7 +810,7 @@ pub mod testing {
         state_key_pairs: Vec<StateKeyPair>,
         master_map: Arc<MasterMap<PubKey>>,
         l1_url: Url,
-        signer: Option<LocalSigner<SigningKey>>,
+        signer: LocalSigner<SigningKey>,
         state_relay_url: Option<Url>,
         builder_port: Option<u16>,
         marketplace_builder_port: Option<u16>,
@@ -839,7 +839,7 @@ pub mod testing {
         }
 
         pub fn signer(mut self, signer: LocalSigner<SigningKey>) -> Self {
-            self.signer = Some(signer);
+            self.signer = signer;
             self
         }
 
@@ -862,6 +862,7 @@ pub mod testing {
                 state_key_pairs: self.state_key_pairs,
                 master_map: self.master_map,
                 l1_url: self.l1_url,
+                signer: self.signer,
                 state_relay_url: self.state_relay_url,
                 marketplace_builder_port: self.marketplace_builder_port,
                 builder_port: self.builder_port,
@@ -931,7 +932,7 @@ pub mod testing {
                 state_key_pairs,
                 master_map,
                 l1_url: "http://localhost:8545".parse().unwrap(),
-                signer: None,
+                signer: LocalSigner::random(),
                 state_relay_url: None,
                 builder_port: None,
                 marketplace_builder_port: None,
@@ -947,6 +948,7 @@ pub mod testing {
         state_key_pairs: Vec<StateKeyPair>,
         master_map: Arc<MasterMap<PubKey>>,
         l1_url: Url,
+        signer: LocalSigner<SigningKey>,
         state_relay_url: Option<Url>,
         builder_port: Option<u16>,
         marketplace_builder_port: Option<u16>,
@@ -972,6 +974,10 @@ pub mod testing {
 
         pub fn builder_port(&self) -> Option<u16> {
             self.builder_port
+        }
+
+        pub fn signer(&self) -> LocalSigner<SigningKey> {
+            self.signer.clone()
         }
 
         pub fn l1_url(&self) -> Url {


### PR DESCRIPTION
POS specific setup is moved inside the `TestNetwork` family and version gated. Now in order to run tests that require POS contracts, you need to call `pos_hook<Version>` before calling `build()` on the `TestNetworkConfigBuilder`. This PR also updates `test_hotshot_event_streaming_epoch_progression` to use this setup (as opposed to "inline" setup as before) to demonstrate a working model. 

The expectation is that going forward tests that require working epochs will use this instead of duplicating the same setup everywhere. 

As a followup we should have `dev-node` use this logic.   