### PR TITLE
fix: installing just with snap takes ages

### DIFF
--- a/.github/workflows/benchmark-build.yaml
+++ b/.github/workflows/benchmark-build.yaml
@@ -17,10 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Install just command runner
-        run: |
-          sudo snap install --edge --classic just
-          just --version
+      - uses: taiki-e/install-action@just
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -395,10 +392,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-dockers]
     steps:
-      - name: Install just command runner
-        run: |
-          sudo snap install --edge --classic just
-          just --version
+      - uses: taiki-e/install-action@just
 
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,6 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
 
-      - name: Install just command runner
-        run: |
-          sudo snap install --edge --classic just
-          just --version
-
       - name: Checkout Repository
         uses: actions/checkout@v4
 
@@ -234,10 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-dockers]
     steps:
-      - name: Install just command runner
-        run: |
-          sudo snap install --edge --classic just
-          just --version
+      - uses: taiki-e/install-action@just
 
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Weirdly, installing just took almost 9 minutes in this run

https://github.com/EspressoSystems/espresso-network/actions/runs/14417749807/job/40436465426
