### PR TITLE
make types migration batch size configurable

### DIFF
--- a/hotshot-query-service/src/data_source/storage/fail_storage.rs
+++ b/hotshot-query-service/src/data_source/storage/fail_storage.rs
@@ -263,7 +263,7 @@ impl<S, Types: NodeType> MigrateTypes<Types> for FailStorage<S>
 where
     S: MigrateTypes<Types> + Sync,
 {
-    async fn migrate_types(&self) -> anyhow::Result<()> {
+    async fn migrate_types(&self, _batch_size: u64) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/hotshot-query-service/src/data_source/storage/fs.rs
+++ b/hotshot-query-service/src/data_source/storage/fs.rs
@@ -151,7 +151,7 @@ impl<Types: NodeType> MigrateTypes<Types> for FileSystemStorage<Types>
 where
     Payload<Types>: QueryablePayload<Types>,
 {
-    async fn migrate_types(&self) -> anyhow::Result<()> {
+    async fn migrate_types(&self, _batch_size: u64) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/sequencer/src/api/sql.rs
+++ b/sequencer/src/api/sql.rs
@@ -82,6 +82,10 @@ impl SequencerDataSource for DataSource {
             builder = builder.with_chunk_fetch_delay(delay);
         }
 
+        if let Some(batch_size) = opt.types_migration_batch_size {
+            builder = builder.with_types_migration_batch_size(batch_size);
+        }
+
         builder.build().await
     }
 }

--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -239,6 +239,13 @@ pub struct Options {
     )]
     pub(crate) max_connections: u32,
 
+    /// Sets the batch size for the types migration.
+    /// Determines how many `(leaf, vid)` rows are selected from the old types table
+    /// and migrated at once.
+    /// Default is `10000`` if not set
+    #[clap(long, env = "ESPRESSO_SEQUENCER_DATABASE_TYPES_MIGRATION_BATCH_SIZE")]
+    pub(crate) types_migration_batch_size: Option<u64>,
+
     // Keep the database connection pool when persistence is created,
     // allowing it to be reused across multiple instances instead of creating
     // a new pool each time such as for API, consensus storage etc


### PR DESCRIPTION
env variable for types migration batch size. Default is 10k