### PR TITLE
Remove ORDER BY from types migration query

### DIFF
--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -847,7 +847,9 @@ impl<Types: NodeType> MigrateTypes<Types> for SqlStorage {
             return Ok(());
         }
 
-        tracing::warn!("migrating query service types storage");
+        tracing::warn!(
+            "migrating query service types storage. Offset={offset}, batch_size={limit}"
+        );
 
         loop {
             let mut tx = self.read().await.map_err(|err| QueryError::Error {
@@ -856,10 +858,12 @@ impl<Types: NodeType> MigrateTypes<Types> for SqlStorage {
 
             let rows = QueryBuilder::default()
                 .query(&format!(
-                    "SELECT leaf, qc, common as vid_common, share as vid_share 
+                    "SELECT leaf, qc, common as vid_common, share as vid_share
                     FROM leaf INNER JOIN vid on leaf.height = vid.height 
-                    WHERE leaf.height >= {offset} ORDER BY leaf.height LIMIT {limit}",
+                    WHERE leaf.height >= $1 AND leaf.height < $2",
                 ))
+                .bind(offset)
+                .bind(offset + limit as i64)
                 .fetch_all(tx.as_mut())
                 .await?;
 
@@ -953,11 +957,10 @@ impl<Types: NodeType> MigrateTypes<Types> for SqlStorage {
                 "types_migration",
                 ["id", "completed", "migrated_rows"],
                 ["id"],
-                [(0_i64, false, offset)],
+                [(1_i64, false, offset)],
             )
             .await?;
-            let total_rows = rows.len();
-            tracing::warn!("Leaf2: inserted {total_rows}");
+
             // migrate vid
             let mut query_builder: sqlx::QueryBuilder<Db> =
                 sqlx::QueryBuilder::new("INSERT INTO vid2 (height, common, share) ");
@@ -972,7 +975,7 @@ impl<Types: NodeType> MigrateTypes<Types> for SqlStorage {
 
             tx.commit().await?;
 
-            tracing::warn!("VID2: inserted {total_rows}");
+            tracing::warn!("Migrated leaf and vid: offset={offset}");
 
             tracing::info!("offset={offset}");
             if rows.len() < limit as usize {
@@ -990,7 +993,7 @@ impl<Types: NodeType> MigrateTypes<Types> for SqlStorage {
             "types_migration",
             ["id", "completed", "migrated_rows"],
             ["id"],
-            [(0_i64, true, offset)],
+            [(1_i64, true, offset)],
         )
         .await?;
 
@@ -1718,7 +1721,7 @@ mod test {
     async fn test_types_migration() {
         setup_test();
 
-        let num_rows = 200;
+        let num_rows = 500;
         let db = TmpDb::init().await;
 
         let storage = SqlStorage::connect(db.config()).await.unwrap();
@@ -1851,6 +1854,10 @@ mod test {
             .unwrap();
             tx.commit().await.unwrap();
         }
+
+        <SqlStorage as MigrateTypes<MockTypes>>::migrate_types(&storage, 50)
+            .await
+            .expect("failed to migrate");
 
         <SqlStorage as MigrateTypes<MockTypes>>::migrate_types(&storage, 50)
             .await

--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -2939,6 +2939,8 @@ mod test {
             },
             "Wrong light client state update certificate in the storage",
         );
+
+        storage.migrate_consensus().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This PR 
- removes ORDER BY from types migration SELECT query
- fixes offset insertion for resuming types migration  