### PR TITLE
feat: export JSON contract ABIs

### DIFF
--- a/contracts/artifacts/abi/LightClient.json
+++ b/contracts/artifacts/abi/LightClient.json
@@ -1,0 +1,1322 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "_getVk",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "vk",
+        "type": "tuple",
+        "internalType": "struct IPlonkVerifier.VerifyingKey",
+        "components": [
+          {
+            "name": "domainSize",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "numInputs",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sigma0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qM12",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qM34",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qO",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qC",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qEcc",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g2LSB",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "g2MSB",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "currentBlockNumber",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "disablePermissionedProverMode",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "finalizedState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "genesisStakeTableState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blsKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "schnorrKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "amountComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "genesisState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getHotShotCommitment",
+    "inputs": [
+      {
+        "name": "hotShotBlockHeight",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "hotShotBlockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "hotshotBlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStateHistoryCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getVersion",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "majorVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "minorVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "patchVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "_genesis",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "_genesisStakeTableState",
+        "type": "tuple",
+        "internalType": "struct LightClient.StakeTableState",
+        "components": [
+          {
+            "name": "threshold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "blsKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "schnorrKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "amountComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "_stateHistoryRetentionPeriod",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isPermissionedProverEnabled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lagOverEscapeHatchThreshold",
+    "inputs": [
+      {
+        "name": "blockNumber",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blockThreshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "newFinalizedState",
+    "inputs": [
+      {
+        "name": "newState",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct IPlonkVerifier.PlonkProof",
+        "components": [
+          {
+            "name": "wire0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "prodPerm",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zeta",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zetaOmega",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wireEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval4",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "prodPermZetaOmegaEval",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permissionedProver",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setPermissionedProver",
+    "inputs": [
+      {
+        "name": "prover",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setstateHistoryRetentionPeriod",
+    "inputs": [
+      {
+        "name": "historySeconds",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryCommitments",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "l1BlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "l1BlockTimestamp",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "hotShotBlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "hotShotBlockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryFirstIndex",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryRetentionPeriod",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NewState",
+    "inputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PermissionedProverNotRequired",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PermissionedProverRequired",
+    "inputs": [
+      {
+        "name": "permissionedProver",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgrade",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedInnerCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientSnapshotHistory",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidArgs",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidHotShotBlockForCommitmentCheck",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMaxStateHistory",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProof",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoChangeRequired",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OutdatedState",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ProverNotPermissioned",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "WrongStakeTableUsed",
+    "inputs": []
+  }
+]

--- a/contracts/artifacts/abi/LightClientMock.json
+++ b/contracts/artifacts/abi/LightClientMock.json
@@ -1,0 +1,1402 @@
+[
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "_getVk",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "vk",
+        "type": "tuple",
+        "internalType": "struct IPlonkVerifier.VerifyingKey",
+        "components": [
+          {
+            "name": "domainSize",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "numInputs",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sigma0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qM12",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qM34",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qO",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qC",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qEcc",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g2LSB",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "g2MSB",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "currentBlockNumber",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "disablePermissionedProverMode",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "finalizedState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "genesisStakeTableState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blsKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "schnorrKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "amountComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "genesisState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getHotShotCommitment",
+    "inputs": [
+      {
+        "name": "hotShotBlockHeight",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "hotShotBlockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "hotshotBlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStateHistoryCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getVersion",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "majorVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "minorVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "patchVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "_genesis",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "_genesisStakeTableState",
+        "type": "tuple",
+        "internalType": "struct LightClient.StakeTableState",
+        "components": [
+          {
+            "name": "threshold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "blsKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "schnorrKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "amountComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "_stateHistoryRetentionPeriod",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isPermissionedProverEnabled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lagOverEscapeHatchThreshold",
+    "inputs": [
+      {
+        "name": "blockNumber",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "newFinalizedState",
+    "inputs": [
+      {
+        "name": "newState",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct IPlonkVerifier.PlonkProof",
+        "components": [
+          {
+            "name": "wire0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "prodPerm",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zeta",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zetaOmega",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wireEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval4",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "prodPermZetaOmegaEval",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permissionedProver",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setFinalizedState",
+    "inputs": [
+      {
+        "name": "state",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setHotShotDownSince",
+    "inputs": [
+      {
+        "name": "l1Height",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setHotShotUp",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setPermissionedProver",
+    "inputs": [
+      {
+        "name": "prover",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setStateHistory",
+    "inputs": [
+      {
+        "name": "_stateHistoryCommitments",
+        "type": "tuple[]",
+        "internalType": "struct LightClient.StateHistoryCommitment[]",
+        "components": [
+          {
+            "name": "l1BlockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l1BlockTimestamp",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "hotShotBlockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "hotShotBlockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setstateHistoryRetentionPeriod",
+    "inputs": [
+      {
+        "name": "historySeconds",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryCommitments",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "l1BlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "l1BlockTimestamp",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "hotShotBlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "hotShotBlockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryFirstIndex",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryRetentionPeriod",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NewState",
+    "inputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PermissionedProverNotRequired",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PermissionedProverRequired",
+    "inputs": [
+      {
+        "name": "permissionedProver",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgrade",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedInnerCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientSnapshotHistory",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidArgs",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidHotShotBlockForCommitmentCheck",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMaxStateHistory",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProof",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoChangeRequired",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OutdatedState",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ProverNotPermissioned",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "WrongStakeTableUsed",
+    "inputs": []
+  }
+]

--- a/contracts/artifacts/abi/LightClientV2.json
+++ b/contracts/artifacts/abi/LightClientV2.json
@@ -1,0 +1,1835 @@
+[
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "_getVk",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "vk",
+        "type": "tuple",
+        "internalType": "struct IPlonkVerifier.VerifyingKey",
+        "components": [
+          {
+            "name": "domainSize",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "numInputs",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sigma0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qM12",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qM34",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qO",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qC",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qEcc",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g2LSB",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "g2MSB",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "blocksPerEpoch",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "currentBlockNumber",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "currentEpoch",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "disablePermissionedProverMode",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "epochFromBlockNumber",
+    "inputs": [
+      {
+        "name": "_blockNum",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "_blocksPerEpoch",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "epochStartBlock",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "finalizedState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "genesisStakeTableState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blsKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "schnorrKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "amountComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "genesisState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getHotShotCommitment",
+    "inputs": [
+      {
+        "name": "hotShotBlockHeight",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "hotShotBlockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "hotshotBlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStateHistoryCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getVersion",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "majorVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "minorVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "patchVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "_genesis",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "_genesisStakeTableState",
+        "type": "tuple",
+        "internalType": "struct LightClient.StakeTableState",
+        "components": [
+          {
+            "name": "threshold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "blsKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "schnorrKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "amountComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "_stateHistoryRetentionPeriod",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initializeV2",
+    "inputs": [
+      {
+        "name": "_blocksPerEpoch",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "_epochStartBlock",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isEpochRoot",
+    "inputs": [
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isGtEpochRoot",
+    "inputs": [
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isPermissionedProverEnabled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lagOverEscapeHatchThreshold",
+    "inputs": [
+      {
+        "name": "blockNumber",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blockThreshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "newFinalizedState",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IPlonkVerifier.PlonkProof",
+        "components": [
+          {
+            "name": "wire0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "prodPerm",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zeta",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zetaOmega",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wireEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval4",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "prodPermZetaOmegaEval",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "newFinalizedState",
+    "inputs": [
+      {
+        "name": "newState",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "nextStakeTable",
+        "type": "tuple",
+        "internalType": "struct LightClient.StakeTableState",
+        "components": [
+          {
+            "name": "threshold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "blsKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "schnorrKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "amountComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct IPlonkVerifier.PlonkProof",
+        "components": [
+          {
+            "name": "wire0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "prodPerm",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zeta",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zetaOmega",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wireEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval4",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "prodPermZetaOmegaEval",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permissionedProver",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setPermissionedProver",
+    "inputs": [
+      {
+        "name": "prover",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setStateHistoryRetentionPeriod",
+    "inputs": [
+      {
+        "name": "historySeconds",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setstateHistoryRetentionPeriod",
+    "inputs": [
+      {
+        "name": "historySeconds",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryCommitments",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "l1BlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "l1BlockTimestamp",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "hotShotBlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "hotShotBlockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryFirstIndex",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryRetentionPeriod",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "votingStakeTableState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blsKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "schnorrKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "amountComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NewEpoch",
+    "inputs": [
+      {
+        "name": "epoch",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NewState",
+    "inputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PermissionedProverNotRequired",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PermissionedProverRequired",
+    "inputs": [
+      {
+        "name": "permissionedProver",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgrade",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "DeprecatedApi",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedInnerCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientSnapshotHistory",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidArgs",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidHotShotBlockForCommitmentCheck",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMaxStateHistory",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProof",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MissingEpochRootUpdate",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoChangeRequired",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OutdatedState",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ProverNotPermissioned",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "WrongStakeTableUsed",
+    "inputs": []
+  }
+]

--- a/contracts/artifacts/abi/LightClientV2Mock.json
+++ b/contracts/artifacts/abi/LightClientV2Mock.json
@@ -1,0 +1,1968 @@
+[
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "_getVk",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "vk",
+        "type": "tuple",
+        "internalType": "struct IPlonkVerifier.VerifyingKey",
+        "components": [
+          {
+            "name": "domainSize",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "numInputs",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sigma0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigma4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "q4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qM12",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qM34",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qO",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qC",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qH4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "qEcc",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g2LSB",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "g2MSB",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "blocksPerEpoch",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "currentBlockNumber",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "currentEpoch",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "disablePermissionedProverMode",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "epochFromBlockNumber",
+    "inputs": [
+      {
+        "name": "_blockNum",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "_blocksPerEpoch",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "epochStartBlock",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "finalizedState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "genesisStakeTableState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blsKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "schnorrKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "amountComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "genesisState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getHotShotCommitment",
+    "inputs": [
+      {
+        "name": "hotShotBlockHeight",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "hotShotBlockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "hotshotBlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStateHistoryCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getVersion",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "majorVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "minorVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "patchVersion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "_genesis",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "_genesisStakeTableState",
+        "type": "tuple",
+        "internalType": "struct LightClient.StakeTableState",
+        "components": [
+          {
+            "name": "threshold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "blsKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "schnorrKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "amountComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "_stateHistoryRetentionPeriod",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initializeV2",
+    "inputs": [
+      {
+        "name": "_blocksPerEpoch",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "_epochStartBlock",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isEpochRoot",
+    "inputs": [
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isGtEpochRoot",
+    "inputs": [
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isPermissionedProverEnabled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lagOverEscapeHatchThreshold",
+    "inputs": [
+      {
+        "name": "blockNumber",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "newFinalizedState",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IPlonkVerifier.PlonkProof",
+        "components": [
+          {
+            "name": "wire0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "prodPerm",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zeta",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zetaOmega",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wireEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval4",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "prodPermZetaOmegaEval",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "newFinalizedState",
+    "inputs": [
+      {
+        "name": "newState",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "nextStakeTable",
+        "type": "tuple",
+        "internalType": "struct LightClient.StakeTableState",
+        "components": [
+          {
+            "name": "threshold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "blsKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "schnorrKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "amountComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct IPlonkVerifier.PlonkProof",
+        "components": [
+          {
+            "name": "wire0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "prodPerm",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split0",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split1",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split2",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split3",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "split4",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zeta",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "zetaOmega",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wireEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "wireEval4",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval0",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval1",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval2",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "sigmaEval3",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "prodPermZetaOmegaEval",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permissionedProver",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setBlocksPerEpoch",
+    "inputs": [
+      {
+        "name": "newBlocksPerEpoch",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setFinalizedState",
+    "inputs": [
+      {
+        "name": "state",
+        "type": "tuple",
+        "internalType": "struct LightClient.LightClientState",
+        "components": [
+          {
+            "name": "viewNum",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setHotShotDownSince",
+    "inputs": [
+      {
+        "name": "l1Height",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setHotShotUp",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setPermissionedProver",
+    "inputs": [
+      {
+        "name": "prover",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setStateHistory",
+    "inputs": [
+      {
+        "name": "_stateHistoryCommitments",
+        "type": "tuple[]",
+        "internalType": "struct LightClient.StateHistoryCommitment[]",
+        "components": [
+          {
+            "name": "l1BlockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l1BlockTimestamp",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "hotShotBlockHeight",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "hotShotBlockCommRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setStateHistoryRetentionPeriod",
+    "inputs": [
+      {
+        "name": "historySeconds",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setVotingStakeTableState",
+    "inputs": [
+      {
+        "name": "stake",
+        "type": "tuple",
+        "internalType": "struct LightClient.StakeTableState",
+        "components": [
+          {
+            "name": "threshold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "blsKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "schnorrKeyComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "amountComm",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setstateHistoryRetentionPeriod",
+    "inputs": [
+      {
+        "name": "historySeconds",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryCommitments",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "l1BlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "l1BlockTimestamp",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "hotShotBlockHeight",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "hotShotBlockCommRoot",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryFirstIndex",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stateHistoryRetentionPeriod",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "votingStakeTableState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blsKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "schnorrKeyComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      },
+      {
+        "name": "amountComm",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NewEpoch",
+    "inputs": [
+      {
+        "name": "epoch",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NewState",
+    "inputs": [
+      {
+        "name": "viewNum",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockHeight",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blockCommRoot",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PermissionedProverNotRequired",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PermissionedProverRequired",
+    "inputs": [
+      {
+        "name": "permissionedProver",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgrade",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "DeprecatedApi",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedInnerCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientSnapshotHistory",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidArgs",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidHotShotBlockForCommitmentCheck",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMaxStateHistory",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProof",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MissingEpochRootUpdate",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoChangeRequired",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OutdatedState",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ProverNotPermissioned",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "WrongStakeTableUsed",
+    "inputs": []
+  }
+]

--- a/justfile
+++ b/justfile
@@ -156,6 +156,16 @@ gen-bindings:
     cargo fmt --all
     cargo sort -g -w
 
+    just export-contract-abis
+
+# export select ABIs, to let downstream projects can use them without solc compilation
+export-contract-abis:
+    rm -rv contracts/artifacts/abi
+    mkdir -p contracts/artifacts/abi
+    for contract in LightClient{,Mock,V2{,Mock}}; do \
+        cat "contracts/out/${contract}.sol/${contract}.json" | jq .abi > "contracts/artifacts/abi/${contract}.json"; \
+    done
+
 # Lint solidity files
 sol-lint:
     forge fmt


### PR DESCRIPTION
While everyone can generate these ABI files it's tedious to setup a solidity project or extract them from the rust bindings. To make the life of downstream projects such as espresso-network-go easier we can check in the json ABIs explicitly.

The Arbitrum versions of the LC have the same ABIs so I think we can skip them.
