### PR TITLE
staking-cli: decode contract reverts

### DIFF
--- a/staking-cli/src/claim.rs
+++ b/staking-cli/src/claim.rs
@@ -1,6 +1,8 @@
 use alloy::{primitives::Address, providers::Provider, rpc::types::TransactionReceipt};
 use anyhow::Result;
-use hotshot_contract_adapter::sol_types::StakeTable;
+use hotshot_contract_adapter::sol_types::StakeTable::{self, StakeTableErrors};
+
+use crate::l1::DecodeRevertError;
 
 pub async fn claim_withdrawal(
     provider: impl Provider,
@@ -12,7 +14,8 @@ pub async fn claim_withdrawal(
     Ok(st
         .claimWithdrawal(validator_address)
         .send()
-        .await?
+        .await
+        .maybe_decode_revert::<StakeTableErrors>()?
         .get_receipt()
         .await?)
 }
@@ -26,7 +29,8 @@ pub async fn claim_validator_exit(
     Ok(st
         .claimValidatorExit(validator_address)
         .send()
-        .await?
+        .await
+        .maybe_decode_revert::<StakeTableErrors>()?
         .get_receipt()
         .await?)
 }

--- a/staking-cli/src/delegation.rs
+++ b/staking-cli/src/delegation.rs
@@ -4,7 +4,12 @@ use alloy::{
     rpc::types::TransactionReceipt,
 };
 use anyhow::Result;
-use hotshot_contract_adapter::sol_types::{EspToken, StakeTable};
+use hotshot_contract_adapter::sol_types::{
+    EspToken::{self, EspTokenErrors},
+    StakeTable::{self, StakeTableErrors},
+};
+
+use crate::l1::DecodeRevertError as _;
 
 pub async fn approve(
     provider: impl Provider,
@@ -16,7 +21,8 @@ pub async fn approve(
     Ok(token
         .approve(stake_table_address, amount)
         .send()
-        .await?
+        .await
+        .maybe_decode_revert::<EspTokenErrors>()?
         .get_receipt()
         .await?)
 }
@@ -28,12 +34,11 @@ pub async fn delegate(
     amount: U256,
 ) -> Result<TransactionReceipt> {
     let st = StakeTable::new(stake_table, provider);
-    // TODO: needs alloy 0.12: use err.as_decoded_error::<StakeTableErrors>().unwrap();
-    // to provide better error messages in case of failure
     Ok(st
         .delegate(validator_address, amount)
         .send()
-        .await?
+        .await
+        .maybe_decode_revert::<StakeTableErrors>()?
         .get_receipt()
         .await?)
 }
@@ -48,7 +53,8 @@ pub async fn undelegate(
     Ok(st
         .undelegate(validator_address, amount)
         .send()
-        .await?
+        .await
+        .maybe_decode_revert::<StakeTableErrors>()?
         .get_receipt()
         .await?)
 }

--- a/staking-cli/src/l1.rs
+++ b/staking-cli/src/l1.rs
@@ -1,4 +1,10 @@
-use alloy::{primitives::Log, rpc::types::TransactionReceipt, sol_types::SolEvent};
+use alloy::{
+    network::Ethereum,
+    primitives::Log,
+    providers::PendingTransactionBuilder,
+    rpc::types::TransactionReceipt,
+    sol_types::{SolEvent, SolInterface},
+};
 
 // TODO this function can be removed once we move to alloy 0.12
 #[allow(dead_code)]
@@ -7,4 +13,54 @@ pub fn decode_log<E: SolEvent>(r: &TransactionReceipt) -> Option<Log<E>> {
         .logs()
         .iter()
         .find_map(|log| E::decode_log(&log.inner, false).ok())
+}
+
+pub trait DecodeRevertError {
+    fn maybe_decode_revert<E: SolInterface + std::fmt::Debug>(
+        self,
+    ) -> anyhow::Result<PendingTransactionBuilder<Ethereum>>;
+}
+
+impl DecodeRevertError
+    for alloy::contract::Result<PendingTransactionBuilder<Ethereum>, alloy::contract::Error>
+{
+    fn maybe_decode_revert<E: SolInterface + std::fmt::Debug>(
+        self,
+    ) -> anyhow::Result<PendingTransactionBuilder<Ethereum>> {
+        match self {
+            Ok(ret) => Ok(ret),
+            Err(err) => {
+                let decoded = err.as_decoded_interface_error::<E>();
+                let msg = match decoded {
+                    Some(e) => format!("{:?}", e),
+                    None => format!("{:?}", err),
+                };
+                Err(anyhow::anyhow!(msg))
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloy::primitives::U256;
+    use hotshot_contract_adapter::sol_types::StakeTable::{self, StakeTableErrors};
+
+    use super::*;
+    use crate::deploy::TestSystem;
+
+    #[tokio::test]
+    async fn test_decode_revert_error() -> anyhow::Result<()> {
+        let system = TestSystem::deploy().await?;
+        let st = StakeTable::new(system.stake_table, system.provider);
+        let err = st
+            .delegate(system.deployer_address, U256::from(123))
+            .send()
+            .await
+            .maybe_decode_revert::<StakeTableErrors>()
+            .unwrap_err();
+        assert!(err.to_string().contains("ValidatorInactive"));
+
+        Ok(())
+    }
 }

--- a/staking-cli/src/lib.rs
+++ b/staking-cli/src/lib.rs
@@ -24,7 +24,7 @@ pub mod claim;
 pub mod delegation;
 pub mod demo;
 pub mod info;
-mod l1;
+pub mod l1;
 pub mod parse;
 pub mod registration;
 

--- a/staking-cli/src/registration.rs
+++ b/staking-cli/src/registration.rs
@@ -4,10 +4,13 @@ use alloy::{
 };
 use anyhow::Result;
 use ark_ec::CurveGroup;
-use hotshot_contract_adapter::sol_types::{EdOnBN254PointSol, G1PointSol, G2PointSol, StakeTable};
+use hotshot_contract_adapter::sol_types::{
+    EdOnBN254PointSol, G1PointSol, G2PointSol,
+    StakeTable::{self, StakeTableErrors},
+};
 use jf_signature::constants::CS_ID_BLS_BN254;
 
-use crate::{parse::Commission, BLSKeyPair, StateVerKey};
+use crate::{l1::DecodeRevertError as _, parse::Commission, BLSKeyPair, StateVerKey};
 
 fn prepare_bls_payload(
     bls_key_pair: &BLSKeyPair,
@@ -41,7 +44,8 @@ pub async fn register_validator(
             commission.to_evm(),
         )
         .send()
-        .await?
+        .await
+        .maybe_decode_revert::<StakeTableErrors>()?
         .get_receipt()
         .await?)
 }
@@ -59,7 +63,8 @@ pub async fn update_consensus_keys(
     Ok(stake_table
         .updateConsensusKeys(bls_vk_sol.into(), schnorr_vk_sol.into(), sig_sol.into())
         .send()
-        .await?
+        .await
+        .maybe_decode_revert::<StakeTableErrors>()?
         .get_receipt()
         .await?)
 }
@@ -72,7 +77,8 @@ pub async fn deregister_validator(
     Ok(stake_table
         .deregisterValidator()
         .send()
-        .await?
+        .await
+        .maybe_decode_revert::<StakeTableErrors>()?
         .get_receipt()
         .await?)
 }


### PR DESCRIPTION
This shows descriptive error messages in the CLI instead of raw Ethereum revert data.

Added some tests but to see in the command line, run for example

```
cargo run --bin staking-cli -- init --mnemonic "test test test test test test test test test test test junk" --account-index 0
cargo run --bin staking-cli -- delegate --validator-address 0x0774A80189030B3673983ebd4D81DCB5AF21c78A --amount 1 
```