### PR TITLE
POS upgrade test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,6 +19,10 @@ retries  = 10
 filter = 'test(test_hotshot_event_streaming_epoch_progression)'
 slow-timeout = { period = "8m", terminate-after = 4 }
 
+[[profile.default.overrides]]
+filter = 'test(test_pos_upgrade_view_based)'
+slow-timeout = { period = "2m", terminate-after = 5 }
+
 # The restart tests run an entire sequencing network, and so are quite resource intensive.
 [[profile.default.overrides]]
 filter = 'test(slow_test_restart)'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,6 @@
 [profile.default]
 # Kill tests after 3 periods of 2m, because they are probably hanging
-slow-timeout = { period = "2m", terminate-after = 3 }
+slow-timeout = { period = "2m", terminate-after = 8 }
 default-filter = 'not (deps(hotshot-testing) | test(slow_) | package(tests))'
 retries = 2
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,6 @@
 [profile.default]
 # Kill tests after 3 periods of 2m, because they are probably hanging
-slow-timeout = { period = "2m", terminate-after = 8 }
+slow-timeout = { period = "2m", terminate-after = 3 }
 default-filter = 'not (deps(hotshot-testing) | test(slow_) | package(tests))'
 retries = 2
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,6 +16,7 @@ on:
   # Run the audit job once a day on main.
   schedule:
     - cron: "0 0 * * *"
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest
@@ -25,3 +26,25 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  audit_fix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Run cargo audit fix
+        uses: simonhyll/cargo-audit@v1
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bot/cargo-audit
+          title: "[Bot] Audit fixes"
+          commit-message: Cargo audit fixes
+          body: >
+            Updates to Cargo.toml and/or Cargo.lock with security fixes.
+          labels: automated pr
+

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,25 +26,3 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-  audit_fix:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-
-    steps:
-      - name: Run cargo audit fix
-        uses: simonhyll/cargo-audit@v1
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: bot/cargo-audit
-          title: "[Bot] Audit fixes"
-          commit-message: Cargo audit fixes
-          body: >
-            Updates to Cargo.toml and/or Cargo.lock with security fixes.
-          labels: automated pr
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10711,6 +10711,8 @@ dependencies = [
  "futures-util",
  "git-version",
  "hotshot-contract-adapter",
+ "hotshot-stake-table",
+ "hotshot-state-prover",
  "hotshot-types",
  "jf-signature 0.2.0",
  "portpicker",

--- a/crates/hotshot/types/src/signature_key.rs
+++ b/crates/hotshot/types/src/signature_key.rs
@@ -30,10 +30,11 @@ use crate::{
     },
 };
 
-/// BLS private key used to sign a message
+/// BLS private key used to sign a consensus message
 pub type BLSPrivKey = SignKey;
-/// BLS public key used to verify a signature
+/// BLS public key used to verify a consensus signature
 pub type BLSPubKey = VerKey;
+/// BLS key pair used to sign and verify a consensus message
 pub type BLSKeyPair = KeyPair;
 /// Public parameters for BLS signature scheme
 pub type BLSPublicParam = ();

--- a/crates/hotshot/types/src/signature_key.rs
+++ b/crates/hotshot/types/src/signature_key.rs
@@ -19,7 +19,7 @@ use rand_chacha::ChaCha20Rng;
 use tracing::instrument;
 
 use crate::{
-    light_client::{LightClientState, StakeTableState},
+    light_client::{CircuitField, LightClientState, StakeTableState, StateVerKey},
     qc::{BitVectorQc, QcParams},
     stake_table::StakeTableEntry,
     traits::{

--- a/crates/hotshot/types/src/signature_key.rs
+++ b/crates/hotshot/types/src/signature_key.rs
@@ -19,7 +19,7 @@ use rand_chacha::ChaCha20Rng;
 use tracing::instrument;
 
 use crate::{
-    light_client::{CircuitField, LightClientState, StakeTableState, StateVerKey},
+    light_client::{LightClientState, StakeTableState},
     qc::{BitVectorQc, QcParams},
     stake_table::StakeTableEntry,
     traits::{

--- a/sequencer-sqlite/Cargo.lock
+++ b/sequencer-sqlite/Cargo.lock
@@ -10125,6 +10125,8 @@ dependencies = [
  "futures-util",
  "git-version",
  "hotshot-contract-adapter",
+ "hotshot-stake-table",
+ "hotshot-state-prover",
  "hotshot-types",
  "jf-signature 0.2.0",
  "portpicker",

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2650,66 +2650,6 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_fee_upgrade_view_based() {
-        setup_test();
-
-        let mut upgrades = std::collections::BTreeMap::new();
-        type MySequencerVersions = SequencerVersions<V0_1, FeeVersion>;
-
-        let mode = UpgradeMode::View(ViewBasedUpgrade {
-            start_voting_view: None,
-            stop_voting_view: None,
-            start_proposing_view: 1,
-            stop_proposing_view: 10,
-        });
-
-        let upgrade_type = UpgradeType::Fee {
-            chain_config: ChainConfig {
-                max_block_size: 300.into(),
-                base_fee: 1.into(),
-                ..Default::default()
-            },
-        };
-
-        upgrades.insert(
-            <MySequencerVersions as Versions>::Upgrade::VERSION,
-            Upgrade { mode, upgrade_type },
-        );
-        test_upgrade_helper::<MySequencerVersions>(upgrades, MySequencerVersions::new()).await;
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_fee_upgrade_time_based() {
-        setup_test();
-
-        let now = OffsetDateTime::now_utc().unix_timestamp() as u64;
-
-        let mut upgrades = std::collections::BTreeMap::new();
-        type MySequencerVersions = SequencerVersions<V0_1, FeeVersion>;
-
-        let mode = UpgradeMode::Time(TimeBasedUpgrade {
-            start_proposing_time: Timestamp::from_integer(now).unwrap(),
-            stop_proposing_time: Timestamp::from_integer(now + 500).unwrap(),
-            start_voting_time: None,
-            stop_voting_time: None,
-        });
-
-        let upgrade_type = UpgradeType::Fee {
-            chain_config: ChainConfig {
-                max_block_size: 300.into(),
-                base_fee: 1.into(),
-                ..Default::default()
-            },
-        };
-
-        upgrades.insert(
-            <MySequencerVersions as Versions>::Upgrade::VERSION,
-            Upgrade { mode, upgrade_type },
-        );
-        test_upgrade_helper::<MySequencerVersions>(upgrades, MySequencerVersions::new()).await;
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
     async fn test_pos_upgrade_view_based() {
         setup_test();
 

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2730,13 +2730,14 @@ mod test {
             }
         };
 
+        let wanted_view = upgrade.new_version_first_view + wait_extra_views;
         // Loop until we get the `new_version_first_view`, then test the upgrade.
         loop {
             let event = events.next().await.unwrap();
             let view_number = event.view_number;
 
             tracing::debug!(?view_number, ?upgrade.new_version_first_view, "upgrade_new_view");
-            if view_number > upgrade.new_version_first_view + wait_extra_views {
+            if view_number > wanted_view {
                 let states: Vec<_> = network
                     .peers
                     .iter()

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2823,6 +2823,9 @@ mod test {
                     .upgrades::<MockSeqVersions>(upgrades)
                     .build(),
             )
+            .pos_hook::<MockSeqVersions>()
+            .await
+            .expect("pos version")
             .build();
 
         let mut network = TestNetwork::new(config, bind_version).await;

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2768,7 +2768,7 @@ mod test {
         bind_version: MockSeqVersions,
     ) {
         let port = pick_unused_port().expect("No ports free");
-        let anvil = Anvil::new().block_time(1).spawn();
+        let anvil = Anvil::new().args(["--slots-in-an-epoch", "0"]).spawn();
         let l1 = anvil.endpoint_url();
         let secret_key = anvil.keys()[0].clone();
         let signer = LocalSigner::from(secret_key);
@@ -2831,11 +2831,10 @@ mod test {
             }
         };
 
+        tracing::info!(?upgrade.new_version_first_view, "seen upgrade proposal");
         loop {
             let event = events.next().await.unwrap();
             let view_number = event.view_number;
-            tracing::info!(?upgrade.new_version_first_view, "seen upgrade proposal");
-            tracing::info!(?upgrade, "seen upgrade proposal");
 
             let states: Vec<_> = network
                 .peers
@@ -2849,8 +2848,7 @@ mod test {
                 .map(|state| state.chain_config.resolve())
                 .collect();
 
-            tracing::info!(?view_number, ?upgrade.new_version_first_view, "checking config");
-
+            tracing::debug!(?view_number, ?upgrade.new_version_first_view, "upgrade_new_view");
             // ChainConfigs will eventually be resolved
             if let Some(configs) = configs {
                 tracing::info!(?configs, "configs");

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2725,7 +2725,6 @@ mod test {
             .build();
 
         let mut network = TestNetwork::new(config, version).await;
-
         let mut events = network.server.event_stream().await;
 
         // First loop to get an `UpgradeProposal`. Note that the

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -996,7 +996,6 @@ pub mod test_helpers {
                         let cfg = &cfg.network_config;
                         let upgrades_map = cfg.upgrades();
 
-                        tracing::error!(?upgrades_map);
                         let marketplace_builder_url = marketplace_builder_url.clone();
                         async move {
                             if i == 0 {

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2651,41 +2651,26 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_pos_upgrade_view_based() {
-        setup_test();
-
-        let upgrades = std::collections::BTreeMap::new();
-        type MySequencerVersions = SequencerVersions<FeeVersion, EpochVersion>;
-
-        test_upgrade_helper::<MySequencerVersions>(upgrades, MySequencerVersions::new()).await;
+        type PosUpgrade = SequencerVersions<FeeVersion, EpochVersion>;
+        test_upgrade_helper::<PosUpgrade>(PosUpgrade::new()).await;
     }
 
     #[ignore]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_marketplace_upgrade_view_based() {
-        setup_test();
-
-        let upgrades = std::collections::BTreeMap::new();
-        type MySequencerVersions = SequencerVersions<EpochVersion, MarketplaceVersion>;
-
-        test_upgrade_helper::<MySequencerVersions>(upgrades, MySequencerVersions::new()).await;
+        type MarketplaceUpgrade = SequencerVersions<EpochVersion, MarketplaceVersion>;
+        test_upgrade_helper::<MarketplaceUpgrade>(MarketplaceUpgrade::new()).await;
     }
 
     #[ignore]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_marketplace_upgrade_time_based() {
-        setup_test();
-
-        let mut upgrades = std::collections::BTreeMap::new();
-        type MySequencerVersions = SequencerVersions<EpochVersion, MarketplaceVersion>;
-
-        upgrades.insert(
-            <MySequencerVersions as Versions>::Upgrade::VERSION,
-            Upgrade::marketplace_time_based(),
-        );
-        test_upgrade_helper::<MySequencerVersions>(upgrades, MySequencerVersions::new()).await;
+        type MarketplaceUpgrade = SequencerVersions<EpochVersion, MarketplaceVersion>;
+        test_upgrade_helper::<MarketplaceUpgrade>(MarketplaceUpgrade::new()).await;
     }
 
-    async fn test_upgrade_helper<V: Versions>(upgrades: BTreeMap<Version, Upgrade>, version: V) {
+    async fn test_upgrade_helper<V: Versions>(version: V) {
+        setup_test();
         // wait this number of views beyond the configured first view
         // before asserting anything.
         let wait_extra_views = 10;

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -899,6 +899,7 @@ pub mod test_helpers {
                 blocks_per_epoch,
                 epoch_start_block,
                 initial_stake_table,
+                network_config.staking_priv_keys(),
                 None,
                 multiple_delegators,
             )

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1947,7 +1947,6 @@ mod test {
         status_test_helper, submit_test_helper, TestNetwork, TestNetworkConfigBuilder,
     };
     use tide_disco::{app::AppHealth, error::ServerError, healthcheck::HealthStatus};
-
     use tokio::time::sleep;
     use vbs::version::{StaticVersion, StaticVersionType};
 

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -726,8 +726,7 @@ pub mod test_helpers {
     use committable::Committable;
     use espresso_types::{
         v0::traits::{NullEventConsumer, PersistenceOptions, StateCatchup},
-        EpochVersion, MarketplaceVersion, MockSequencerVersions, NamespaceId, Upgrade, UpgradeMode,
-        UpgradeType, ValidatedState, ViewBasedUpgrade,
+        EpochVersion, MarketplaceVersion, MockSequencerVersions, NamespaceId, ValidatedState,
     };
     use futures::{
         future::{join_all, FutureExt},
@@ -1968,7 +1967,7 @@ mod api_tests {
 #[cfg(test)]
 mod test {
     use std::{
-        collections::{BTreeMap, HashSet},
+        collections::HashSet,
         time::Duration,
     };
 
@@ -1979,8 +1978,7 @@ mod test {
         traits::NullEventConsumer,
         v0_1::{block_reward, RewardAmount},
         BackoffParams, EpochVersion, FeeAmount, FeeVersion, Header, MarketplaceVersion,
-        MockSequencerVersions, SequencerVersions, TimeBasedUpgrade, Timestamp, Upgrade, UpgradeMap,
-        UpgradeMode, UpgradeType, ValidatedState, ViewBasedUpgrade, V0_1,
+        MockSequencerVersions, SequencerVersions, ValidatedState,
     };
     use futures::{
         future::{self, join_all},
@@ -2000,16 +1998,16 @@ mod test {
     };
     use jf_merkle_tree::prelude::{MerkleProof, Sha3Node};
     use portpicker::pick_unused_port;
-    use sequencer_utils::{ser::FromStringOrInteger, test_utils::setup_test};
+    use sequencer_utils::test_utils::setup_test;
     use surf_disco::Client;
     use test_helpers::{
         catchup_test_helper, spawn_dishonest_peer_catchup_api, state_signature_test_helper,
         status_test_helper, submit_test_helper, TestNetwork, TestNetworkConfigBuilder,
     };
     use tide_disco::{app::AppHealth, error::ServerError, healthcheck::HealthStatus};
-    use time::OffsetDateTime;
+    
     use tokio::time::sleep;
-    use vbs::version::{StaticVersion, StaticVersionType, Version};
+    use vbs::version::{StaticVersion, StaticVersionType};
 
     use self::{
         data_source::testing::TestableSequencerDataSource, options::HotshotEvents,

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -979,36 +979,11 @@ pub mod test_helpers {
                 }
             };
 
-            if <V as Versions>::Base::VERSION >= EpochVersion::VERSION {
-                let state = ValidatedState {
-                    chain_config: chain_config.into(),
-                    ..state
-                };
-                return Ok(self.states(std::array::from_fn(|_| state.clone())));
-            }
-
-            if <V as Versions>::Upgrade::VERSION >= EpochVersion::VERSION {
-                let mut network_config = self.network_config.clone().unwrap();
-
-                let mode = UpgradeMode::View(ViewBasedUpgrade {
-                    start_voting_view: None,
-                    stop_voting_view: None,
-                    start_proposing_view: 1,
-                    stop_proposing_view: 10,
-                });
-
-                let upgrade_type = UpgradeType::Epoch { chain_config };
-
-                let mut upgrades = std::collections::BTreeMap::new();
-                upgrades.insert(
-                    <V as Versions>::Upgrade::VERSION,
-                    Upgrade { mode, upgrade_type },
-                );
-
-                network_config.with_upgrades(upgrades);
-                return Ok(self.network_config(network_config));
-            }
-            Ok(self)
+            let state = ValidatedState {
+                chain_config: chain_config.into(),
+                ..state
+            };
+            Ok(self.states(std::array::from_fn(|_| state.clone())))
         }
 
         pub fn build(self) -> TestNetworkConfig<{ NUM_NODES }, P, C> {

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -598,9 +598,8 @@ pub mod testing {
     use espresso_types::{
         eth_signature_key::EthKeyPair,
         v0::traits::{EventConsumer, NullEventConsumer, PersistenceOptions, StateCatchup},
-        v0_99::ChainConfig,
         EpochVersion, Event, FeeAccount, L1Client, MarketplaceVersion, NetworkConfig, PubKey,
-        SeqTypes, Transaction, Upgrade, UpgradeMap, UpgradeMode, UpgradeType, ViewBasedUpgrade,
+        SeqTypes, Transaction, Upgrade, UpgradeMap,
     };
     use futures::{
         future::join_all,
@@ -616,13 +615,13 @@ pub mod testing {
     use hotshot_builder_core_refactored::service::{
         BuilderConfig as LegacyBuilderConfig, GlobalState as LegacyGlobalState,
     };
-    use hotshot_stake_table::vec_based::StakeTable;
+    
     use hotshot_testing::block_builder::{
         BuilderTask, SimpleBuilderImplementation, TestBuilderImplementation,
     };
     use hotshot_types::{
         event::LeafInfo,
-        light_client::{CircuitField, StateKeyPair, StateVerKey},
+        light_client::StateKeyPair,
         signature_key::BLSKeyPair,
         traits::{
             block_contents::BlockHeader,

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -989,6 +989,10 @@ pub mod testing {
             self.upgrades.clone()
         }
 
+        pub fn with_upgrades(&mut self, upgrades: BTreeMap<Version, Upgrade>) {
+            self.upgrades = upgrades;
+        }
+
         pub fn staking_priv_keys(&self) -> Vec<(PrivateKeySigner, BLSKeyPair, StateKeyPair)> {
             let seed = [42u8; 32];
             let mut rng = ChaCha20Rng::from_seed(seed); // Create a deterministic RNG

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -66,7 +66,6 @@ use hotshot_types::{
     utils::BuilderCommitment,
     ValidatorConfig,
 };
-
 pub use options::Options;
 use serde::{Deserialize, Serialize};
 use vbs::version::{StaticVersion, StaticVersionType};
@@ -615,7 +614,6 @@ pub mod testing {
     use hotshot_builder_core_refactored::service::{
         BuilderConfig as LegacyBuilderConfig, GlobalState as LegacyGlobalState,
     };
-
     use hotshot_testing::block_builder::{
         BuilderTask, SimpleBuilderImplementation, TestBuilderImplementation,
     };

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -95,7 +95,7 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence> Clone for Node<N, P> 
 }
 
 pub type SequencerApiVersion = StaticVersion<0, 1>;
-pub type XStakeTable = StakeTable<BLSPubKey, StateVerKey, CircuitField>;
+pub type StakeTableVecBased = StakeTable<BLSPubKey, StateVerKey, CircuitField>;
 
 impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence> NodeImplementation<SeqTypes>
     for Node<N, P>
@@ -1000,8 +1000,8 @@ pub mod testing {
         upgrades: BTreeMap<Version, Upgrade>,
     }
 
-    pub fn stake_table(nodes: Vec<PeerConfig<SeqTypes>>) -> XStakeTable {
-        let mut st = XStakeTable::new(STAKE_TABLE_CAPACITY_FOR_TEST as usize);
+    pub fn stake_table(nodes: Vec<PeerConfig<SeqTypes>>) -> StakeTableVecBased {
+        let mut st = StakeTableVecBased::new(STAKE_TABLE_CAPACITY_FOR_TEST as usize);
         nodes.iter().for_each(|config| {
             st.register(
                 *config.stake_table_entry.key(),
@@ -1093,7 +1093,7 @@ pub mod testing {
             .await
         }
 
-        pub fn stake_table(&self) -> XStakeTable {
+        pub fn stake_table(&self) -> StakeTableVecBased {
             stake_table(self.config.known_nodes_with_stake.clone())
         }
 

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -1051,10 +1051,6 @@ pub mod testing {
             self.upgrades.clone()
         }
 
-        pub fn with_upgrades(&mut self, upgrades: BTreeMap<Version, Upgrade>) {
-            self.upgrades = upgrades;
-        }
-
         pub fn staking_priv_keys(&self) -> Vec<(PrivateKeySigner, BLSKeyPair, StateKeyPair)> {
             let seed = [42u8; 32];
             let mut rng = ChaCha20Rng::from_seed(seed); // Create a deterministic RNG

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -900,7 +900,6 @@ pub mod testing {
         }
 
         pub fn build(self) -> TestConfig<NUM_NODES> {
-            tracing::error!(?self.upgrades, "TestConfig.build()");
             TestConfig {
                 config: self.config,
                 priv_keys: self.priv_keys,
@@ -1164,7 +1163,6 @@ pub mod testing {
 
             let coordinator = EpochMembershipCoordinator::new(membership, 100);
 
-            tracing::error!(?upgrades);
             let node_state = NodeState::new(
                 i as u64,
                 chain_config,

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -856,6 +856,8 @@ pub mod testing {
             self
         }
 
+        /// Version specific upgrade setup. Extend to future upgrades
+        /// by adding a branch to the `match` statement.
         pub async fn set_upgrades(mut self, version: Version) -> Self {
             let upgrade = match version {
                 version if version >= EpochVersion::VERSION => {

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -600,7 +600,7 @@ pub mod testing {
         v0::traits::{EventConsumer, NullEventConsumer, PersistenceOptions, StateCatchup},
         v0_99::ChainConfig,
         EpochVersion, Event, FeeAccount, L1Client, MarketplaceVersion, NetworkConfig, PubKey,
-        SeqTypes, Transaction, Upgrade, UpgradeMode, UpgradeType, ViewBasedUpgrade,
+        SeqTypes, Transaction, Upgrade, UpgradeMap, UpgradeMode, UpgradeType, ViewBasedUpgrade,
     };
     use futures::{
         future::join_all,
@@ -856,10 +856,9 @@ pub mod testing {
             self
         }
 
-        pub async fn set_upgrades<V: Versions>(mut self) -> Self {
-            let version = <V as Versions>::Upgrade::VERSION;
+        pub async fn set_upgrades(mut self, version: Version) -> Self {
             let upgrade = if version >= EpochVersion::VERSION {
-                tracing::error!(?version, "set_upgrade version");
+                tracing::debug!(?version, "set_upgrade version");
                 let blocks_per_epoch = self.config.epoch_height;
                 let epoch_start_block = self.config.epoch_start_block;
 
@@ -1055,6 +1054,10 @@ pub mod testing {
 
         pub fn l1_url(&self) -> Url {
             self.l1_url.clone()
+        }
+
+        pub fn get_upgrade_map(&self) -> UpgradeMap {
+            self.upgrades.clone().into()
         }
 
         pub fn upgrades(&self) -> BTreeMap<Version, Upgrade> {

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -615,7 +615,7 @@ pub mod testing {
     use hotshot_builder_core_refactored::service::{
         BuilderConfig as LegacyBuilderConfig, GlobalState as LegacyGlobalState,
     };
-    
+
     use hotshot_testing::block_builder::{
         BuilderTask, SimpleBuilderImplementation, TestBuilderImplementation,
     };
@@ -874,6 +874,7 @@ pub mod testing {
                         epoch_start_block,
                         initial_stake_table,
                         None,
+                        false,
                     )
                     .await
                     .expect("deployed pos contracts");

--- a/staking-cli/Cargo.toml
+++ b/staking-cli/Cargo.toml
@@ -23,7 +23,6 @@ hotshot-contract-adapter = { workspace = true }
 hotshot-types = { workspace = true }
 hotshot-stake-table = { workspace = true }
 hotshot-state-prover = { workspace = true }
-rand_chacha = { workspace = true }
 jf-signature = { workspace = true, features = ["bls", "schnorr"] }
 portpicker = { workspace = true }
 rand = { workspace = true }

--- a/staking-cli/Cargo.toml
+++ b/staking-cli/Cargo.toml
@@ -20,9 +20,9 @@ espresso-types = { version = "0.1.0", path = "../types" }
 futures-util = "0.3.31"
 git-version = "0.3.9"
 hotshot-contract-adapter = { workspace = true }
-hotshot-types = { workspace = true }
 hotshot-stake-table = { workspace = true }
 hotshot-state-prover = { workspace = true }
+hotshot-types = { workspace = true }
 jf-signature = { workspace = true, features = ["bls", "schnorr"] }
 portpicker = { workspace = true }
 rand = { workspace = true }

--- a/staking-cli/Cargo.toml
+++ b/staking-cli/Cargo.toml
@@ -21,6 +21,9 @@ futures-util = "0.3.31"
 git-version = "0.3.9"
 hotshot-contract-adapter = { workspace = true }
 hotshot-types = { workspace = true }
+hotshot-stake-table = { workspace = true }
+hotshot-state-prover = { workspace = true }
+rand_chacha = { workspace = true }
 jf-signature = { workspace = true, features = ["bls", "schnorr"] }
 portpicker = { workspace = true }
 rand = { workspace = true }

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -402,10 +402,10 @@ fn staking_priv_keys() -> Vec<(PrivateKeySigner, BLSKeyPair, StateKeyPair)> {
     let num_nodes = STAKE_TABLE_CAPACITY_FOR_TEST;
 
     let (_, priv_keys): (Vec<_>, Vec<_>) = (0..num_nodes)
-        .map(|i| <PubKey as SignatureKey>::generated_from_seed_indexed(seed, i as u64))
+        .map(|i| <PubKey as SignatureKey>::generated_from_seed_indexed(seed, i))
         .unzip();
     let state_key_pairs = (0..num_nodes)
-        .map(|i| StateKeyPair::generate_from_seed_indexed(seed, i as u64))
+        .map(|i| StateKeyPair::generate_from_seed_indexed(seed, i))
         .collect::<Vec<_>>();
 
     let mut rng = ChaCha20Rng::from_seed([42u8; 32]); // Create a deterministic RNG

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -39,7 +39,7 @@ use crate::{
     Config,
 };
 
-pub type XStakeTable = StakeTable<BLSPubKey, StateVerKey, CircuitField>;
+pub type StakeTableVecBased = StakeTable<BLSPubKey, StateVerKey, CircuitField>;
 
 pub const STAKE_TABLE_CAPACITY_FOR_TEST: u64 = 3;
 type Prov = FillProvider<
@@ -328,7 +328,7 @@ pub async fn pos_deploy_routine(
     signer: &LocalSigner<SigningKey>, // TODO maybe from_instance(AnvilInstance)
     blocks_per_epoch: u64,
     epoch_start_block: u64,
-    initial_stake_table: XStakeTable,
+    initial_stake_table: StakeTableVecBased,
     _multisig: Option<Address>,
     multiple_delegators: bool,
 ) -> anyhow::Result<Address> {
@@ -447,7 +447,7 @@ mod test {
         let secret_key = anvil.keys()[0].clone();
         let signer = LocalSigner::from(secret_key);
 
-        let mut st = XStakeTable::new(STAKE_TABLE_CAPACITY_FOR_TEST as usize);
+        let mut st = StakeTableVecBased::new(STAKE_TABLE_CAPACITY_FOR_TEST as usize);
         mock_stake(num_nodes).0.iter().for_each(|config| {
             st.register(
                 *config.stake_table_entry.key(),

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -327,6 +327,7 @@ pub async fn pos_deploy_routine(
     epoch_start_block: u64,
     initial_stake_table: XStakeTable,
     _multisig: Option<Address>,
+    multiple_delegators: bool,
 ) -> anyhow::Result<Address> {
     let contracts = &mut Contracts::new();
 
@@ -375,7 +376,7 @@ pub async fn pos_deploy_routine(
     )
     .await?;
 
-    let staking_priv_keys = staking_priv_keys(); // arbitrary num
+    let staking_priv_keys = staking_priv_keys();
 
     let stake_table_address = contracts
         .address(Contract::StakeTableProxy)
@@ -389,7 +390,7 @@ pub async fn pos_deploy_routine(
             .address(Contract::EspTokenProxy)
             .expect("ESP token deployed"),
         staking_priv_keys,
-        false,
+        multiple_delegators,
     )
     .await?;
 
@@ -455,7 +456,7 @@ mod test {
         st.advance();
         st.advance();
 
-        let _address = pos_deploy_routine(&l1, &signer, 50, 1, st, None)
+        let _address = pos_deploy_routine(&l1, &signer, 50, 1, st, None, false)
             .await
             .unwrap();
 

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -19,7 +19,10 @@ use alloy::{
 };
 use anyhow::Result;
 use espresso_types::PubKey;
-use hotshot_contract_adapter::sol_types::EspToken;
+use hotshot_contract_adapter::{
+    evm::DecodeRevert,
+    sol_types::EspToken::{self, EspTokenErrors},
+};
 use hotshot_stake_table::vec_based::StakeTable;
 use hotshot_state_prover::service::legacy_light_client_genesis_from_stake_table;
 use hotshot_types::{
@@ -125,7 +128,8 @@ pub async fn stake_in_contract_for_test(
         let receipt = token
             .transfer(validator_address, fund_amount_esp)
             .send()
-            .await?
+            .await
+            .maybe_decode_revert::<EspTokenErrors>()?
             .get_receipt()
             .await?;
         assert!(receipt.status());
@@ -135,7 +139,8 @@ pub async fn stake_in_contract_for_test(
         let receipt = validator_token
             .approve(stake_table_address, fund_amount_esp)
             .send()
-            .await?
+            .await
+            .maybe_decode_revert::<EspTokenErrors>()?
             .get_receipt()
             .await?;
         assert!(receipt.status());

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -18,7 +18,6 @@ use alloy::{
     },
 };
 use anyhow::Result;
-use espresso_types::PubKey;
 use hotshot_contract_adapter::{
     evm::DecodeRevert,
     sol_types::EspToken::{self, EspTokenErrors},
@@ -28,7 +27,6 @@ use hotshot_state_prover::service::legacy_light_client_genesis_from_stake_table;
 use hotshot_types::{
     light_client::{CircuitField, StateKeyPair, StateVerKey},
     signature_key::{BLSKeyPair, BLSPubKey},
-    traits::signature_key::SignatureKey,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -328,6 +326,7 @@ pub async fn stake_for_demo(config: &Config, num_validators: u16) -> Result<()> 
 /// Commonly used contract deployment routine.
 // TODO move to proper place for shared code. See:
 // https://github.com/EspressoSystems/espresso-network/pull/3083#discussion_r2048832370
+#[allow(clippy::too_many_arguments)]
 pub async fn pos_deploy_routine(
     l1_url: &Url,
     signer: &LocalSigner<SigningKey>, // TODO maybe from_instance(AnvilInstance)
@@ -407,9 +406,12 @@ pub async fn pos_deploy_routine(
 #[cfg(test)]
 mod test {
     use alloy::node_bindings::Anvil;
-    use espresso_types::{v0_3::StakeTable, SeqTypes};
+    use espresso_types::{v0_3::StakeTable, PubKey, SeqTypes};
     use hotshot_types::{
-        traits::{signature_key::StakeTableEntryType, stake_table::StakeTableScheme},
+        traits::{
+            signature_key::{SignatureKey, StakeTableEntryType},
+            stake_table::StakeTableScheme,
+        },
         PeerConfig,
     };
 

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -1,10 +1,16 @@
 use alloy::{
-    network::{EthereumWallet, TransactionBuilder as _},
+    network::{Ethereum, EthereumWallet, TransactionBuilder as _},
     primitives::{
         utils::{format_ether, parse_ether},
         Address, U256,
     },
-    providers::{Provider, ProviderBuilder, WalletProvider},
+    providers::{
+        fillers::{
+            BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, TxFiller,
+            WalletFiller,
+        },
+        Identity, Provider, ProviderBuilder, RootProvider, WalletProvider,
+    },
     rpc::types::TransactionRequest,
     signers::{
         k256::ecdsa::SigningKey,
@@ -21,7 +27,7 @@ use hotshot_types::{
     signature_key::{BLSKeyPair, BLSPubKey},
     traits::{signature_key::SignatureKey, stake_table::StakeTableScheme},
 };
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use sequencer_utils::deployer::{self, Contract, Contracts};
 use url::Url;
@@ -36,6 +42,23 @@ use crate::{
 pub type XStakeTable = StakeTable<BLSPubKey, StateVerKey, CircuitField>;
 
 pub const STAKE_TABLE_CAPACITY_FOR_TEST: u64 = 3;
+type Prov = FillProvider<
+    JoinFill<
+        JoinFill<
+            Identity,
+            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+        >,
+        WalletFiller<EthereumWallet>,
+    >,
+    RootProvider,
+>;
+
+fn make_provider(rpc_url: &Url, signer: LocalSigner<SigningKey>) -> Prov {
+    let wallet = EthereumWallet::from(signer);
+    ProviderBuilder::new()
+        .wallet(wallet)
+        .on_http(rpc_url.clone())
+}
 
 pub async fn stake_in_contract_for_test(
     rpc_url: Url,
@@ -43,19 +66,13 @@ pub async fn stake_in_contract_for_test(
     stake_table_address: Address,
     token_address: Address,
     validator_keys: Vec<(PrivateKeySigner, BLSKeyPair, StateKeyPair)>,
+    multiple_delegators: bool,
 ) -> Result<()> {
     tracing::info!("staking to stake table contract for demo");
 
-    let mk_provider = |signer| {
-        let wallet = EthereumWallet::from(signer);
-        ProviderBuilder::new()
-            .wallet(wallet)
-            .on_http(rpc_url.clone())
-    };
-
     tracing::info!("stake table address: {}", stake_table_address);
 
-    let token_signer = mk_provider(grant_recipient.clone());
+    let token_signer = make_provider(&rpc_url, grant_recipient.clone());
 
     tracing::info!("ESP token address: {token_address}");
     let token = EspToken::new(token_address, token_signer.clone());
@@ -69,19 +86,23 @@ pub async fn stake_in_contract_for_test(
         panic!("grant recipient has no ESP tokens, funding won't work");
     }
 
-    let fund_amount_eth = "1000";
-    let fund_amount = parse_ether(fund_amount_eth)?;
+    let fund_amount_esp = parse_ether("1000")?;
+    let fund_amount_eth = parse_ether("10")?;
+
+    // Set up deterministic rng
+    let seed = [42u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
 
     for (val_index, (signer, bls_key_pair, state_key_pair)) in
         validator_keys.into_iter().enumerate()
     {
-        let validator_provider = mk_provider(signer);
+        let validator_provider = make_provider(&rpc_url, signer);
         let validator_address = validator_provider.default_signer_address();
 
         tracing::info!("fund val {val_index} address: {validator_address}, {fund_amount_eth} ETH");
         let tx = TransactionRequest::default()
             .with_to(validator_address)
-            .with_value(fund_amount);
+            .with_value(fund_amount_eth);
         let receipt = token_signer
             .send_transaction(tx)
             .await?
@@ -100,19 +121,19 @@ pub async fn stake_in_contract_for_test(
 
         tracing::info!("validator {val_index} address: {validator_address}, balance: {bal}");
 
-        tracing::info!("transfer {fund_amount_eth} ESP to {validator_address}",);
+        tracing::info!("transfer {fund_amount_esp} ESP to {validator_address}",);
         let receipt = token
-            .transfer(validator_address, fund_amount)
+            .transfer(validator_address, fund_amount_esp)
             .send()
             .await?
             .get_receipt()
             .await?;
         assert!(receipt.status());
 
-        tracing::info!("approve {fund_amount_eth} ESP for {stake_table_address}",);
+        tracing::info!("approve {fund_amount_esp} ESP for {stake_table_address}",);
         let validator_token = EspToken::new(token_address, validator_provider.clone());
         let receipt = validator_token
-            .approve(stake_table_address, fund_amount)
+            .approve(stake_table_address, fund_amount_esp)
             .send()
             .await?
             .get_receipt()
@@ -142,8 +163,101 @@ pub async fn stake_in_contract_for_test(
         )
         .await?;
         assert!(receipt.status());
+
+        if multiple_delegators {
+            tracing::info!("adding multiple delegators for validator  {val_index} ");
+
+            let num_delegators = rng.gen_range(2..=5);
+
+            add_multiple_delegators(
+                &rpc_url,
+                validator_address,
+                &token_signer,
+                &token,
+                stake_table_address,
+                token_address,
+                &mut rng,
+                num_delegators,
+            )
+            .await?;
+        }
     }
     tracing::info!("completed staking for demo");
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn add_multiple_delegators<F: TxFiller<Ethereum>, P: Provider<Ethereum>>(
+    rpc_url: &Url,
+    validator_address: Address,
+    token_signer: &FillProvider<F, P, Ethereum>,
+    token: &EspToken::EspTokenInstance<(), FillProvider<F, P, Ethereum>>,
+    stake_table_address: Address,
+    token_address: Address,
+    rng: &mut ChaCha20Rng,
+    num_delegators: u64,
+) -> Result<()> {
+    let fund_amount_esp = parse_ether("1000")?;
+    let fund_amount_eth = parse_ether("10")?;
+
+    for delegator_index in 0..num_delegators {
+        let delegator_wallet: LocalSigner<SigningKey> = SigningKey::random(rng).into();
+        let delegator_address = delegator_wallet.address();
+        tracing::info!("delegator {delegator_index}: address {delegator_address}");
+
+        let tx = TransactionRequest::default()
+            .with_to(delegator_address)
+            .with_value(fund_amount_eth);
+        let receipt = token_signer
+            .send_transaction(tx)
+            .await?
+            .get_receipt()
+            .await?;
+        assert!(receipt.status());
+
+        tracing::info!("delegator {delegator_index}: funded with {fund_amount_eth} ETH");
+
+        let random_amount: u64 = rng.gen_range(100..=500);
+        let delegate_amount = parse_ether(&random_amount.to_string())?;
+        let delegate_amount_esp = format_ether(delegate_amount);
+
+        let receipt = token
+            .transfer(delegator_address, fund_amount_esp)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        assert!(receipt.status());
+
+        tracing::info!("delegator {delegator_index}: received {fund_amount_esp} ESP");
+
+        let delegator_provider = make_provider(rpc_url, delegator_wallet.clone());
+
+        let validator_token = EspToken::new(token_address, delegator_provider.clone());
+        let receipt = validator_token
+            .approve(stake_table_address, delegate_amount)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        assert!(receipt.status());
+
+        tracing::info!(
+            "delegator {delegator_index}: approved {delegate_amount_esp} ESP to stake table"
+        );
+
+        let receipt = delegate(
+            &delegator_provider,
+            stake_table_address,
+            validator_address,
+            delegate_amount,
+        )
+        .await?;
+        assert!(receipt.status());
+
+        tracing::info!("delegator {delegator_index}: delegation complete");
+    }
+
     Ok(())
 }
 
@@ -198,6 +312,7 @@ pub async fn stake_for_demo(config: &Config, num_validators: u16) -> Result<()> 
         config.stake_table_address,
         config.token_address,
         validator_keys,
+        false,
     )
     .await?;
 
@@ -274,6 +389,7 @@ pub async fn pos_deploy_routine(
             .address(Contract::EspTokenProxy)
             .expect("ESP token deployed"),
         staking_priv_keys,
+        false,
     )
     .await?;
 
@@ -307,7 +423,7 @@ mod test {
     use hotshot_types::{traits::signature_key::StakeTableEntryType, PeerConfig};
 
     use super::*;
-    use crate::{deploy::TestSystem, l1::decode_log};
+    use crate::deploy::TestSystem;
 
     fn mock_stake(n: u16) -> StakeTable {
         [..n]

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -25,7 +25,7 @@ use hotshot_state_prover::service::legacy_light_client_genesis_from_stake_table;
 use hotshot_types::{
     light_client::{CircuitField, StateKeyPair, StateVerKey},
     signature_key::{BLSKeyPair, BLSPubKey},
-    traits::{signature_key::SignatureKey, stake_table::StakeTableScheme},
+    traits::signature_key::SignatureKey,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -420,10 +420,12 @@ fn staking_priv_keys() -> Vec<(PrivateKeySigner, BLSKeyPair, StateKeyPair)> {
 mod test {
     use alloy::node_bindings::Anvil;
     use espresso_types::{v0_3::StakeTable, SeqTypes};
-    use hotshot_types::{traits::signature_key::StakeTableEntryType, PeerConfig};
+    use hotshot_types::{
+        traits::{signature_key::StakeTableEntryType, stake_table::StakeTableScheme},
+        PeerConfig,
+    };
 
     use super::*;
-    use crate::deploy::TestSystem;
 
     fn mock_stake(n: u16) -> StakeTable {
         [..n]

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -320,6 +320,9 @@ pub async fn stake_for_demo(config: &Config, num_validators: u16) -> Result<()> 
     Ok(())
 }
 
+/// Commonly used contract deployment routine.
+// TODO move to proper place for shared code. See:
+// https://github.com/EspressoSystems/espresso-network/pull/3083#discussion_r2048832370
 pub async fn pos_deploy_routine(
     l1_url: &Url,
     signer: &LocalSigner<SigningKey>, // TODO maybe from_instance(AnvilInstance)

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -1,16 +1,10 @@
 use alloy::{
-    network::{Ethereum, EthereumWallet, TransactionBuilder as _},
+    network::{EthereumWallet, TransactionBuilder as _},
     primitives::{
         utils::{format_ether, parse_ether},
         Address, U256,
     },
-    providers::{
-        fillers::{
-            BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, TxFiller,
-            WalletFiller,
-        },
-        Identity, Provider, ProviderBuilder, RootProvider, WalletProvider,
-    },
+    providers::{Provider, ProviderBuilder, WalletProvider},
     rpc::types::TransactionRequest,
     signers::{
         k256::ecdsa::SigningKey,
@@ -18,13 +12,18 @@ use alloy::{
     },
 };
 use anyhow::Result;
-use hotshot_contract_adapter::{
-    evm::DecodeRevert,
-    sol_types::EspToken::{self, EspTokenErrors},
+use espresso_types::PubKey;
+use hotshot_contract_adapter::sol_types::EspToken;
+use hotshot_stake_table::vec_based::StakeTable;
+use hotshot_state_prover::service::legacy_light_client_genesis_from_stake_table;
+use hotshot_types::{
+    light_client::{CircuitField, StateKeyPair, StateVerKey},
+    signature_key::{BLSKeyPair, BLSPubKey},
+    traits::{signature_key::SignatureKey, stake_table::StakeTableScheme},
 };
-use hotshot_types::{light_client::StateKeyPair, signature_key::BLSKeyPair};
-use rand::{Rng, SeedableRng};
+use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
+use sequencer_utils::deployer::{self, Contract, Contracts};
 use url::Url;
 
 use crate::{
@@ -34,23 +33,9 @@ use crate::{
     Config,
 };
 
-type Prov = FillProvider<
-    JoinFill<
-        JoinFill<
-            Identity,
-            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-        >,
-        WalletFiller<EthereumWallet>,
-    >,
-    RootProvider,
->;
+pub type XStakeTable = StakeTable<BLSPubKey, StateVerKey, CircuitField>;
 
-fn make_provider(rpc_url: &Url, signer: LocalSigner<SigningKey>) -> Prov {
-    let wallet = EthereumWallet::from(signer);
-    ProviderBuilder::new()
-        .wallet(wallet)
-        .on_http(rpc_url.clone())
-}
+pub const STAKE_TABLE_CAPACITY_FOR_TEST: u64 = 3;
 
 pub async fn stake_in_contract_for_test(
     rpc_url: Url,
@@ -58,13 +43,19 @@ pub async fn stake_in_contract_for_test(
     stake_table_address: Address,
     token_address: Address,
     validator_keys: Vec<(PrivateKeySigner, BLSKeyPair, StateKeyPair)>,
-    multiple_delegators: bool,
 ) -> Result<()> {
     tracing::info!("staking to stake table contract for demo");
 
+    let mk_provider = |signer| {
+        let wallet = EthereumWallet::from(signer);
+        ProviderBuilder::new()
+            .wallet(wallet)
+            .on_http(rpc_url.clone())
+    };
+
     tracing::info!("stake table address: {}", stake_table_address);
 
-    let token_signer = make_provider(&rpc_url, grant_recipient.clone());
+    let token_signer = mk_provider(grant_recipient.clone());
 
     tracing::info!("ESP token address: {token_address}");
     let token = EspToken::new(token_address, token_signer.clone());
@@ -78,23 +69,19 @@ pub async fn stake_in_contract_for_test(
         panic!("grant recipient has no ESP tokens, funding won't work");
     }
 
-    let fund_amount_esp = parse_ether("1000")?;
-    let fund_amount_eth = parse_ether("10")?;
-
-    // Set up deterministic rng
-    let seed = [42u8; 32];
-    let mut rng = ChaCha20Rng::from_seed(seed);
+    let fund_amount_eth = "1000";
+    let fund_amount = parse_ether(fund_amount_eth)?;
 
     for (val_index, (signer, bls_key_pair, state_key_pair)) in
         validator_keys.into_iter().enumerate()
     {
-        let validator_provider = make_provider(&rpc_url, signer);
+        let validator_provider = mk_provider(signer);
         let validator_address = validator_provider.default_signer_address();
 
         tracing::info!("fund val {val_index} address: {validator_address}, {fund_amount_eth} ETH");
         let tx = TransactionRequest::default()
             .with_to(validator_address)
-            .with_value(fund_amount_eth);
+            .with_value(fund_amount);
         let receipt = token_signer
             .send_transaction(tx)
             .await?
@@ -113,23 +100,21 @@ pub async fn stake_in_contract_for_test(
 
         tracing::info!("validator {val_index} address: {validator_address}, balance: {bal}");
 
-        tracing::info!("transfer {fund_amount_esp} ESP to {validator_address}",);
+        tracing::info!("transfer {fund_amount_eth} ESP to {validator_address}",);
         let receipt = token
-            .transfer(validator_address, fund_amount_esp)
+            .transfer(validator_address, fund_amount)
             .send()
-            .await
-            .maybe_decode_revert::<EspTokenErrors>()?
+            .await?
             .get_receipt()
             .await?;
         assert!(receipt.status());
 
-        tracing::info!("approve {fund_amount_esp} ESP for {stake_table_address}",);
+        tracing::info!("approve {fund_amount_eth} ESP for {stake_table_address}",);
         let validator_token = EspToken::new(token_address, validator_provider.clone());
         let receipt = validator_token
-            .approve(stake_table_address, fund_amount_esp)
+            .approve(stake_table_address, fund_amount)
             .send()
-            .await
-            .maybe_decode_revert::<EspTokenErrors>()?
+            .await?
             .get_receipt()
             .await?;
         assert!(receipt.status());
@@ -157,101 +142,8 @@ pub async fn stake_in_contract_for_test(
         )
         .await?;
         assert!(receipt.status());
-
-        if multiple_delegators {
-            tracing::info!("adding multiple delegators for validator  {val_index} ");
-
-            let num_delegators = rng.gen_range(2..=5);
-
-            add_multiple_delegators(
-                &rpc_url,
-                validator_address,
-                &token_signer,
-                &token,
-                stake_table_address,
-                token_address,
-                &mut rng,
-                num_delegators,
-            )
-            .await?;
-        }
     }
     tracing::info!("completed staking for demo");
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn add_multiple_delegators<F: TxFiller<Ethereum>, P: Provider<Ethereum>>(
-    rpc_url: &Url,
-    validator_address: Address,
-    token_signer: &FillProvider<F, P, Ethereum>,
-    token: &EspToken::EspTokenInstance<(), FillProvider<F, P, Ethereum>>,
-    stake_table_address: Address,
-    token_address: Address,
-    rng: &mut ChaCha20Rng,
-    num_delegators: u64,
-) -> Result<()> {
-    let fund_amount_esp = parse_ether("1000")?;
-    let fund_amount_eth = parse_ether("10")?;
-
-    for delegator_index in 0..num_delegators {
-        let delegator_wallet: LocalSigner<SigningKey> = SigningKey::random(rng).into();
-        let delegator_address = delegator_wallet.address();
-        tracing::info!("delegator {delegator_index}: address {delegator_address}");
-
-        let tx = TransactionRequest::default()
-            .with_to(delegator_address)
-            .with_value(fund_amount_eth);
-        let receipt = token_signer
-            .send_transaction(tx)
-            .await?
-            .get_receipt()
-            .await?;
-        assert!(receipt.status());
-
-        tracing::info!("delegator {delegator_index}: funded with {fund_amount_eth} ETH");
-
-        let random_amount: u64 = rng.gen_range(100..=500);
-        let delegate_amount = parse_ether(&random_amount.to_string())?;
-        let delegate_amount_esp = format_ether(delegate_amount);
-
-        let receipt = token
-            .transfer(delegator_address, fund_amount_esp)
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        assert!(receipt.status());
-
-        tracing::info!("delegator {delegator_index}: received {fund_amount_esp} ESP");
-
-        let delegator_provider = make_provider(rpc_url, delegator_wallet.clone());
-
-        let validator_token = EspToken::new(token_address, delegator_provider.clone());
-        let receipt = validator_token
-            .approve(stake_table_address, delegate_amount)
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        assert!(receipt.status());
-
-        tracing::info!(
-            "delegator {delegator_index}: approved {delegate_amount_esp} ESP to stake table"
-        );
-
-        let receipt = delegate(
-            &delegator_provider,
-            stake_table_address,
-            validator_address,
-            delegate_amount,
-        )
-        .await?;
-        assert!(receipt.status());
-
-        tracing::info!("delegator {delegator_index}: delegation complete");
-    }
-
     Ok(())
 }
 
@@ -306,10 +198,149 @@ pub async fn stake_for_demo(config: &Config, num_validators: u16) -> Result<()> 
         config.stake_table_address,
         config.token_address,
         validator_keys,
-        false,
     )
     .await?;
 
     tracing::info!("completed staking for demo");
     Ok(())
+}
+
+pub async fn pos_deploy_routine(
+    l1_url: &Url,
+    signer: &LocalSigner<SigningKey>, // TODO maybe from_instance(AnvilInstance)
+    blocks_per_epoch: u64,
+    epoch_start_block: u64,
+    initial_stake_table: XStakeTable,
+    _multisig: Option<Address>,
+) -> anyhow::Result<Address> {
+    let contracts = &mut Contracts::new();
+
+    let wallet = EthereumWallet::from(signer.clone());
+    let provider = ProviderBuilder::new()
+        .wallet(wallet.clone())
+        .on_http(l1_url.clone());
+    let admin = provider.get_accounts().await?[0];
+
+    let (genesis_state, genesis_stake) =
+        legacy_light_client_genesis_from_stake_table(initial_stake_table.clone())?;
+
+    // deploy EspToken, proxy
+    let token_proxy_addr = deployer::deploy_token_proxy(&provider, contracts, admin, admin).await?;
+
+    // deploy light client v1, proxy
+    let lc_proxy_addr = deployer::deploy_light_client_proxy(
+        &provider,
+        contracts,
+        true, // use mock
+        genesis_state.clone(),
+        genesis_stake.clone(),
+        admin,
+        None, // no permissioned prover
+    )
+    .await?;
+    // upgrade to LightClientV2
+    deployer::upgrade_light_client_v2(
+        &provider,
+        contracts,
+        true, // use mock
+        blocks_per_epoch,
+        epoch_start_block,
+    )
+    .await?;
+
+    // deploy permissionless stake table
+    let exit_escrow_period = U256::from(300); // 300 sec
+    let _stake_table_proxy_addr = deployer::deploy_stake_table_proxy(
+        &provider,
+        contracts,
+        token_proxy_addr,
+        lc_proxy_addr,
+        exit_escrow_period,
+        admin,
+    )
+    .await?;
+
+    let staking_priv_keys = staking_priv_keys(); // arbitrary num
+
+    let stake_table_address = contracts
+        .address(Contract::StakeTableProxy)
+        .expect("stake table deployed");
+
+    stake_in_contract_for_test(
+        l1_url.clone(),
+        signer.clone(),
+        stake_table_address,
+        contracts
+            .address(Contract::EspTokenProxy)
+            .expect("ESP token deployed"),
+        staking_priv_keys,
+    )
+    .await?;
+
+    Ok(stake_table_address)
+}
+
+fn staking_priv_keys() -> Vec<(PrivateKeySigner, BLSKeyPair, StateKeyPair)> {
+    let seed = [42u8; 32];
+    let num_nodes = STAKE_TABLE_CAPACITY_FOR_TEST;
+
+    let (_, priv_keys): (Vec<_>, Vec<_>) = (0..num_nodes)
+        .map(|i| <PubKey as SignatureKey>::generated_from_seed_indexed(seed, i as u64))
+        .unzip();
+    let state_key_pairs = (0..num_nodes)
+        .map(|i| StateKeyPair::generate_from_seed_indexed(seed, i as u64))
+        .collect::<Vec<_>>();
+
+    let mut rng = ChaCha20Rng::from_seed([42u8; 32]); // Create a deterministic RNG
+    let eth_key_pairs = (0..num_nodes).map(|_| SigningKey::random(&mut rng).into());
+    eth_key_pairs
+        .zip(priv_keys.iter())
+        .zip(state_key_pairs.iter())
+        .map(|((eth, bls), state)| (eth, bls.clone().into(), state.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use alloy::node_bindings::Anvil;
+    use espresso_types::{v0_3::StakeTable, SeqTypes};
+    use hotshot_types::{traits::signature_key::StakeTableEntryType, PeerConfig};
+
+    use super::*;
+    use crate::{deploy::TestSystem, l1::decode_log};
+
+    fn mock_stake(n: u16) -> StakeTable {
+        [..n]
+            .iter()
+            .map(|_| PeerConfig::default())
+            .collect::<Vec<PeerConfig<SeqTypes>>>()
+            .into()
+    }
+
+    #[tokio::test]
+    async fn test_deploy_rutine() -> Result<()> {
+        let num_nodes = 3;
+        let anvil = Anvil::new().spawn();
+        let l1 = anvil.endpoint_url();
+        let secret_key = anvil.keys()[0].clone();
+        let signer = LocalSigner::from(secret_key);
+
+        let mut st = XStakeTable::new(STAKE_TABLE_CAPACITY_FOR_TEST as usize);
+        mock_stake(num_nodes).0.iter().for_each(|config| {
+            st.register(
+                *config.stake_table_entry.key(),
+                config.stake_table_entry.stake(),
+                config.state_ver_key.clone(),
+            )
+            .unwrap()
+        });
+        st.advance();
+        st.advance();
+
+        let _address = pos_deploy_routine(&l1, &signer, 50, 1, st, None)
+            .await
+            .unwrap();
+
+        Ok(())
+    }
 }

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -318,7 +318,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_deploy_rutine() -> Result<()> {
+    async fn test_deploy_routine() -> Result<()> {
         let num_nodes = 3;
         let anvil = Anvil::new().spawn();
         let l1 = anvil.endpoint_url();

--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -6,9 +6,7 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use hotshot::types::BLSPubKey;
 use hotshot_types::{
-    data::EpochNumber,
-    epoch_membership::EpochMembershipCoordinator,
-    traits::{node_implementation::Versions, states::InstanceState},
+    data::EpochNumber, epoch_membership::EpochMembershipCoordinator, traits::states::InstanceState,
     HotShotConfig,
 };
 use indexmap::IndexMap;

--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -5,10 +5,14 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use hotshot::types::BLSPubKey;
 use hotshot_types::{
-    data::EpochNumber, epoch_membership::EpochMembershipCoordinator, traits::states::InstanceState,
+    data::EpochNumber,
+    epoch_membership::EpochMembershipCoordinator,
+    traits::{node_implementation::Versions, states::InstanceState},
     HotShotConfig,
 };
 use indexmap::IndexMap;
+use sequencer_utils::ser::FromStringOrInteger;
+use time::OffsetDateTime;
 #[cfg(any(test, feature = "testing"))]
 use vbs::version::StaticVersionType;
 use vbs::version::Version;
@@ -18,7 +22,7 @@ use super::{
     traits::MembershipPersistence,
     v0_1::NoStorage,
     v0_3::{EventKey, IndexedStake, StakeTableEvent, Validator},
-    SeqTypes,
+    SeqTypes, TimeBasedUpgrade, UpgradeType,
 };
 use crate::v0::{
     traits::StateCatchup, v0_99::ChainConfig, GenesisHeader, L1BlockInfo, L1Client, Timestamp,
@@ -264,6 +268,25 @@ impl NodeState {
     }
 }
 
+/// NewType to hold upgrades and some convenience behavior.
+pub struct UpgradeMap(pub BTreeMap<Version, Upgrade>);
+impl UpgradeMap {
+    pub fn chain_config(&self, version: Version) -> ChainConfig {
+        self.0
+            .get(&version)
+            .unwrap()
+            .upgrade_type
+            .chain_config()
+            .unwrap()
+    }
+}
+
+impl From<BTreeMap<Version, Upgrade>> for UpgradeMap {
+    fn from(inner: BTreeMap<Version, Upgrade>) -> Self {
+        Self(inner)
+    }
+}
+
 // This allows us to turn on `Default` on InstanceState trait
 // which is used in `HotShot` by `TestBuilderImplementation`.
 #[cfg(any(test, feature = "testing"))]
@@ -324,6 +347,26 @@ impl Upgrade {
                 config.stop_voting_view = u64::MAX;
             },
         }
+    }
+
+    pub fn marketplace_time_based() -> Upgrade {
+        let now = OffsetDateTime::now_utc().unix_timestamp() as u64;
+        let mode = UpgradeMode::Time(TimeBasedUpgrade {
+            start_proposing_time: Timestamp::from_integer(now).unwrap(),
+            stop_proposing_time: Timestamp::from_integer(now + 500).unwrap(),
+            start_voting_time: None,
+            stop_voting_time: None,
+        });
+
+        let upgrade_type = UpgradeType::Marketplace {
+            chain_config: ChainConfig {
+                max_block_size: 400.into(),
+                base_fee: 2.into(),
+                bid_recipient: Some(Default::default()),
+                ..Default::default()
+            },
+        };
+        Upgrade { mode, upgrade_type }
     }
 }
 

--- a/types/src/v0/impls/mod.rs
+++ b/types/src/v0/impls/mod.rs
@@ -17,7 +17,7 @@ pub use auction::SolverAuctionResultsProvider;
 pub use fee_info::{retain_accounts, FeeError};
 #[cfg(any(test, feature = "testing"))]
 pub use instance_state::mock;
-pub use instance_state::NodeState;
+pub use instance_state::{NodeState, UpgradeMap};
 pub use stake_table::*;
 pub use state::{
     get_l1_deposits, BuilderValidationError, ProposalValidationError, StateValidationError,

--- a/types/src/v0/mod.rs
+++ b/types/src/v0/mod.rs
@@ -191,7 +191,7 @@ pub type PrivKey = <PubKey as SignatureKey>::PrivateKey;
 
 pub type NetworkConfig = hotshot_types::network::NetworkConfig<SeqTypes>;
 
-pub use self::impls::{NodeState, SolverAuctionResultsProvider, ValidatedState};
+pub use self::impls::{NodeState, SolverAuctionResultsProvider, UpgradeMap, ValidatedState};
 pub use crate::v0_1::{
     BLOCK_MERKLE_TREE_HEIGHT, FEE_MERKLE_TREE_HEIGHT, NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN,
     NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, TX_OFFSET_BYTE_LEN,


### PR DESCRIPTION
Adds a unit test for POS upgrades, principally  addition of `set_upgrades` method  to `TestNetworkBuilder`.

Also:

  * improvements for upgrade testing "framework"
  * removal of upgrade tests for version we won't be upgrading to (again, i.e. `FeeVersion`).
  * deployment code shared w/ `pos_hook` moved to a common place for de-duplication
  * some shared functions needed contract deployment moved to an accessible location
  * created a new type for upgrade map, in order to add some convenience functions
  * moved upgrade configurations into static methods on `Upgrade`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210024927640840