### PR TITLE
fix rerunning of types migration

### DIFF
--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -837,7 +837,7 @@ impl<Types: NodeType> MigrateTypes<Types> for SqlStorage {
         // After each batch insert, it is updated with the number of rows migrated.
         // This is necessary to resume from the same point in case of a restart.
         let (is_migration_completed, mut offset) = query_as::<(bool, i64)>(
-            "SELECT completed, migrated_rows from types_migration LIMIT 1 ",
+            "SELECT completed, migrated_rows from types_migration WHERE id = 1 ",
         )
         .fetch_one(tx.as_mut())
         .await?;


### PR DESCRIPTION
Query-0 on decaf was deployed with PoS binary with a version without types migration fixes and then upgraded to a binary with fixes which resulted in 2 entries in types_migration table i.e id =0 and id=1.  This PR fixes that.
Basically, without this WHERE clause, it can return any row (id 0 or id 1). 