### PR TITLE
simple builder: keep block header input in state

### DIFF
--- a/crates/hotshot/testing/src/block_builder/simple.rs
+++ b/crates/hotshot/testing/src/block_builder/simple.rs
@@ -319,7 +319,7 @@ where
 
         let mut blocks = self.blocks.write().await;
         let entry = blocks.get_mut(block_hash).ok_or(BuildError::NotFound)?;
-        entry.header_input.take().ok_or(BuildError::Missing)
+        Ok(entry.header_input.clone().ok_or(BuildError::Missing)?)
     }
 
     async fn builder_address(&self) -> Result<TYPES::BuilderSignatureKey, BuildError> {


### PR DESCRIPTION
This fixes the flaky query_service: availability::test::test_api

Not sure if it will break other things. Let's see what CI says.