### PR TITLE
CI: cargo audit fix: checkout repo

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -34,6 +34,8 @@ jobs:
       pull-requests: write
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Run cargo audit fix
         uses: simonhyll/cargo-audit@v1
 


### PR DESCRIPTION
I think this should fix the

    error: not found: Couldn't load Cargo.lock: I/O operation failed:
    I/O operation failed: NotFound

error we get.

https://github.com/EspressoSystems/espresso-network/actions/runs/14627593975/job/41042784497
