### PR TITLE
CI: turn on auto merge for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,29 +15,14 @@ updates:
     groups:
       # The `all` group should include mainly updates from crates.io which are
       # more likely to succeed without intervention.
-      all:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "ark-*"
-          - "cdn-*"
-          - "hotshot-*"
-          - "jf-*"
-          - "marketplace-*"
       ark:
         patterns:
           - "ark-*"
       cdn:
         patterns:
           - "cdn-*"
-      hotshot:
-        patterns:
-          - "hotshot-*"
       jf:
         patterns:
           - "jf-*"
-      marketplace:
-        patterns:
-          - "marketplace-*"
     schedule:
       interval: "daily"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,25 @@
+name: Dependabot enable auto merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  dependabot-auto-merge:
+    name: Dependabot
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'}}
+    steps:
+      - name: Dependabot metadata
+        uses: dependabot/fetch-metadata@v2.3.0
+        id: metadata
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- Remove dependabot "all" group that usually causes build to fail.
- Enable auto merge.

Not quite sure if this is going to work. I think it may still need a review unless we can somehow disable review requirement for dependabot PRs.

The github action code is from @Ancient123 's https://github.com/Ancient123/fh5-g27-leds/blob/802eca8d9288d3170d899884dad8e5ea20ffaabb/.github/workflows/build.yml#L46