### PR TITLE
Add mnemonic tool

### DIFF
--- a/crates/hotshot/types/Cargo.toml
+++ b/crates/hotshot/types/Cargo.toml
@@ -64,3 +64,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [features]
 gpu-vid = ["jf-vid/gpu-vid"]
 test-srs = ["jf-vid/test-srs"]
+
+[[bin]]
+name = "mnemonic"
+path = "bin/mnemonic.rs"

--- a/crates/hotshot/types/bin/mnemonic.rs
+++ b/crates/hotshot/types/bin/mnemonic.rs
@@ -1,0 +1,25 @@
+use std::env;
+
+use hotshot_types::{signature_key::BLSPubKey, utils::mnemonic};
+
+pub fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let keys: Vec<_> = args[1..].to_vec();
+
+    print!("\nKeys:\n\n");
+
+    for key in &keys {
+        print!("{}\n", key);
+    }
+
+    print!("\nMnemonics:\n\n");
+
+    for key in keys {
+        let mnemonic = mnemonic(
+            BLSPubKey::try_from(&tagged_base64::TaggedBase64::parse(&key).unwrap()).unwrap(),
+        );
+
+        print!("{}\n", mnemonic);
+    }
+}

--- a/crates/hotshot/types/bin/mnemonic.rs
+++ b/crates/hotshot/types/bin/mnemonic.rs
@@ -7,19 +7,19 @@ pub fn main() {
 
     let keys: Vec<_> = args[1..].to_vec();
 
-    print!("\nKeys:\n\n");
+    println!("\nKeys:\n");
 
     for key in &keys {
-        print!("{}\n", key);
+        println!("{}", key);
     }
 
-    print!("\nMnemonics:\n\n");
+    println!("\nMnemonics:\n");
 
     for key in keys {
         let mnemonic = mnemonic(
             BLSPubKey::try_from(&tagged_base64::TaggedBase64::parse(&key).unwrap()).unwrap(),
         );
 
-        print!("{}\n", mnemonic);
+        println!("{}", mnemonic);
     }
 }


### PR DESCRIPTION
Adds a tool that can be used to convert a BLS public key used by hotshot to the mnemonic displayed in logs.

You can run this with e.g.

```
cargo run --bin mnemonic BLS_VER_KEY~<key>
```
