### PR TITLE
Eliminate linear scaling in finalized block fetching

### DIFF
--- a/types/src/v0/v0_1/l1.rs
+++ b/types/src/v0/v0_1/l1.rs
@@ -151,7 +151,7 @@ pub struct L1ClientOptions {
     /// Typically this would be a WebSockets endpoint while the main provider uses HTTP.
     #[clap(long, env = "ESPRESSO_SEQUENCER_L1_WS_PROVIDER", value_delimiter = ',')]
     pub l1_ws_provider: Option<Vec<Url>>,
-    
+
     /// Interval at which the background update loop polls the L1 stake table contract for new events
     /// and updates local persistence.
     ///
@@ -162,6 +162,22 @@ pub struct L1ClientOptions {
         value_parser = parse_duration,
     )]
     pub stake_table_update_interval: Duration,
+
+    /// A block range which is expected to contain the finalized heads of all L1 provider chains.
+    ///
+    /// If specified, it is assumed that if a block `n` is known to be finalized according to a
+    /// certain provider, then any block less than `n - L1_FINALIZED_SAFETY_MARGIN` is finalized
+    /// _according to any provider_. In other words, if we fail over from one provider to another,
+    /// the second provider will never be lagging the first by more than this margin.
+    ///
+    /// This allows us to quickly query for very old finalized blocks by number. Without this
+    /// assumption, we always need to verify that a block is finalized by fetching all blocks in a
+    /// hash chain between the known finalized block and the desired block, recomputing and checking
+    /// the hashes. This is fine and good for blocks very near the finalized head, but for
+    /// extremely old blocks it is prohibitively expensive, and these old blocks are extremely
+    /// unlikely to be unfinalized anyways.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_L1_FINALIZED_SAFETY_MARGIN")]
+    pub l1_finalized_safety_margin: Option<u64>,
 
     #[clap(skip = Arc::<Box<dyn Metrics>>::new(Box::new(NoMetrics)))]
     pub metrics: Arc<Box<dyn Metrics>>,


### PR DESCRIPTION
Eliminates scaling linear in the length of the parent chain for fetching of finalized blocks (whether by number or timestamp). This is particularly relevant for fetching the L1 genesis block on startup, and in the worst case it could prevent a node from starting up in a feasible amount of time. In both cases, fetching an old block is expensive because the implementation works backwards block by block from the latest block (when fetching by number, to verify hash chains; when fetching by timestamp, to find the earliest L1 block with a sufficient timestamp).

This change should not affect consensus much if at all, because in consensus we generally only fetch very recent blocks for which this working backwards doesn't cost much.

https://app.asana.com/1/1208976916964769/project/1209380117384039/task/1209924222720523

### This PR:

* when fetching by number, add a "safety margin"; blocks older than this margin are assumed to be so safe from reorg, even for lagging providers, that we can just fetch them without fetching the entire chain
* when fetching by timestamp, use binary search instead of linear search to find the earliest block with sufficient timestamp
