### PR TITLE
feat: Allow prover to submit a single proof to multiple contracts

### DIFF
--- a/hotshot-state-prover/README.md
+++ b/hotshot-state-prover/README.md
@@ -1,0 +1,46 @@
+# HotShot State Prover
+
+The HotShot State Prover is a service that generates proofs for light client state updates and submits them to the smart contracts.
+
+## Features
+
+- Generates SNARK proofs for light client state updates
+- Submits state updates and proofs to light client contracts
+- Supports submitting a single proof to multiple contract instances
+- Supports epoch-based updates and state synchronization
+- Includes a health check server for monitoring
+
+## Configuration
+
+The state prover is configured through the `StateProverConfig` structure, which includes:
+
+- `relay_server`: URL of the state relay server where sequencers push their signatures
+- `update_interval`: Interval between light client state updates
+- `retry_interval`: Interval between retries if a state update fails
+- `provider_endpoint`: URL of the chain (L1 or L2) JSON-RPC provider
+- `light_client_address`: Address of the primary LightClient proxy contract
+- `additional_light_client_addresses`: Additional LightClient proxy contract addresses to submit proofs to
+- `signer`: Transaction signing key for Ethereum or other L2
+- `sequencer_url`: URL of a node providing the HotShot config
+- `port`: Optional port for running a basic HTTP server
+- `stake_table_capacity`: Stake table capacity for the prover circuit
+- `blocks_per_epoch`: Epoch length in number of HotShot blocks
+- `epoch_start_block`: The epoch start block
+- `max_retries`: Maximum number of retries for one-shot prover
+
+## Running the Prover
+
+The prover can be run in two modes:
+
+1. As a daemon service using `run_prover_service` that continuously checks for updates
+2. As a one-shot process using `run_prover_once` that runs once and exits
+
+## Multi-Contract Support
+
+The prover can submit the same proof to multiple contract instances simultaneously. This is useful when the same state needs to be maintained across multiple chains or when multiple contracts on the same chain need to receive the state updates.
+
+To use this feature:
+1. Set the primary contract address in `light_client_address`
+2. Add additional contract addresses to the `additional_light_client_addresses` vector
+
+The prover will first submit the proof to the primary contract, and only if that succeeds, it will attempt to submit to the additional contracts. Failures in additional contract submissions will be logged but won't cause the overall operation to fail. 

--- a/hotshot-state-prover/api/prover-service.toml
+++ b/hotshot-state-prover/api/prover-service.toml
@@ -1,4 +1,9 @@
 [route.getlightclientcontract]
 PATH = ["/lightclient_contract"]
 METHOD = "GET"
-DOC = "Get the address of light client contract on Layer1."
+DOC = "Get the address of the primary light client contract on Layer1."
+
+[route.getlightclientcontracts]
+PATH = ["/lightclient_contracts"]
+METHOD = "GET"
+DOC = "Get the addresses of all light client contracts (primary and additional ones)."


### PR DESCRIPTION
Closes #3124

### This PR:
- Adds functionality for the state prover to submit a single proof to multiple light client contracts
- Adds a new field additional_light_client_addresses to StateProverConfig for specifying additional contract addresses
- Updates the contract validation to verify all contracts are valid proxies
- Implements thread-local state storage to access config from submission functions
- Adds a new API endpoint to retrieve all contract addresses

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
- service.rs: StateProverConfig struct - Added additional_light_client_addresses field
- service.rs: submit_state_and_proof_to_contract and submit_state_and_proof functions - Core functionality
- service.rs: CURRENT_PROVER_STATE thread-local storage implementation
- service.rs: run_prover_service and run_prover_once - Setting thread-local state
- prover-service.toml: New getlightclientcontracts endpoint
- service.rs: test_submit_to_multiple_contracts test case

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
