### PR TITLE
dependabot: add sequencer-sqlite directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,9 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "cargo"
-    directory: "/"
+    directories:
+      - "/"
+      - "/sequencer-sqlite"
     groups:
       # The `all` group should include mainly updates from crates.io which are
       # more likely to succeed without intervention.


### PR DESCRIPTION
Currently the CI for dependabot PRs often fails because dependabot does not update the Cargo.lock file in sequencer-sqlite. I don't know if this will fix but I figured it's worth a try.
