### PR TITLE
Add fallback deserialization to avoid duplicate http requests for fetching legacy data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -8709,7 +8709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -10433,7 +10433,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -10888,9 +10888,9 @@ dependencies = [
 
 [[package]]
 name = "surf-disco"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e00ab9d939d04110f14281d5a1e45b6c8acdfbc42e720cbfaef33007c907e6"
+checksum = "2bcf4981d3d4dc702a855914e80a9ea4f348b5a2c634cd64eed7bd583a14e26d"
 dependencies = [
  "async-std",
  "async-tungstenite",

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -2454,17 +2454,19 @@ mod test {
             }
 
             // Append the latest known leaf to the local store
-
+            // This would trigger fetches for the corresponding missing data
+            // such as header, vid and payload
+            // This would also trigger fetches for the parent data
             ds.append(leaves.last().cloned().unwrap().into())
                 .await
                 .unwrap();
 
-            // This should now fetch from the provider
-            let leaf = ds.get_leaf(test_leaf.height() as usize).await;
-            let payload = ds.get_payload(test_payload.height() as usize).await;
-            let common = ds.get_vid_common(test_common.height() as usize).await;
-
+            // check that the data has been fetches and matches the network data source
             {
+                let leaf = ds.get_leaf(test_leaf.height() as usize).await;
+                let payload = ds.get_payload(test_payload.height() as usize).await;
+                let common = ds.get_vid_common(test_common.height() as usize).await;
+
                 let truth = network.data_source();
                 assert_eq!(
                     leaf.await,

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -22,7 +22,10 @@ use hotshot_types::{
 };
 use jf_vid::VidScheme;
 use surf_disco::{Client, Url};
-use vbs::{version::StaticVersionType, BinarySerializer};
+use vbs::{
+    version::{StaticVersion, StaticVersionType},
+    BinarySerializer,
+};
 
 use super::Provider;
 use crate::{
@@ -63,7 +66,7 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
             return None;
         };
 
-        let payload = vbs::Serializer::<vbs::version::StaticVersion<0, 1>>::deserialize::<
+        let payload = vbs::Serializer::<StaticVersion<0, 1>>::deserialize::<
             ADVZPayloadQueryData<Types>,
         >(&payload_bytes)
         .map_err(|err| {
@@ -71,7 +74,7 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
         })
         .ok()?;
 
-        let common = vbs::Serializer::<vbs::version::StaticVersion<0, 1>>::deserialize::<
+        let common = vbs::Serializer::<StaticVersion<0, 1>>::deserialize::<
             ADVZCommonQueryData<Types>,
         >(&common_bytes)
         .map_err(|err| {
@@ -106,10 +109,9 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
             return None;
         };
 
-        match vbs::Serializer::<vbs::version::StaticVersion<0, 1>>::deserialize::<
-            ADVZCommonQueryData<Types>,
-        >(&bytes)
-        {
+        match vbs::Serializer::<StaticVersion<0, 1>>::deserialize::<ADVZCommonQueryData<Types>>(
+            &bytes,
+        ) {
             Ok(res) => {
                 if ADVZScheme::is_consistent(&advz_commit, &res.common).is_ok() {
                     Some(VidCommon::V0(res.common))
@@ -129,10 +131,9 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
         bytes: Vec<u8>,
         req: LeafRequest<Types>,
     ) -> Option<LeafQueryData<Types>> {
-        match vbs::Serializer::<vbs::version::StaticVersion<0, 1>>::deserialize::<
-            LeafQueryDataLegacy<Types>,
-        >(&bytes)
-        {
+        match vbs::Serializer::<StaticVersion<0, 1>>::deserialize::<LeafQueryDataLegacy<Types>>(
+            &bytes,
+        ) {
             Ok(mut leaf) => {
                 if leaf.height() != req.height {
                     tracing::error!(?req, ?leaf, "received leaf with the wrong height");
@@ -205,24 +206,26 @@ where
             })
             .ok()?;
 
-        let payload = vbs::Serializer::<vbs::version::StaticVersion<0, 1>>::deserialize::<
-            PayloadQueryData<Types>,
-        >(&payload_bytes)
-        .map_err(|err| {
-            tracing::info!("error deserializing PayloadQueryData for {}: {err}", req.0);
-        })
-        .ok();
+        let payload =
+            vbs::Serializer::<StaticVersion<0, 1>>::deserialize::<PayloadQueryData<Types>>(
+                &payload_bytes,
+            )
+            .map_err(|err| {
+                tracing::info!("error deserializing PayloadQueryData for {}: {err}", req.0);
+            })
+            .ok();
 
-        let common = vbs::Serializer::<vbs::version::StaticVersion<0, 1>>::deserialize::<
-            VidCommonQueryData<Types>,
-        >(&common_bytes)
-        .map_err(|err| {
-            tracing::info!(
-                "error deserializing VidCommonQueryData for {}: {err}",
-                req.0
-            );
-        })
-        .ok();
+        let common =
+            vbs::Serializer::<StaticVersion<0, 1>>::deserialize::<VidCommonQueryData<Types>>(
+                &common_bytes,
+            )
+            .map_err(|err| {
+                tracing::info!(
+                    "error deserializing VidCommonQueryData for {}: {err}",
+                    req.0
+                );
+            })
+            .ok();
 
         let (payload, common) = match (payload, common) {
             (Some(payload), Some(common)) => (payload, common),
@@ -273,9 +276,9 @@ where
                     })
                     .ok()
                     .and_then(|header_bytes| {
-                        vbs::Serializer::<vbs::version::StaticVersion<0, 1>>::deserialize::<
-                            Header<Types>,
-                        >(&header_bytes)
+                        vbs::Serializer::<StaticVersion<0, 1>>::deserialize::<Header<Types>>(
+                            &header_bytes,
+                        )
                         .map_err(|err| {
                             tracing::error!(%err, "failed to deserialize header");
                         })
@@ -340,10 +343,7 @@ where
 
         // Attempt to deserialize using the new type
 
-        match vbs::Serializer::<vbs::version::StaticVersion<0, 1>>::deserialize::<
-            LeafQueryData<Types>,
-        >(&bytes)
-        {
+        match vbs::Serializer::<StaticVersion<0, 1>>::deserialize::<LeafQueryData<Types>>(&bytes) {
             Ok(mut leaf) => {
                 if leaf.height() != req.height {
                     tracing::error!(?req, ?leaf, "received leaf with the wrong height");
@@ -401,10 +401,9 @@ where
             },
         };
 
-        match vbs::Serializer::<vbs::version::StaticVersion<0, 1>>::deserialize::<
-            VidCommonQueryData<Types>,
-        >(&bytes)
-        {
+        match vbs::Serializer::<StaticVersion<0, 1>>::deserialize::<VidCommonQueryData<Types>>(
+            &bytes,
+        ) {
             Ok(res) => match req.0 {
                 VidCommitment::V0(commit) => {
                     if let VidCommon::V0(common) = res.common {
@@ -457,7 +456,7 @@ mod test {
     use portpicker::pick_unused_port;
     use rand::RngCore;
     use tide_disco::{error::ServerError, App};
-    use vbs::version::StaticVersion;
+    use StaticVersion;
 
     use super::*;
     use crate::{

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -255,20 +255,13 @@ where
 
                 let header = self
                     .client
-                    .get::<()>(&format!("availability/header/{}", payload.height()))
-                    .bytes()
+                    .get::<Header<Types>>(&format!("availability/header/{}", payload.height()))
+                    .send()
                     .await
                     .map_err(|err| {
                         tracing::error!(%err, "failed to fetch header for payload");
                     })
-                    .ok()
-                    .and_then(|header_bytes| {
-                        vbs::Serializer::<Ver>::deserialize::<Header<Types>>(&header_bytes)
-                            .map_err(|err| {
-                                tracing::error!(%err, "failed to deserialize header");
-                            })
-                            .ok()
-                    })?;
+                    .ok()?;
 
                 if header.payload_commitment() != req.0 {
                     tracing::error!(?req, ?header, "received inconsistent payload");

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -2513,7 +2513,7 @@ mod test {
         // The fetch initially attempts deserialization with new types,
         // which fails because the v0 provider returns legacy types.
         // It then falls back to deserializing as legacy types,
-        // which succeeds, allowing the test to pass.
+        // and the fetch passes
         run_test_helper::<MockVersions>(format!(
             "http://localhost:{}/v0",
             pick_unused_port().unwrap()
@@ -2527,13 +2527,7 @@ mod test {
             pick_unused_port().unwrap()
         ))
         .await;
-
-        run_test_helper::<MockVersions>(format!(
-            "http://localhost:{}/v1",
-            pick_unused_port().unwrap()
-        ))
-        .await;
-        // Fetch Proof-of-Stake (PoS) data using the v1 availability API.
+        // Fetch Proof of Stake (PoS) data using the v1 availability API.
         // This is the same as previous run, but with proof of stake version
         run_test_helper::<EpochsTestVersions>(format!(
             "http://localhost:{}/v1",
@@ -2541,7 +2535,7 @@ mod test {
         ))
         .await;
 
-        // Run with the Proof-of-Stake (PoS) version against a v0 provider.
+        // Run with the PoS version against a v0 provider.
         // Fetch requests are expected to fail because PoS commitments differ from the legacy commitments
         // returned by the v0 provider.
         // For example: a PoS Leaf2 commitment will not match the downgraded commitment from a legacy Leaf1.
@@ -2558,17 +2552,6 @@ mod test {
                     &Default::default(),
                     StaticVersion::<0, 1> {},
                     "0.0.1".parse().unwrap(),
-                )
-                .unwrap(),
-            )
-            .unwrap();
-
-            app.register_module(
-                "availability",
-                define_api(
-                    &Default::default(),
-                    StaticVersion::<0, 1> {},
-                    "1.0.0".parse().unwrap(),
                 )
                 .unwrap(),
             )
@@ -2600,7 +2583,7 @@ mod test {
 
             sleep(Duration::from_secs(3)).await;
 
-            // Try to resolve (should error)
+            // fetches fail because of different commitments
             leaf.try_resolve().unwrap_err();
             payload.try_resolve().unwrap_err();
             common.try_resolve().unwrap_err();

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -53,7 +53,7 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
 }
 
 impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
-    async fn fetch_legacy_payload<Types: NodeType>(
+    async fn deserialize_legacy_payload<Types: NodeType>(
         &self,
         payload_bytes: Vec<u8>,
         common_bytes: Vec<u8>,
@@ -95,7 +95,7 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
         Some(payload.data)
     }
 
-    async fn fetch_legacy_vid_common<Types: NodeType>(
+    async fn deserialize_legacy_vid_common<Types: NodeType>(
         &self,
         bytes: Vec<u8>,
         req: VidCommonRequest,
@@ -119,7 +119,7 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
             },
         }
     }
-    async fn fetch_legacy_leaf<Types: NodeType>(
+    async fn deserialize_legacy_leaf<Types: NodeType>(
         &self,
         bytes: Vec<u8>,
         req: LeafRequest<Types>,
@@ -221,7 +221,7 @@ where
 
                 // fallback deserialization
                 return self
-                    .fetch_legacy_payload::<Types>(payload_bytes, common_bytes, req)
+                    .deserialize_legacy_payload::<Types>(payload_bytes, common_bytes, req)
                     .await;
             },
         };
@@ -347,7 +347,7 @@ where
             Err(err) => {
                 tracing::warn!("failed to fetch leaf req={req:?}. err={err}");
                 // Fallback deserialization
-                self.fetch_legacy_leaf(bytes, req).await
+                self.deserialize_legacy_leaf(bytes, req).await
             },
         }
     }
@@ -410,7 +410,8 @@ where
                 );
 
                 // Fallback deserialization
-                self.fetch_legacy_vid_common::<Types>(bytes, req).await
+                self.deserialize_legacy_vid_common::<Types>(bytes, req)
+                    .await
             },
         }
     }

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -362,7 +362,7 @@ where
                 tracing::warn!("failed to fetch leaf req={req:?}. err={err}");
                 // --- Fallback Deserialization ---
                 //
-                // If deserialization into the new format fails (e.g., because the provider is still
+                // If deserialization into the new type fails (e.g., because the provider is still
                 // returning legacy data), attempt to deserialize using an older, legacy format instead.
                 // This fallback ensures compatibility with older nodes or providers that have not yet upgraded.
                 //
@@ -427,7 +427,7 @@ where
 
                 // --- Fallback Deserialization ---
                 //
-                // If deserialization into the new format fails (e.g., because the provider is still
+                // If deserialization into the new type fails (e.g., because the provider is still
                 // returning legacy data), attempt to deserialize using an older, legacy format instead.
                 // This fallback ensures compatibility with older nodes or providers that have not yet upgraded.
                 //

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -174,6 +174,13 @@ impl<Types, Ver: StaticVersionType> Provider<Types, PayloadRequest> for QuerySer
 where
     Types: NodeType,
 {
+    /// Fetches the `Payload` for a given request.
+    ///
+    /// Attempts to fetch and deserialize the requested data using the new type first.
+    /// If deserialization into the new type fails (e.g., because the provider is still returning
+    /// legacy data), it falls back to attempt deserialization using an older, legacy type instead.
+    /// This fallback ensures compatibility with older nodes or providers that have not yet upgraded.
+    ///
     async fn fetch(&self, req: PayloadRequest) -> Option<Payload<Types>> {
         // Fetch the payload and the VID common data. We need the common data to recompute the VID
         // commitment, to ensure the payload we received is consistent with the commitment we
@@ -222,13 +229,7 @@ where
             _ => {
                 tracing::info!("fetching legacy payload for req={}", req.0);
 
-                // --- Fallback Deserialization ---
-                //
-                // If deserialization into the new type fails (e.g., because the provider is still
-                // returning legacy data), attempt to deserialize using an older, legacy format instead.
-                // This fallback ensures compatibility with older nodes or providers that have not yet upgraded.
-                //
-                // If the fallback also fails, the fetch will fail and return `None`.
+                // fallback deserialization
                 return self
                     .fetch_legacy_payload::<Types>(payload_bytes, common_bytes, req)
                     .await;
@@ -316,6 +317,13 @@ impl<Types, Ver: StaticVersionType> Provider<Types, LeafRequest<Types>>
 where
     Types: NodeType,
 {
+    /// Fetches the `Leaf` for a given request.
+    ///
+    /// Attempts to fetch and deserialize the requested data using the new type first.
+    /// If deserialization into the new type fails (e.g., because the provider is still returning
+    /// legacy data), it falls back to attempt deserialization using an older, legacy type instead.
+    /// This fallback ensures compatibility with older nodes or providers that have not yet upgraded.
+    ///
     async fn fetch(&self, req: LeafRequest<Types>) -> Option<LeafQueryData<Types>> {
         let bytes = self
             .client
@@ -360,13 +368,7 @@ where
             },
             Err(err) => {
                 tracing::warn!("failed to fetch leaf req={req:?}. err={err}");
-                // --- Fallback Deserialization ---
-                //
-                // If deserialization into the new type fails (e.g., because the provider is still
-                // returning legacy data), attempt to deserialize using an older, legacy format instead.
-                // This fallback ensures compatibility with older nodes or providers that have not yet upgraded.
-                //
-                // If the fallback also fails, the fetch will fail and return `None`.
+                // Fallback deserialization
                 self.fetch_legacy_leaf(bytes, req).await
             },
         }
@@ -378,6 +380,13 @@ impl<Types, Ver: StaticVersionType> Provider<Types, VidCommonRequest> for QueryS
 where
     Types: NodeType,
 {
+    /// Fetches the `VidCommon` for a given request.
+    ///
+    /// Attempts to fetch and deserialize the requested data using the new type first.
+    /// If deserialization into the new type fails (e.g., because the provider is still returning
+    /// legacy data), it falls back to attempt deserialization using an older, legacy type instead.
+    /// This fallback ensures compatibility with older nodes or providers that have not yet upgraded.
+    ///
     async fn fetch(&self, req: VidCommonRequest) -> Option<VidCommon> {
         let bytes = self
             .client
@@ -425,13 +434,7 @@ where
                     req.0
                 );
 
-                // --- Fallback Deserialization ---
-                //
-                // If deserialization into the new type fails (e.g., because the provider is still
-                // returning legacy data), attempt to deserialize using an older, legacy format instead.
-                // This fallback ensures compatibility with older nodes or providers that have not yet upgraded.
-                //
-                // If the fallback also fails, the fetch will fail and return `None`.
+                // Fallback deserialization
                 self.fetch_legacy_vid_common::<Types>(bytes, req).await
             },
         }

--- a/sequencer-sqlite/Cargo.lock
+++ b/sequencer-sqlite/Cargo.lock
@@ -1929,7 +1929,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -8123,7 +8123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -9848,7 +9848,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -10302,9 +10302,9 @@ dependencies = [
 
 [[package]]
 name = "surf-disco"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e00ab9d939d04110f14281d5a1e45b6c8acdfbc42e720cbfaef33007c907e6"
+checksum = "2bcf4981d3d4dc702a855914e80a9ea4f348b5a2c634cd64eed7bd583a14e26d"
 dependencies = [
  "async-std",
  "async-tungstenite",


### PR DESCRIPTION


Closes https://app.asana.com/1/1208976916964769/project/1209413670216270/task/1210014495940934
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->


This PR removes duplicate fetch request in the query service from the same provider.


For the proof-of-stake upgrade, we have new types. The new binary migrates all the query service data to the new types. When the new binary is deployed on the testnet, it may take some time to migrate all the existing data, and so the node has to catch up on all the missing data, which means it needs to fetch from the peers running old binary. The new binary, therefore, registers two availability module versions: `v0` and `v1`. Version v1 returns the new types, while v0 returns the downgraded (legacy) types. The old peers only have `v0` availability module

A quick solution was implemented, which makes a request to the provider expecting the new type. If that fails, another request is made for the legacy type from the same provider. This legacy type is then converted to the new type and returned as the result.

This means two http requests to fulfil one missing pre-epoch req.

This PR adds a fallback deserialization to solve this. It returns the bytes from the provider and first tries to deserialize them into the new type. If that fails, another attempt is made to parse the bytes as the old legacy type. This eliminates the need for two catch-up requests.


https://github.com/EspressoSystems/surf-disco/pull/68 added the bytes() to return response bytes.


### Key places to review:
The fetch() for all the requests.
