### PR TITLE
Fix reloading stake tables from persistence: only reload most recent stake tables

### DIFF
--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -1383,4 +1383,53 @@ mod persistence_tests {
 
         Ok(())
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_membership_persistence<P: TestablePersistence>() -> anyhow::Result<()> {
+        setup_test();
+
+        let tmp = P::tmp_storage().await;
+        let mut opt = P::options(&tmp);
+
+        let storage = opt.create().await.unwrap();
+
+        let validator = Validator::mock();
+        let mut st = IndexMap::new();
+        st.insert(validator.account, validator);
+        storage
+            .store_stake(EpochNumber::new(10), st.clone())
+            .await?;
+
+        let table = storage.load_stake(EpochNumber::new(10)).await?.unwrap();
+        assert_eq!(st, table);
+
+        let val2 = Validator::mock();
+        let mut st2 = IndexMap::new();
+        st2.insert(val2.account, val2);
+        storage
+            .store_stake(EpochNumber::new(11), st2.clone())
+            .await?;
+
+        let tables = storage.load_latest_stake(4).await?.unwrap();
+        let mut iter = tables.iter();
+        assert_eq!(Some(&(EpochNumber::new(11), st2.clone())), iter.next());
+        assert_eq!(Some(&(EpochNumber::new(10), st)), iter.next());
+        assert_eq!(None, iter.next());
+
+        for i in 0..=20 {
+            storage
+                .store_stake(EpochNumber::new(i), st2.clone())
+                .await?;
+        }
+
+        let tables = storage.load_latest_stake(5).await?.unwrap();
+        let mut iter = tables.iter();
+        assert_eq!(Some(&(EpochNumber::new(20), st2.clone())), iter.next());
+        assert_eq!(Some(&(EpochNumber::new(19), st2.clone())), iter.next());
+        assert_eq!(Some(&(EpochNumber::new(18), st2.clone())), iter.next());
+        assert_eq!(Some(&(EpochNumber::new(17), st2.clone())), iter.next());
+        assert_eq!(Some(&(EpochNumber::new(16), st2)), iter.next());
+
+        Ok(())
+    }
 }

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -54,7 +54,7 @@ mod persistence_tests {
     use committable::{Commitment, Committable};
     use espresso_types::{
         traits::{EventConsumer, NullEventConsumer, PersistenceOptions},
-        v0_3::StakeTableFetcher,
+        v0_3::{StakeTableFetcher, Validator},
         Event, L1Client, Leaf, Leaf2, NodeState, PubKey, SeqTypes, SequencerVersions,
         ValidatedState,
     };
@@ -86,6 +86,7 @@ mod persistence_tests {
         vid::avidm::{init_avidm_param, AvidMScheme},
         vote::HasViewNumber,
     };
+    use indexmap::IndexMap;
     use portpicker::pick_unused_port;
     use sequencer_utils::test_utils::setup_test;
     use surf_disco::Client;
@@ -1385,7 +1386,7 @@ mod persistence_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_membership_persistence<P: TestablePersistence>() -> anyhow::Result<()> {
+    pub async fn test_membership_persistence<P: TestablePersistence>() -> anyhow::Result<()> {
         setup_test();
 
         let tmp = P::tmp_storage().await;

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -1430,6 +1430,7 @@ mod persistence_tests {
         assert_eq!(Some(&(EpochNumber::new(18), st2.clone())), iter.next());
         assert_eq!(Some(&(EpochNumber::new(17), st2.clone())), iter.next());
         assert_eq!(Some(&(EpochNumber::new(16), st2)), iter.next());
+        assert_eq!(None, iter.next());
 
         Ok(())
     }

--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -1403,8 +1403,8 @@ impl MembershipPersistence for Persistence {
         let inner = self.inner.read().await;
         let path = &inner.stake_table_dir_path();
         let sorted = epoch_files(&path)?
-        .sorted_by(|(e1, _), (e2, _)| e2.cmp(e1))
-        .take(limit);
+            .sorted_by(|(e1, _), (e2, _)| e2.cmp(e1))
+            .take(limit);
 
         sorted
             .map(|(epoch, path)| -> anyhow::Result<Option<IndexedStake>> {


### PR DESCRIPTION
The SQL query for stake tables reloading is missing `ORDER BY DESC `clause which would return random stake tables
The FileSystem returns recent stake tables but uses an exclusive range for filtering out—for example, if the total number of stake tables is 5 and the limit is 4, it returns only 3 stake tables. This PR fixes both of these issues

The test is also moved to persistence.rs to avoid duplicate persistence code as generic macro would run the test for both sql and fs 