### PR TITLE
Set default L1 finalized safety margin

### DIFF
--- a/docker/sequencer.Dockerfile
+++ b/docker/sequencer.Dockerfile
@@ -46,6 +46,10 @@ RUN chmod +x /bin/sequencer
 # configuration beyond the lifetime of the Docker container itself.
 ENV ESPRESSO_SEQUENCER_STORAGE_PATH=/store/sequencer
 
+# Set an L1 safety margin by default. This enables fast startup on chains where the L1 genesis block
+# is very old.
+ENV ESPRESSO_SEQUENCER_L1_FINALIZED_SAFETY_MARGIN=100
+
 CMD ["/bin/sequencer", "--", "http"]
 HEALTHCHECK --interval=1s --timeout=1s --retries=100 CMD curl --fail http://localhost:${ESPRESSO_SEQUENCER_API_PORT}/healthcheck  || exit 1
 EXPOSE ${ESPRESSO_SEQUENCER_API_PORT}


### PR DESCRIPTION
Allows fast startup by default even on chains with very old L1 genesis. Marginally decreases safety in cases that are probably only theoretical.

### This PR:
Sets `ESPRESSO_SEQUENCER_L1_FINALIZED_SAFETY_MARGIN=100` by default in the sequencer Dockerfile. Since this is only set via an env var in Docker, it can easily be unset if desired to have deterministic safety.
