### PR TITLE
load recent epochs and drb only on startup

### DIFF
--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -76,6 +76,7 @@ pub mod network;
 mod run;
 pub use run::main;
 
+pub const RECENT_STAKE_TABLES_LIMIT: u64 = 20;
 /// The Sequencer node is generic over the hotshot CommChannel.
 #[derive(Derivative, Serialize, Deserialize)]
 #[derivative(
@@ -514,7 +515,7 @@ pub async fn init_node<P: SequencerPersistence + MembershipPersistence, V: Versi
         network_config.config.known_da_nodes.clone(),
         fetcher,
     );
-    membership.reload_stake(50).await;
+    membership.reload_stake(RECENT_STAKE_TABLES_LIMIT).await;
 
     let membership: Arc<RwLock<EpochCommittees>> = Arc::new(RwLock::new(membership));
     let coordinator =

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -253,7 +253,7 @@ mod persistence_tests {
         // Store more than the limit
         let total_epochs = RECENT_STAKE_TABLES_LIMIT + 10;
         for i in 0..total_epochs {
-            let epoch = EpochNumber::new(i as u64);
+            let epoch = EpochNumber::new(i);
             let drb = [i as u8; 32];
             storage
                 .add_drb_result(epoch, drb)

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -101,7 +101,7 @@ mod persistence_tests {
             Options,
         },
         testing::TestConfigBuilder,
-        SequencerApiVersion,
+        SequencerApiVersion, RECENT_STAKE_TABLES_LIMIT,
     };
 
     #[derive(Clone, Debug, Default)]
@@ -249,6 +249,35 @@ mod persistence_tests {
                 }
             ]
         );
+
+        // Store more than the limit
+        let total_epochs = RECENT_STAKE_TABLES_LIMIT + 10;
+        for i in 0..total_epochs {
+            let epoch = EpochNumber::new(i as u64);
+            let drb = [i as u8; 32];
+            storage
+                .add_drb_result(epoch, drb)
+                .await
+                .unwrap_or_else(|_| panic!("Failed to store DRB result for epoch {}", i));
+        }
+
+        let results = storage.load_start_epoch_info().await.unwrap();
+
+        // Check that only the most recent RECENT_STAKE_TABLES_LIMIT epochs are returned
+        assert_eq!(
+            results.len(),
+            RECENT_STAKE_TABLES_LIMIT as usize,
+            "Should return only the most recent {RECENT_STAKE_TABLES_LIMIT} epochs",
+        );
+
+        for (i, info) in results.iter().enumerate() {
+            let expected_epoch =
+                EpochNumber::new(total_epochs - RECENT_STAKE_TABLES_LIMIT + i as u64);
+            let expected_drb = [(total_epochs - RECENT_STAKE_TABLES_LIMIT + i as u64) as u8; 32];
+            assert_eq!(info.epoch, expected_epoch, "invalid epoch at index {i}",);
+            assert_eq!(info.drb_result, expected_drb, "invalid DRB at index {i}",);
+            assert!(info.block_header.is_none(), "Expected no block header");
+        }
     }
 
     fn leaf_info(leaf: Leaf2) -> LeafInfo<SeqTypes> {

--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -40,7 +40,7 @@ use hotshot_types::{
 use indexmap::IndexMap;
 use itertools::Itertools;
 
-use crate::ViewNumber;
+use crate::{ViewNumber, RECENT_STAKE_TABLES_LIMIT};
 
 /// Options for file system backed persistence.
 #[derive(Parser, Clone, Debug)]
@@ -1348,7 +1348,13 @@ impl SequencerPersistence for Persistence {
 
         result.sort_by(|a, b| a.epoch.cmp(&b.epoch));
 
-        Ok(result)
+        // Keep only the most recent epochs
+        let start = result
+            .len()
+            .saturating_sub(RECENT_STAKE_TABLES_LIMIT as usize);
+        let recent = result[start..].to_vec();
+
+        Ok(recent)
     }
 
     async fn load_state_cert(


### PR DESCRIPTION
This PR loads only the recent epoch and DRB. This is important because `add_epoch_root() `is called for these epochs during startup, which can overload L1 fetching. By loading the same recent epochs as the stake tables— which are reloaded into persistent storage before loading the consensus state — we can avoid unnecessary L1 calls. When `add_epoch_root() `is called for the recent startup epochs, it will skip L1 fetching if the corresponding stake tables are already present. L1 fetching will only occur if any stake table is missing from storage or fails to reload, which should be rare.