### PR TITLE
Register v1 version for all API modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,6 +5026,7 @@ dependencies = [
  "hotshot-types",
  "portpicker",
  "rand 0.8.5",
+ "semver 1.0.26",
  "serde",
  "snafu 0.8.5",
  "surf-disco",

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -257,7 +257,10 @@ pub mod testing {
                 Arc<RwLock<EventsStreamer<SeqTypes>>>,
                 SeqTypes,
                 StaticVersion<0, 1>,
-            >(&EventStreamingApiOptions::default())
+            >(
+                &EventStreamingApiOptions::default(),
+                "0.0.1".parse().unwrap(),
+            )
             .expect("Failed to define hotshot eventsAPI");
 
             let mut app = App::<_, EventStreamApiError>::with_state(source);

--- a/hotshot-events-service/Cargo.toml
+++ b/hotshot-events-service/Cargo.toml
@@ -15,6 +15,7 @@ derive_more = { workspace = true }
 futures = { workspace = true }
 hotshot-types = { workspace = true }
 rand = { workspace = true }
+semver = { workspace = true }
 serde = { workspace = true }
 snafu = "0.8"
 tide-disco = "0.9"

--- a/hotshot-events-service/src/events.rs
+++ b/hotshot-events-service/src/events.rs
@@ -81,7 +81,10 @@ impl tide_disco::error::Error for Error {
     }
 }
 
-pub fn define_api<State, Types, Ver>(options: &Options) -> Result<Api<State, Error, Ver>, ApiError>
+pub fn define_api<State, Types, Ver>(
+    options: &Options,
+    api_ver: semver::Version,
+) -> Result<Api<State, Error, Ver>, ApiError>
 where
     State: 'static + Send + Sync + ReadState,
     <State as ReadState>::State: Send + Sync + EventsSource<Types>,
@@ -93,7 +96,7 @@ where
         include_str!("../api/hotshot_events.toml"),
         options.extensions.clone(),
     )?;
-    api.with_version("0.1.0".parse().unwrap())
+    api.with_version(api_ver)
         .stream("events", move |_, state| {
             async move {
                 tracing::info!("client subscribed to events");

--- a/hotshot-events-service/src/test.rs
+++ b/hotshot-events-service/src/test.rs
@@ -54,11 +54,12 @@ mod tests {
         // Start the web server.
         let mut app = App::<_, Error>::with_state(events_streamer.clone());
 
-        let hotshot_events_api =
-            define_api::<Arc<RwLock<EventsStreamer<TestTypes>>>, TestTypes, StaticVersion<0, 1>>(
-                &Options::default(),
-            )
-            .expect("Failed to define hotshot eventsAPI");
+        let hotshot_events_api = define_api::<
+            Arc<RwLock<EventsStreamer<TestTypes>>>,
+            TestTypes,
+            StaticVersion<0, 1>,
+        >(&Options::default(), "0.0.1".parse().unwrap())
+        .expect("Failed to define hotshot eventsAPI");
 
         app.register_module("hotshot_events", hotshot_events_api)
             .expect("Failed to register hotshot events API");
@@ -113,11 +114,12 @@ mod tests {
         // Start the web server.
         let mut app = App::<_, Error>::with_state(events_streamer.clone());
 
-        let hotshot_events_api =
-            define_api::<Arc<RwLock<EventsStreamer<TestTypes>>>, TestTypes, StaticVersion<0, 1>>(
-                &Options::default(),
-            )
-            .expect("Failed to define hotshot eventsAPI");
+        let hotshot_events_api = define_api::<
+            Arc<RwLock<EventsStreamer<TestTypes>>>,
+            TestTypes,
+            StaticVersion<0, 1>,
+        >(&Options::default(), "0.0.1".parse().unwrap())
+        .expect("Failed to define hotshot eventsAPI");
 
         app.register_module("api", hotshot_events_api)
             .expect("Failed to register hotshot events API");
@@ -157,11 +159,12 @@ mod tests {
         // Start the web server.
         let mut app = App::<_, Error>::with_state(events_streamer.clone());
 
-        let hotshot_events_api =
-            define_api::<Arc<RwLock<EventsStreamer<TestTypes>>>, TestTypes, StaticVersion<0, 1>>(
-                &Options::default(),
-            )
-            .expect("Failed to define hotshot eventsAPI");
+        let hotshot_events_api = define_api::<
+            Arc<RwLock<EventsStreamer<TestTypes>>>,
+            TestTypes,
+            StaticVersion<0, 1>,
+        >(&Options::default(), "1.0.0".parse().unwrap())
+        .expect("Failed to define hotshot eventsAPI");
 
         app.register_module("hotshot_events", hotshot_events_api)
             .expect("Failed to register hotshot events API");

--- a/hotshot-query-service/src/explorer.rs
+++ b/hotshot-query-service/src/explorer.rs
@@ -238,6 +238,7 @@ fn validate_limit(
 /// defined in the `explorer.toml` file.
 pub fn define_api<State, Types: NodeType, Ver: StaticVersionType + 'static>(
     _: Ver,
+    api_ver: semver::Version,
 ) -> Result<Api<State, Error, Ver>, ApiError>
 where
     State: 'static + Send + Sync + ReadState,
@@ -252,7 +253,7 @@ where
         None,
     )?;
 
-    api.with_version("0.0.1".parse().unwrap())
+    api.with_version(api_ver)
         .get("get_block_detail", move |req, state| {
             async move {
                 let target = match (
@@ -871,8 +872,11 @@ mod test {
         // Start the web server.
         let port = pick_unused_port().unwrap();
         let mut app = App::<_, Error>::with_state(ApiState::from(network.data_source()));
-        app.register_module("explorer", define_api(MockBase::instance()).unwrap())
-            .unwrap();
+        app.register_module(
+            "explorer",
+            define_api(MockBase::instance(), "0.0.1".parse().unwrap()).unwrap(),
+        )
+        .unwrap();
         app.register_module(
             "availability",
             availability::define_api(

--- a/hotshot-query-service/src/lib.rs
+++ b/hotshot-query-service/src/lib.rs
@@ -555,8 +555,10 @@ where
         "1.0.0".parse().unwrap(),
     )
     .map_err(Error::internal)?;
-    let node_api = node::define_api(&options.node, bind_version).map_err(Error::internal)?;
-    let status_api = status::define_api(&options.status, bind_version).map_err(Error::internal)?;
+    let node_api = node::define_api(&options.node, bind_version, "0.0.1".parse().unwrap())
+        .map_err(Error::internal)?;
+    let status_api = status::define_api(&options.status, bind_version, "0.0.1".parse().unwrap())
+        .map_err(Error::internal)?;
 
     // Create app.
     let data_source = Arc::new(data_source);
@@ -884,19 +886,29 @@ mod test {
             availability::define_api(
                 &Default::default(),
                 MockBase::instance(),
-                "1.0.0".parse().unwrap(),
+                "0.0.1".parse().unwrap(),
             )
             .unwrap(),
         )
         .unwrap()
         .register_module(
             "node",
-            node::define_api(&Default::default(), MockBase::instance()).unwrap(),
+            node::define_api(
+                &Default::default(),
+                MockBase::instance(),
+                "0.0.1".parse().unwrap(),
+            )
+            .unwrap(),
         )
         .unwrap()
         .register_module(
             "status",
-            status::define_api(&Default::default(), MockBase::instance()).unwrap(),
+            status::define_api(
+                &Default::default(),
+                MockBase::instance(),
+                "0.0.1".parse().unwrap(),
+            )
+            .unwrap(),
         )
         .unwrap()
         .module::<Error, MockBase>("mod", module_spec)

--- a/hotshot-query-service/src/merklized_state.rs
+++ b/hotshot-query-service/src/merklized_state.rs
@@ -79,6 +79,7 @@ pub fn define_api<
     const ARITY: usize,
 >(
     options: &Options,
+    api_ver: semver::Version,
 ) -> Result<Api<State, Error, Ver>, ApiError>
 where
     State: 'static + Send + Sync + ReadState,
@@ -92,7 +93,7 @@ where
         options.extensions.clone(),
     )?;
 
-    api.with_version("0.0.1".parse().unwrap())
+    api.with_version(api_ver)
         .get("get_path", move |req, state| {
             async move {
                 // Determine the snapshot type based on request parameters, either index or commit

--- a/hotshot-query-service/src/node.rs
+++ b/hotshot-query-service/src/node.rs
@@ -115,6 +115,7 @@ impl Error {
 pub fn define_api<State, Types: NodeType, Ver: StaticVersionType + 'static>(
     options: &Options,
     _: Ver,
+    api_ver: semver::Version,
 ) -> Result<Api<State, Error, Ver>, ApiError>
 where
     State: 'static + Send + Sync + ReadState,
@@ -126,7 +127,7 @@ where
         options.extensions.clone(),
     )?;
     let window_limit = options.window_limit;
-    api.with_version("0.0.1".parse().unwrap())
+    api.with_version(api_ver)
         .get("block_height", |_req, state| {
             async move { state.block_height().await.context(QuerySnafu) }.boxed()
         })?
@@ -258,6 +259,7 @@ mod test {
                     ..Default::default()
                 },
                 MockBase::instance(),
+                "1.0.0".parse().unwrap(),
             )
             .unwrap(),
         )
@@ -431,7 +433,12 @@ mod test {
         let mut app = App::<_, Error>::with_state(ApiState::from(network.data_source()));
         app.register_module(
             "node",
-            define_api(&Default::default(), MockBase::instance()).unwrap(),
+            define_api(
+                &Default::default(),
+                MockBase::instance(),
+                "1.0.0".parse().unwrap(),
+            )
+            .unwrap(),
         )
         .unwrap();
         network.spawn(
@@ -607,6 +614,7 @@ mod test {
                     ..Default::default()
                 },
                 MockBase::instance(),
+                "1.0.0".parse().unwrap(),
             )
             .unwrap();
         api.get("get_ext", |_, state| {

--- a/marketplace-builder-shared/src/utils/event_service_wrapper.rs
+++ b/marketplace-builder-shared/src/utils/event_service_wrapper.rs
@@ -203,7 +203,11 @@ mod tests {
         let source = MockEventsSource {
             counter: AtomicU64::new(0),
         };
-        let api = define_api::<MockEventsSource, _, MockVersion>(&Default::default()).unwrap();
+        let api = define_api::<MockEventsSource, _, MockVersion>(
+            &Default::default(),
+            "0.0.1".parse().unwrap(),
+        )
+        .unwrap();
 
         let mut app: App<MockEventsSource, hotshot_events_service::events::Error> =
             App::with_state(source);

--- a/marketplace-solver/src/events.rs
+++ b/marketplace-solver/src/events.rs
@@ -158,9 +158,11 @@ pub mod mock {
         let mut app =
             App::<_, hotshot_events_service::events::Error>::with_state(events_streamer.clone());
 
-        let hotshot_events_api =
-            hotshot_events_service::events::define_api::<_, _, StaticVer01>(&Default::default())
-                .expect("Failed to define hotshot eventsAPI");
+        let hotshot_events_api = hotshot_events_service::events::define_api::<_, _, StaticVer01>(
+            &Default::default(),
+            "0.0.1".parse().unwrap(),
+        )
+        .expect("Failed to define hotshot eventsAPI");
 
         app.register_module("events_api", hotshot_events_api)
             .expect("Failed to register hotshot events API");

--- a/sequencer-sqlite/Cargo.lock
+++ b/sequencer-sqlite/Cargo.lock
@@ -4726,6 +4726,7 @@ dependencies = [
  "futures",
  "hotshot-types",
  "rand 0.8.5",
+ "semver 1.0.26",
  "serde",
  "snafu 0.8.5",
  "tide-disco",

--- a/sequencer/src/api/options.rs
+++ b/sequencer/src/api/options.rs
@@ -24,7 +24,7 @@ use hotshot_types::traits::{
     network::ConnectedNetwork,
     node_implementation::Versions,
 };
-use tide_disco::{listener::RateLimitListener, method::ReadState, App, Url};
+use tide_disco::{listener::RateLimitListener, method::ReadState, Api, App, Url};
 use vbs::version::StaticVersionType;
 
 use super::{
@@ -205,10 +205,11 @@ impl Options {
                 state.clone(),
             )));
 
-            // Initialize status API.
-            let status_api =
-                status::define_api(&Default::default(), SequencerApiVersion::instance())?;
-            app.register_module("status", status_api)?;
+            // Initialize v0 and v1 status API.
+            register_api("status", &mut app, move |ver| {
+                status::define_api(&Default::default(), SequencerApiVersion::instance(), ver)
+                    .context("failed to define status api")
+            })?;
 
             self.init_hotshot_modules(&mut app)?;
 
@@ -273,12 +274,11 @@ impl Options {
         let api_state: endpoints::AvailState<N, P, D, V> = ds.clone().into();
         let mut app = App::<_, Error>::with_state(api_state);
 
-        // Initialize status API
-        let status_api = status::define_api::<endpoints::AvailState<N, P, D, _>, _>(
-            &Default::default(),
-            bind_version,
-        )?;
-        app.register_module("status", status_api)?;
+        // Initialize v0 and v1 status API.
+        register_api("status", &mut app, move |ver| {
+            status::define_api(&Default::default(), SequencerApiVersion::instance(), ver)
+                .context("failed to define status api")
+        })?;
 
         // Initialize availability and node APIs (these both use the same data source).
 
@@ -288,35 +288,38 @@ impl Options {
 
         // initialize the availability module for API version V0.
         // This ensures compatibility for nodes that expect `Leaf1` for leaf endpoints
-        app.register_module(
-            "availability",
-            endpoints::availability("0.0.1".parse().unwrap())?,
-        )?;
 
-        // initialize the availability module for API version V1.
-        // This enables support for the new `Leaf2` type
-        app.register_module(
-            "availability",
-            endpoints::availability("1.0.0".parse().unwrap())?,
-        )?;
+        register_api("availability", &mut app, move |ver| {
+            endpoints::availability(ver).context("failed to define availability api")
+        })?;
 
-        app.register_module("node", endpoints::node()?)?;
+        register_api("node", &mut app, move |ver| {
+            endpoints::node(ver).context("failed to define node api")
+        })?;
 
         // Initialize submit API
         if self.submit.is_some() {
-            app.register_module(
-                "submit",
-                endpoints::submit::<_, _, _, SequencerApiVersion>()?,
-            )?;
+            register_api("submit", &mut app, move |ver| {
+                endpoints::submit::<_, _, _, SequencerApiVersion>(ver)
+                    .context("failed to define submit api")
+            })?;
         }
 
         tracing::info!("initializing catchup API");
-        app.register_module("catchup", endpoints::catchup(bind_version)?)?;
 
-        app.register_module("state-signature", endpoints::state_signature(bind_version)?)?;
+        register_api("catchup", &mut app, move |ver| {
+            endpoints::catchup(bind_version, ver).context("failed to define catchup api")
+        })?;
+
+        register_api("state-signature", &mut app, move |ver| {
+            endpoints::state_signature(bind_version, ver)
+                .context("failed to define state signature api")
+        })?;
 
         if self.config.is_some() {
-            app.register_module("config", endpoints::config(bind_version)?)?;
+            register_api("config", &mut app, move |ver| {
+                endpoints::config(bind_version, ver).context("failed to define config api")
+            })?;
         }
         Ok((metrics, ds, app))
     }
@@ -390,21 +393,28 @@ impl Options {
             .await?;
 
         if self.explorer.is_some() {
-            app.register_module("explorer", endpoints::explorer()?)?;
+            register_api("explorer", &mut app, move |ver| {
+                endpoints::explorer(ver).context("failed to define explorer api")
+            })?;
         }
 
         // Initialize merklized state module for block merkle tree
-        app.register_module(
-            "block-state",
-            endpoints::merklized_state::<N, P, _, BlockMerkleTree, _, 3>()?,
-        )?;
-        // Initialize merklized state module for fee merkle tree
-        app.register_module("fee-state", endpoints::fee::<_, SequencerApiVersion>()?)?;
 
-        app.register_module(
-            "reward-state",
-            endpoints::reward::<_, SequencerApiVersion>()?,
-        )?;
+        register_api("block-state", &mut app, move |ver| {
+            endpoints::merklized_state::<N, P, _, BlockMerkleTree, _, 3>(ver)
+                .context("failed to define block-state api")
+        })?;
+
+        // Initialize merklized state module for fee merkle tree
+
+        register_api("fee-state", &mut app, move |ver| {
+            endpoints::fee::<_, SequencerApiVersion>(ver).context("failed to define fee-state api")
+        })?;
+
+        register_api("reward-state", &mut app, move |ver| {
+            endpoints::reward::<_, SequencerApiVersion>(ver)
+                .context("failed to define reward-state api")
+        })?;
 
         let get_node_state = {
             let state = state.clone();
@@ -450,22 +460,30 @@ impl Options {
         let bind_version = SequencerApiVersion::instance();
         // Initialize submit API
         if self.submit.is_some() {
-            let submit_api = endpoints::submit::<_, _, _, SequencerApiVersion>()?;
-            app.register_module("submit", submit_api)?;
+            register_api("submit", app, move |ver| {
+                endpoints::submit::<_, _, _, SequencerApiVersion>(ver)
+                    .context("failed to define submit api")
+            })?;
         }
 
         // Initialize state API.
         if self.catchup.is_some() {
             tracing::info!("initializing state API");
-            let catchup_api = endpoints::catchup(bind_version)?;
-            app.register_module("catchup", catchup_api)?;
+
+            register_api("catchup", app, move |ver| {
+                endpoints::catchup(bind_version, ver).context("failed to define catchup api")
+            })?;
         }
 
-        let state_signature_api = endpoints::state_signature(bind_version)?;
-        app.register_module("state-signature", state_signature_api)?;
+        register_api("state-signature", app, move |ver| {
+            endpoints::state_signature(bind_version, ver)
+                .context("failed to define state signature api")
+        })?;
 
         if self.config.is_some() {
-            app.register_module("config", endpoints::config(bind_version)?)?;
+            register_api("config", app, move |ver| {
+                endpoints::config(bind_version, ver).context("failed to define config api")
+            })?;
         }
 
         Ok(())
@@ -492,11 +510,14 @@ impl Options {
         let mut app = App::<_, EventStreamingError>::with_state(AppState::from(state));
 
         tracing::info!("initializing hotshot events API");
-        let hotshot_events_api = hotshot_events_service::events::define_api(
-            &hotshot_events_service::events::Options::default(),
-        )?;
 
-        app.register_module::<_, SequencerApiVersion>("hotshot-events", hotshot_events_api)?;
+        register_api("hotshot-events", &mut app, move |ver| {
+            hotshot_events_service::events::define_api::<_, _, SequencerApiVersion>(
+                &hotshot_events_service::events::Options::default(),
+                ver,
+            )
+            .context("failed to define hotshot events api")
+        })?;
 
         tasks.spawn(
             "Hotshot Events Streaming API server",
@@ -603,3 +624,27 @@ pub struct HotshotEvents {
 /// Options for the explorer API module.
 #[derive(Parser, Clone, Copy, Debug, Default)]
 pub struct Explorer;
+
+/// Registers two versions (v0 and v1) of the same API module under the given path.
+fn register_api<E, S, F, ModuleError, ModuleVersion>(
+    path: &'static str,
+    app: &mut App<S, E>,
+    f: F,
+) -> anyhow::Result<()>
+where
+    S: 'static + Send + Sync,
+    E: Send + Sync + 'static + tide_disco::Error + From<ModuleError>,
+    ModuleError: Send + Sync + 'static,
+    ModuleVersion: StaticVersionType + 'static,
+    F: Fn(semver::Version) -> anyhow::Result<Api<S, ModuleError, ModuleVersion>>,
+{
+    let v0 = "0.0.1".parse().unwrap();
+    let v1 = "1.0.0".parse().unwrap();
+    let result1 = f(v0)?;
+    let result2 = f(v1)?;
+
+    app.register_module(path, result1)?;
+    app.register_module(path, result2)?;
+
+    Ok(())
+}

--- a/sequencer/src/api/options.rs
+++ b/sequencer/src/api/options.rs
@@ -286,9 +286,6 @@ impl Options {
         // - `availability/v0/leaf/0` returns the old `Leaf1` type for backward compatibility.
         // - `availability/v1/leaf/0` returns the new `Leaf2` type
 
-        // initialize the availability module for API version V0.
-        // This ensures compatibility for nodes that expect `Leaf1` for leaf endpoints
-
         register_api("availability", &mut app, move |ver| {
             endpoints::availability(ver).context("failed to define availability api")
         })?;


### PR DESCRIPTION
Adds v1 versioning to all APIs to ensure consistency and avoid confusion, since the availability API already has both v0 and v1 versions.
All APIs—except for availability v0 and v1—register the same endpoints with identical behavior.