### PR TITLE
add dummy table for initiating sqlite write txn

### DIFF
--- a/hotshot-query-service/migrations/sqlite/V700__dummy_write_tx_table.sql
+++ b/hotshot-query-service/migrations/sqlite/V700__dummy_write_tx_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE begin_write
+(
+   id INTEGER
+);

--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -727,11 +727,12 @@ impl PruneStorage for SqlStorage {
             if height < target_height {
                 height = min(height + batch_size, target_height);
                 let mut tx = self.write().await?;
+                tracing::info!("deleting batch height={height}");
                 tx.delete_batch(state_tables, height).await?;
                 tx.commit().await.map_err(|e| QueryError::Error {
                     message: format!("failed to commit {e}"),
                 })?;
-
+                tracing::info!("batch deleted height={height}");
                 pruner.pruned_height = Some(height);
                 return Ok(Some(height));
             }

--- a/hotshot-query-service/src/data_source/storage/sql/transaction.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/transaction.rs
@@ -131,7 +131,7 @@ impl TransactionMode for Write {
         // statement that has no actual effect on the database is suitable for this purpose, hence
         // the `WHERE false`.
         #[cfg(feature = "embedded-db")]
-        conn.execute("UPDATE pruned_height SET id = id WHERE false")
+        conn.execute("UPDATE begin_write SET id = id WHERE false")
             .await?;
 
         // With Postgres things are much more straightforward: just tell Postgres we want a write


### PR DESCRIPTION
This is to debug an issue on devnet where pruned_height isn't being updated. It removes the possibility that the pruned_height table is locked, because it is part of every sqlite write transaction