### PR TITLE
Request/response fixes

### DIFF
--- a/sequencer/src/catchup.rs
+++ b/sequencer/src/catchup.rs
@@ -17,8 +17,8 @@ use espresso_types::{
     v0::traits::StateCatchup,
     v0_1::{RewardAccount, RewardAccountProof, RewardMerkleCommitment, RewardMerkleTree},
     v0_99::ChainConfig,
-    BackoffParams, BlockMerkleTree, FeeAccount, FeeAccountProof, FeeMerkleCommitment,
-    FeeMerkleTree, Leaf2, NodeState, PubKey, SeqTypes, ValidatedState,
+    BackoffParams, BlockMerkleTree, EpochVersion, FeeAccount, FeeAccountProof, FeeMerkleCommitment,
+    FeeMerkleTree, Leaf2, NodeState, PubKey, SeqTypes, SequencerVersions, ValidatedState,
 };
 use futures::{
     future::{Future, FutureExt, TryFuture, TryFutureExt},
@@ -28,6 +28,7 @@ use futures::{
 use hotshot_types::{
     consensus::Consensus,
     data::ViewNumber,
+    message::UpgradeLock,
     network::NetworkConfig,
     traits::{
         metrics::{Counter, CounterFamily, Metrics},
@@ -35,7 +36,7 @@ use hotshot_types::{
         node_implementation::{ConsensusTime as _, NodeType, Versions},
         ValidatedState as ValidatedStateTrait,
     },
-    utils::{View, ViewInner},
+    utils::{verify_leaf_chain, View, ViewInner},
     PeerConfig, ValidatorConfig,
 };
 use itertools::Itertools;
@@ -259,9 +260,9 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
         view: ViewNumber,
         fee_merkle_tree_root: FeeMerkleCommitment,
         accounts: &[FeeAccount],
-    ) -> anyhow::Result<FeeMerkleTree> {
+    ) -> anyhow::Result<Vec<FeeAccountProof>> {
         self.fetch(retry, |client| async move {
-            let snapshot = client
+            let tree = client
                 .inner
                 .post::<FeeMerkleTree>(&format!("catchup/{height}/{}/accounts", view.u64()))
                 .body_binary(&accounts.to_vec())?
@@ -269,15 +270,17 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
                 .await?;
 
             // Verify proofs.
+            let mut proofs = Vec::new();
             for account in accounts {
-                let (proof, _) = FeeAccountProof::prove(&snapshot, (*account).into())
+                let (proof, _) = FeeAccountProof::prove(&tree, (*account).into())
                     .context(format!("response missing account {account}"))?;
                 proof
                     .verify(&fee_merkle_tree_root)
                     .context(format!("invalid proof for accoujnt {account}"))?;
+                proofs.push(proof);
             }
 
-            anyhow::Ok(snapshot)
+            anyhow::Ok(proofs)
         })
         .await
     }
@@ -330,15 +333,36 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
         })
         .await
     }
-    async fn try_fetch_leaves(&self, retry: usize, height: u64) -> anyhow::Result<Vec<Leaf2>> {
-        self.fetch(retry, |client| async move {
-            let leaf = client
-                .get::<Vec<Leaf2>>(&format!("catchup/{}/leafchain", height))
-                .send()
-                .await?;
-            anyhow::Ok(leaf)
-        })
+
+    async fn try_fetch_leaf(
+        &self,
+        retry: usize,
+        height: u64,
+        stake_table: Vec<PeerConfig<SeqTypes>>,
+        success_threshold: U256,
+    ) -> anyhow::Result<Leaf2> {
+        // Get the leaf chain
+        let leaf_chain = self
+            .fetch(retry, |client| async move {
+                let leaf = client
+                    .get::<Vec<Leaf2>>(&format!("catchup/{}/leafchain", height))
+                    .send()
+                    .await?;
+                anyhow::Ok(leaf)
+            })
+            .await
+            .with_context(|| format!("failed to fetch leaf at height {height}"))?;
+
+        // Verify it, returning the leaf at the given height
+        verify_leaf_chain(
+            leaf_chain,
+            &stake_table,
+            success_threshold,
+            height,
+            &UpgradeLock::<SeqTypes, SequencerVersions<EpochVersion, EpochVersion>>::new(),
+        )
         .await
+        .with_context(|| format!("failed to verify leaf chain at height {height}"))
     }
 
     #[tracing::instrument(skip(self, _instance))]
@@ -350,9 +374,9 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
         view: ViewNumber,
         reward_merkle_tree_root: RewardMerkleCommitment,
         accounts: &[RewardAccount],
-    ) -> anyhow::Result<RewardMerkleTree> {
+    ) -> anyhow::Result<Vec<RewardAccountProof>> {
         self.fetch(retry, |client| async move {
-            let snapshot = client
+            let tree = client
                 .inner
                 .post::<RewardMerkleTree>(&format!(
                     "catchup/{height}/{}/reward-accounts",
@@ -363,15 +387,18 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
                 .await?;
 
             // Verify proofs.
+            // Verify proofs.
+            let mut proofs = Vec::new();
             for account in accounts {
-                let (proof, _) = RewardAccountProof::prove(&snapshot, (*account).into())
+                let (proof, _) = RewardAccountProof::prove(&tree, (*account).into())
                     .context(format!("response missing account {account}"))?;
                 proof
                     .verify(&reward_merkle_tree_root)
-                    .context(format!("invalid proof for account {account}"))?;
+                    .context(format!("invalid proof for accoujnt {account}"))?;
+                proofs.push(proof);
             }
 
-            anyhow::Ok(snapshot)
+            anyhow::Ok(proofs)
         })
         .await
     }
@@ -542,8 +569,28 @@ impl<T> StateCatchup for SqlStateCatchup<T>
 where
     T: CatchupStorage + Send + Sync,
 {
-    async fn try_fetch_leaves(&self, _retry: usize, height: u64) -> anyhow::Result<Vec<Leaf2>> {
-        self.db.get_leaf_chain(height).await
+    async fn try_fetch_leaf(
+        &self,
+        _retry: usize,
+        height: u64,
+        stake_table: Vec<PeerConfig<SeqTypes>>,
+        success_threshold: U256,
+    ) -> anyhow::Result<Leaf2> {
+        // Get the leaf chain
+        let leaf_chain = self.db.get_leaf_chain(height).await?;
+
+        // Verify the leaf chain
+        let leaf = verify_leaf_chain(
+            leaf_chain,
+            &stake_table,
+            success_threshold,
+            height,
+            &UpgradeLock::<SeqTypes, SequencerVersions<EpochVersion, EpochVersion>>::new(),
+        )
+        .await
+        .with_context(|| "failed to verify leaf chain")?;
+
+        Ok(leaf)
     }
     // TODO: add a test for the account proof validation
     // issue # 2102 (https://github.com/EspressoSystems/espresso-sequencer/issues/2102)
@@ -554,14 +601,28 @@ where
         instance: &NodeState,
         block_height: u64,
         view: ViewNumber,
-        _fee_merkle_tree_root: FeeMerkleCommitment,
+        fee_merkle_tree_root: FeeMerkleCommitment,
         accounts: &[FeeAccount],
-    ) -> anyhow::Result<FeeMerkleTree> {
-        Ok(self
+    ) -> anyhow::Result<Vec<FeeAccountProof>> {
+        // Get the accounts
+        let (fee_merkle_tree_from_db, _) = self
             .db
             .get_accounts(instance, block_height, view, accounts)
-            .await?
-            .0)
+            .await
+            .with_context(|| "failed to get reward accounts from DB")?;
+
+        // Verify the accounts
+        let mut proofs = Vec::new();
+        for account in accounts {
+            let (proof, _) = FeeAccountProof::prove(&fee_merkle_tree_from_db, (*account).into())
+                .context(format!("response missing account {account}"))?;
+            proof
+                .verify(&fee_merkle_tree_root)
+                .context(format!("invalid proof for account {account}"))?;
+            proofs.push(proof);
+        }
+
+        Ok(proofs)
     }
 
     #[tracing::instrument(skip(self, _retry, instance, mt))]
@@ -618,16 +679,27 @@ where
         view: ViewNumber,
         reward_merkle_tree_root: RewardMerkleCommitment,
         accounts: &[RewardAccount],
-    ) -> anyhow::Result<RewardMerkleTree> {
-        let merkle_tree = self
+    ) -> anyhow::Result<Vec<RewardAccountProof>> {
+        // Get the accounts
+        let (reward_merkle_tree_from_db, _) = self
             .db
             .get_reward_accounts(instance, block_height, view, accounts)
-            .await?
-            .0;
-        if merkle_tree.commitment() != reward_merkle_tree_root {
-            bail!("reward merkle tree root mismatch");
+            .await
+            .with_context(|| "failed to get reward accounts from DB")?;
+
+        // Verify the accounts
+        let mut proofs = Vec::new();
+        for account in accounts {
+            let (proof, _) =
+                RewardAccountProof::prove(&reward_merkle_tree_from_db, (*account).into())
+                    .context(format!("response missing account {account}"))?;
+            proof
+                .verify(&reward_merkle_tree_root)
+                .context(format!("invalid proof for account {account}"))?;
+            proofs.push(proof);
         }
-        Ok(merkle_tree)
+
+        Ok(proofs)
     }
 
     fn backoff(&self) -> &BackoffParams {
@@ -676,9 +748,16 @@ impl NullStateCatchup {
 
 #[async_trait]
 impl StateCatchup for NullStateCatchup {
-    async fn try_fetch_leaves(&self, _retry: usize, _height: u64) -> anyhow::Result<Vec<Leaf2>> {
-        bail!("state catchup is didabled")
+    async fn try_fetch_leaf(
+        &self,
+        _retry: usize,
+        _height: u64,
+        _stake_table: Vec<PeerConfig<SeqTypes>>,
+        _success_threshold: U256,
+    ) -> anyhow::Result<Leaf2> {
+        bail!("state catchup is disabled")
     }
+
     async fn try_fetch_accounts(
         &self,
         _retry: usize,
@@ -687,7 +766,7 @@ impl StateCatchup for NullStateCatchup {
         _view: ViewNumber,
         _fee_merkle_tree_root: FeeMerkleCommitment,
         _account: &[FeeAccount],
-    ) -> anyhow::Result<FeeMerkleTree> {
+    ) -> anyhow::Result<Vec<FeeAccountProof>> {
         bail!("state catchup is disabled");
     }
 
@@ -699,7 +778,7 @@ impl StateCatchup for NullStateCatchup {
         _view: ViewNumber,
         _fee_merkle_tree_root: RewardMerkleCommitment,
         _account: &[RewardAccount],
-    ) -> anyhow::Result<RewardMerkleTree> {
+    ) -> anyhow::Result<Vec<RewardAccountProof>> {
         bail!("state catchup is disabled");
     }
 
@@ -743,18 +822,13 @@ impl StateCatchup for NullStateCatchup {
 #[derive(Clone)]
 pub struct ParallelStateCatchup {
     providers: Arc<Mutex<Vec<Arc<dyn StateCatchup>>>>,
-    remote_request_delay: Duration,
 }
 
 impl ParallelStateCatchup {
     /// Create a new [`ParallelStateCatchup`] with two providers.
-    ///
-    /// `remote_request_delay` is the amount of time to wait for a local response (e.g. database)
-    /// before spawning remote requests for the same data.
-    pub fn new(providers: &[Arc<dyn StateCatchup>], remote_request_delay: Duration) -> Self {
+    pub fn new(providers: &[Arc<dyn StateCatchup>]) -> Self {
         Self {
             providers: Arc::new(Mutex::new(providers.to_vec())),
-            remote_request_delay,
         }
     }
 
@@ -772,30 +846,15 @@ impl ParallelStateCatchup {
     {
         // Make sure we have at least one provider
         let providers = self.providers.lock().clone();
-
         if providers.is_empty() {
             return Err(anyhow::anyhow!("no providers were initialized"));
         }
 
-        // Get the remote request delay so we can throw it into the future
-        let remote_request_delay = self.remote_request_delay;
-
         // Spawn futures for each provider
         let mut futures = FuturesUnordered::new();
         for provider in providers {
-            if provider.is_local() {
-                // If this is a local provider, spawn the future directly
-                let closure = closure.clone();
-                futures.push(AbortOnDropHandle::new(tokio::spawn(closure(provider))));
-            } else {
-                // If this is a remote provider, spawn a future that sleeps for the remote request delay
-                // before calling the closure. These will automatically be cancelled when this function returns
-                let closure = closure.clone();
-                futures.push(AbortOnDropHandle::new(tokio::spawn(async move {
-                    tokio::time::sleep(remote_request_delay).await;
-                    closure(provider).await
-                })));
-            }
+            let closure = closure.clone();
+            futures.push(AbortOnDropHandle::new(tokio::spawn(closure(provider))));
         }
 
         // Return the first successful result
@@ -829,52 +888,137 @@ impl ParallelStateCatchup {
 /// It returns the result of the first provider to complete.
 #[async_trait]
 impl StateCatchup for ParallelStateCatchup {
-    async fn try_fetch_leaves(&self, _retry: usize, _height: u64) -> anyhow::Result<Vec<Leaf2>> {
-        unreachable!()
+    async fn try_fetch_leaf(
+        &self,
+        retry: usize,
+        height: u64,
+        stake_table: Vec<PeerConfig<SeqTypes>>,
+        success_threshold: U256,
+    ) -> anyhow::Result<Leaf2> {
+        // Try fetching the leaf on all providers
+        self.on_all_providers(move |provider| {
+            // Clone things we need in the closure
+            let stake_table_clone = stake_table.clone();
+
+            async move {
+                provider
+                    .try_fetch_leaf(retry, height, stake_table_clone, success_threshold)
+                    .await
+            }
+        })
+        .await
     }
 
     async fn try_fetch_accounts(
         &self,
-        _retry: usize,
-        _instance: &NodeState,
-        _height: u64,
-        _view: ViewNumber,
-        _fee_merkle_tree_root: FeeMerkleCommitment,
-        _accounts: &[FeeAccount],
-    ) -> anyhow::Result<FeeMerkleTree> {
-        unreachable!()
+        retry: usize,
+        instance: &NodeState,
+        height: u64,
+        view: ViewNumber,
+        fee_merkle_tree_root: FeeMerkleCommitment,
+        accounts: &[FeeAccount],
+    ) -> anyhow::Result<Vec<FeeAccountProof>> {
+        let instance_clone = instance.clone();
+        let accounts_vec = accounts.to_vec();
+        self.on_all_providers(move |provider| {
+            // Clone things we need in the closure
+            let instance_clone = instance_clone.clone();
+            let accounts_clone = accounts_vec.clone();
+
+            async move {
+                provider
+                    .try_fetch_accounts(
+                        retry,
+                        &instance_clone,
+                        height,
+                        view,
+                        fee_merkle_tree_root,
+                        &accounts_clone,
+                    )
+                    .await
+            }
+        })
+        .await
     }
 
     async fn try_remember_blocks_merkle_tree(
         &self,
-        _retry: usize,
-        _instance: &NodeState,
-        _height: u64,
-        _view: ViewNumber,
-        _mt: &mut BlockMerkleTree,
+        retry: usize,
+        instance: &NodeState,
+        height: u64,
+        view: ViewNumber,
+        mt: &mut BlockMerkleTree,
     ) -> anyhow::Result<()> {
-        unreachable!()
+        let mt_clone = mt.clone();
+        let instance_clone = instance.clone();
+
+        let merkle_tree = self
+            .on_all_providers(move |provider| {
+                let instance_clone = instance_clone.clone();
+                let mut mt_clone = mt_clone.clone();
+
+                async move {
+                    provider
+                        .try_remember_blocks_merkle_tree(
+                            retry,
+                            &instance_clone,
+                            height,
+                            view,
+                            &mut mt_clone,
+                        )
+                        .await?;
+                    Ok(mt_clone)
+                }
+            })
+            .await
+            .with_context(|| "failed to remember blocks merkle tree")?;
+
+        // Update the original, local merkle tree
+        *mt = merkle_tree;
+
+        Ok(())
     }
 
     async fn try_fetch_chain_config(
         &self,
-        _retry: usize,
-        _commitment: Commitment<ChainConfig>,
+        retry: usize,
+        commitment: Commitment<ChainConfig>,
     ) -> anyhow::Result<ChainConfig> {
-        unreachable!()
+        self.on_all_providers(move |provider| async move {
+            provider.try_fetch_chain_config(retry, commitment).await
+        })
+        .await
     }
 
-    #[tracing::instrument(skip(self, _instance))]
     async fn try_fetch_reward_accounts(
         &self,
-        _retry: usize,
-        _instance: &NodeState,
-        _height: u64,
-        _view: ViewNumber,
-        _reward_merkle_tree_root: RewardMerkleCommitment,
-        _accounts: &[RewardAccount],
-    ) -> anyhow::Result<RewardMerkleTree> {
-        unreachable!()
+        retry: usize,
+        instance: &NodeState,
+        height: u64,
+        view: ViewNumber,
+        reward_merkle_tree_root: RewardMerkleCommitment,
+        accounts: &[RewardAccount],
+    ) -> anyhow::Result<Vec<RewardAccountProof>> {
+        let instance_clone = instance.clone();
+        let accounts_vec = accounts.to_vec();
+        self.on_all_providers(move |provider| {
+            let instance_clone = instance_clone.clone();
+            let accounts_clone = accounts_vec.clone();
+
+            async move {
+                provider
+                    .try_fetch_reward_accounts(
+                        retry,
+                        &instance_clone,
+                        height,
+                        view,
+                        reward_merkle_tree_root,
+                        &accounts_clone,
+                    )
+                    .await
+            }
+        })
+        .await
     }
 
     fn backoff(&self) -> &BackoffParams {

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -474,7 +474,7 @@ pub async fn init_node<P: SequencerPersistence + MembershipPersistence, V: Versi
     }
 
     // Create the list of parallel catchup providers
-    let state_catchup_providers = ParallelStateCatchup::new(&[], Duration::from_secs(1));
+    let state_catchup_providers = ParallelStateCatchup::new(&[]);
 
     // Add the state peers to the list
     let state_peers = StatePeers::<SequencerApiVersion>::from_urls(
@@ -1162,7 +1162,7 @@ pub mod testing {
             let chain_config = state.chain_config.resolve().unwrap_or_default();
 
             // Create an empty list of catchup providers
-            let catchup_providers = ParallelStateCatchup::new(&[], Duration::from_millis(500));
+            let catchup_providers = ParallelStateCatchup::new(&[]);
 
             // If we have the state peers, add them
             if let Some(state_peers) = state_peers {

--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -383,16 +383,18 @@ impl Upgrade {
 pub mod mock {
     use std::collections::HashMap;
 
+    use alloy::primitives::U256;
+    use anyhow::Context;
     use async_trait::async_trait;
     use committable::Commitment;
-    use hotshot_types::data::ViewNumber;
+    use hotshot_types::{data::ViewNumber, PeerConfig};
     use jf_merkle_tree::{ForgetableMerkleTreeScheme, MerkleTreeScheme};
 
     use super::*;
     use crate::{
         retain_accounts,
-        v0_1::{RewardAccount, RewardMerkleCommitment, RewardMerkleTree},
-        BackoffParams, BlockMerkleTree, FeeAccount, FeeMerkleCommitment, FeeMerkleTree, Leaf2,
+        v0_1::{RewardAccount, RewardAccountProof, RewardMerkleCommitment},
+        BackoffParams, BlockMerkleTree, FeeAccount, FeeAccountProof, FeeMerkleCommitment, Leaf2,
     };
 
     #[derive(Debug, Clone, Default)]
@@ -412,11 +414,13 @@ pub mod mock {
 
     #[async_trait]
     impl StateCatchup for MockStateCatchup {
-        async fn try_fetch_leaves(
+        async fn try_fetch_leaf(
             &self,
             _retry: usize,
             _height: u64,
-        ) -> anyhow::Result<Vec<Leaf2>> {
+            _stake_table: Vec<PeerConfig<SeqTypes>>,
+            _success_threshold: U256,
+        ) -> anyhow::Result<Leaf2> {
             Err(anyhow::anyhow!("todo"))
         }
 
@@ -428,12 +432,26 @@ pub mod mock {
             view: ViewNumber,
             fee_merkle_tree_root: FeeMerkleCommitment,
             accounts: &[FeeAccount],
-        ) -> anyhow::Result<FeeMerkleTree> {
+        ) -> anyhow::Result<Vec<FeeAccountProof>> {
             let src = &self.state[&view].fee_merkle_tree;
             assert_eq!(src.commitment(), fee_merkle_tree_root);
 
             tracing::info!("catchup: fetching accounts {accounts:?} for view {view:?}");
-            retain_accounts(src, accounts.iter().copied())
+            let tree = retain_accounts(src, accounts.iter().copied())
+                .with_context(|| "failed to retain accounts")?;
+
+            // Verify the proofs
+            let mut proofs = Vec::new();
+            for account in accounts {
+                let (proof, _) = FeeAccountProof::prove(&tree, (*account).into())
+                    .context(format!("response missing account {account}"))?;
+                proof
+                    .verify(&fee_merkle_tree_root)
+                    .context(format!("invalid proof for accoujnt {account}"))?;
+                proofs.push(proof);
+            }
+
+            Ok(proofs)
         }
 
         async fn try_remember_blocks_merkle_tree(
@@ -477,7 +495,7 @@ pub mod mock {
             _view: ViewNumber,
             _reward_merkle_tree_root: RewardMerkleCommitment,
             _accounts: &[RewardAccount],
-        ) -> anyhow::Result<RewardMerkleTree> {
+        ) -> anyhow::Result<Vec<RewardAccountProof>> {
             anyhow::bail!("unimplemented")
         }
 

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -23,14 +23,12 @@ use hotshot_types::{
         election::{generate_stake_cdf, select_randomized_leader, RandomizedCommittee},
         DrbResult,
     },
-    message::UpgradeLock,
     stake_table::StakeTableEntry,
     traits::{
         election::Membership,
         node_implementation::{ConsensusTime, NodeType},
         signature_key::StakeTableEntryType,
     },
-    utils::verify_leaf_chain,
     PeerConfig,
 };
 use indexmap::IndexMap;
@@ -46,7 +44,6 @@ use super::{
     v0_99::ChainConfig,
     Header, L1Client, Leaf2, PubKey, SeqTypes,
 };
-use crate::{EpochVersion, SequencerVersions};
 
 type Epoch = <SeqTypes as NodeType>::Epoch;
 
@@ -1290,18 +1287,9 @@ impl Membership<SeqTypes> for EpochCommittees {
             epoch,
             block_height
         );
-        let mut drb_leaf_chain = peers.try_fetch_leaves(1, block_height).await?;
-
-        drb_leaf_chain.sort_by_key(|l| l.view_number());
-        let leaf_chain = drb_leaf_chain.into_iter().rev().collect();
-        let drb_leaf = verify_leaf_chain(
-            leaf_chain,
-            stake_table.clone(),
-            success_threshold,
-            block_height,
-            &UpgradeLock::<SeqTypes, SequencerVersions<EpochVersion, EpochVersion>>::new(),
-        )
-        .await?;
+        let drb_leaf = peers
+            .try_fetch_leaf(1, block_height, stake_table, success_threshold)
+            .await?;
 
         let Some(drb) = drb_leaf.next_drb_result else {
             tracing::error!(


### PR DESCRIPTION
## This PR:
1. Makes all response validation happen in the fallible versions of the `StateCatchup` functions. Before this, we had been doing some validation in the top-level, infallible functions and some in the lower-level ones. This change makes it so all are validated, so a response from `try_xyz` is always already valid
2. Various usability improvements
3. `try_xyz` implementations for `ParallelStateCatchup` and `RequestResponseProtocol` with sane defaults so we don't hit anything `unreachable` if we want to manually use the lower-level functions