### PR TITLE
Catchup for DRB even if add_epoch_root() fails

### DIFF
--- a/crates/hotshot/types/src/epoch_membership.rs
+++ b/crates/hotshot/types/src/epoch_membership.rs
@@ -173,14 +173,15 @@ where
             anytrace::bail!("get epoch root failed for epoch {:?}", root_epoch);
         };
 
-        let updater = self
+        if let Some(updater) = self
             .membership
             .read()
             .await
             .add_epoch_root(epoch, root_leaf.block_header().clone())
             .await
-            .ok_or(anytrace::warn!("add epoch root failed"))?;
-        updater(&mut *(self.membership.write().await));
+        {
+            updater(&mut *(self.membership.write().await));
+        };
 
         let drb_membership = match root_membership.next_epoch_stake_table().await {
             Ok(drb_membership) => drb_membership,


### PR DESCRIPTION
Currently, if add_epoch_root() returns None, we treat it as an error and fail the catchup request. One reason it might return None is if a stake table already exists. This means DRB catchup wouldn't happen, since it only happens if add_epoch_root() returns Some.

This PR fixes that by allowing the DRB catchup even if add_epoch_root() fails (i.e., returns None)