### PR TITLE
staking-cli: support same delegation amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,18 +175,6 @@ In order to profile the gas consumption of the light client contract do the foll
 4. Use the hash of the transaction generated in step two when calling the function `newFinalizedState` in order to
    obtain the gas profile.
 
-## Misc
-
-### Authenticate with GitHub container registry
-
-This is only necessary to fetch private images.
-
-- Go to your github profile
-- Developer Settings > Personal access tokens > Personal access tokens (classic)
-- Generate a new token
-  - for the scope options of the token, tick the _repo_ box.
-- Run `docker login ghcr.io --username <you_github_id> --password <your_personal_access_token>`
-
 # License
 
 ## Copyright

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -666,7 +666,7 @@ pub mod test_helpers {
     use jf_merkle_tree::{MerkleCommitment, MerkleTreeScheme};
     use portpicker::pick_unused_port;
     use sequencer_utils::test_utils::setup_test;
-    use staking_cli::demo::setup_stake_table_contract_for_test;
+    use staking_cli::demo::{setup_stake_table_contract_for_test, DelegationConfig};
     use surf_disco::Client;
     use tempfile::TempDir;
     use tide_disco::{error::ServerError, Api, App, Error, StatusCode};
@@ -798,7 +798,7 @@ pub mod test_helpers {
         /// stake table address to state. Must be called before `build()`.
         pub async fn pos_hook<V: Versions>(
             self,
-            multiple_delegators: bool,
+            delegation_config: DelegationConfig,
         ) -> anyhow::Result<Self> {
             if <V as Versions>::Upgrade::VERSION < EpochVersion::VERSION
                 && <V as Versions>::Base::VERSION < EpochVersion::VERSION
@@ -851,7 +851,7 @@ pub mod test_helpers {
                 stake_table_address,
                 token_addr,
                 network_config.staking_priv_keys(),
-                multiple_delegators,
+                delegation_config,
             )
             .await
             .expect("stake table setup failed");
@@ -1885,6 +1885,7 @@ mod test {
     use jf_merkle_tree::prelude::{MerkleProof, Sha3Node};
     use portpicker::pick_unused_port;
     use sequencer_utils::test_utils::setup_test;
+    use staking_cli::demo::DelegationConfig;
     use surf_disco::Client;
     use test_helpers::{
         catchup_test_helper, state_signature_test_helper, status_test_helper, submit_test_helper,
@@ -3021,7 +3022,7 @@ mod test {
         let config = TestNetworkConfigBuilder::default()
             .api_config(options)
             .network_config(network_config.clone())
-            .pos_hook::<PosVersion>(false)
+            .pos_hook::<PosVersion>(DelegationConfig::VariableAmounts)
             .await
             .expect("Pos Deployment")
             .build();
@@ -3120,7 +3121,7 @@ mod test {
                     &NoMetrics,
                 )
             }))
-            .pos_hook::<PosVersion>(false)
+            .pos_hook::<PosVersion>(DelegationConfig::VariableAmounts)
             .await
             .unwrap()
             .build();
@@ -3212,7 +3213,7 @@ mod test {
                     &NoMetrics,
                 )
             }))
-            .pos_hook::<PosVersion>(true)
+            .pos_hook::<PosVersion>(DelegationConfig::MultipleDelegators)
             .await
             .unwrap()
             .build();
@@ -3331,7 +3332,7 @@ mod test {
                     &NoMetrics,
                 )
             }))
-            .pos_hook::<PosVersion>(true)
+            .pos_hook::<PosVersion>(DelegationConfig::MultipleDelegators)
             .await
             .unwrap()
             .build();
@@ -3439,7 +3440,7 @@ mod test {
                     &NoMetrics,
                 )
             }))
-            .pos_hook::<PosVersion>(true)
+            .pos_hook::<PosVersion>(DelegationConfig::MultipleDelegators)
             .await
             .unwrap()
             .build();

--- a/sequencer/src/bin/espresso-dev-node.rs
+++ b/sequencer/src/bin/espresso-dev-node.rs
@@ -43,7 +43,7 @@ use sequencer::{
 };
 use sequencer_utils::logging;
 use serde::{Deserialize, Serialize};
-use staking_cli::demo::setup_stake_table_contract_for_test;
+use staking_cli::demo::{setup_stake_table_contract_for_test, DelegationConfig};
 use tempfile::NamedTempFile;
 use tide_disco::{error::ServerError, method::ReadState, Api, Error as _, StatusCode};
 use tokio::spawn;
@@ -502,7 +502,7 @@ async fn main() -> anyhow::Result<()> {
                     .address(Contract::EspTokenProxy)
                     .expect("ESP token deployed"),
                 staking_priv_keys,
-                false,
+                DelegationConfig::default(),
             )
             .await?;
         }

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -679,7 +679,7 @@ pub mod testing {
     use portpicker::pick_unused_port;
     use rand::SeedableRng as _;
     use rand_chacha::ChaCha20Rng;
-    use staking_cli::demo::setup_stake_table_contract_for_test;
+    use staking_cli::demo::{setup_stake_table_contract_for_test, DelegationConfig};
     use tokio::spawn;
     use vbs::version::Version;
 
@@ -984,7 +984,7 @@ pub mod testing {
                         st_addr,
                         token_addr,
                         validators,
-                        false,
+                        DelegationConfig::default(),
                     )
                     .await
                     .expect("stake table setup failed");

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -88,6 +88,7 @@ mod persistence_tests {
     use indexmap::IndexMap;
     use portpicker::pick_unused_port;
     use sequencer_utils::test_utils::setup_test;
+    use staking_cli::demo::DelegationConfig;
     use surf_disco::Client;
     use testing::TestablePersistence;
     use tide_disco::error::ServerError;
@@ -1179,7 +1180,7 @@ mod persistence_tests {
             .api_config(query_api_options)
             .network_config(network_config.clone())
             .persistences(persistence_options.clone())
-            .pos_hook::<PosVersion>(true)
+            .pos_hook::<PosVersion>(DelegationConfig::MultipleDelegators)
             .await
             .expect("Pos deployment failed")
             .build();
@@ -1340,7 +1341,7 @@ mod persistence_tests {
             .api_config(query_api_options)
             .network_config(network_config.clone())
             .persistences(persistence_options.clone())
-            .pos_hook::<PosVersion>(true)
+            .pos_hook::<PosVersion>(DelegationConfig::MultipleDelegators)
             .await
             .expect("Pos deployment failed")
             .build();

--- a/staking-cli/DEVELOPER_DOCS.md
+++ b/staking-cli/DEVELOPER_DOCS.md
@@ -1,0 +1,31 @@
+# staking-cli Developer Docs
+
+The staking-cli can be used to fund the stake table on L1 for our testnet and demos.
+
+```
+cargo run --bin staking-cli -- stake-for-demo --help
+
+Usage: staking-cli stake-for-demo [OPTIONS]
+
+Options:
+      --num-validators <NUM_VALIDATORS>
+          The number of validators to register.
+
+          The default (5) works for the local native and docker demos.
+
+          [default: 5]
+
+      --delegation-config <DELEGATION_CONFIG>
+          [default: VariableAmounts]
+          [possible values: equal-amounts, variable-amounts, multiple-delegators]
+
+  -h, --help
+          Print help (see a summary with '-h')
+```
+
+Currently supported are these delegation configurations:
+
+1. Equal amounts: each validator self delegates an equal amount. Leading to uniform staking weights.
+2. Variable amounts: validator delegate 100, 200, ..., 500 ESP tokens in order. This is currently the default because it
+   used to be the only option.
+3. Multiple delegators: Like 2, but also adds a randomly chosen number of other delegators to each validator.

--- a/staking-cli/src/lib.rs
+++ b/staking-cli/src/lib.rs
@@ -10,6 +10,7 @@ use alloy::{
 use anyhow::{bail, Result};
 use clap::{Parser, Subcommand};
 use clap_serde_derive::ClapSerde;
+use demo::DelegationConfig;
 pub(crate) use hotshot_types::{
     light_client::{StateSignKey, StateVerKey},
     signature_key::BLSPrivKey,
@@ -330,5 +331,8 @@ pub enum Commands {
         /// The default (5) works for the local native and docker demos.
         #[clap(long, default_value_t = 5)]
         num_validators: u16,
+
+        #[arg(long, value_enum, default_value_t = DelegationConfig::default())]
+        delegation_config: DelegationConfig,
     },
 }

--- a/staking-cli/src/main.rs
+++ b/staking-cli/src/main.rs
@@ -308,9 +308,16 @@ pub async fn main() -> Result<()> {
             tracing::info!("Claiming validator exit for {validator_address}");
             claim_validator_exit(&provider, stake_table_addr, validator_address).await
         },
-        Commands::StakeForDemo { num_validators } => {
-            tracing::info!("Staking for demo with {num_validators} validators");
-            stake_for_demo(&config, num_validators).await.unwrap();
+        Commands::StakeForDemo {
+            num_validators,
+            delegation_config,
+        } => {
+            tracing::info!(
+                "Staking for demo with {num_validators} validators and config {delegation_config}"
+            );
+            stake_for_demo(&config, num_validators, delegation_config)
+                .await
+                .unwrap();
             return Ok(());
         },
         Commands::TokenBalance { address } => {

--- a/staking-cli/src/registration.rs
+++ b/staking-cli/src/registration.rs
@@ -98,8 +98,7 @@ mod test {
         let system = TestSystem::deploy().await?;
         let validator_address = system.deployer_address;
         let (bls_vk_sol, _) = prepare_bls_payload(&system.bls_key_pair, validator_address);
-        let schnorr_vk_sol: EdOnBN254PointSol =
-            system.schnorr_key_pair.ver_key().to_affine().into();
+        let schnorr_vk_sol: EdOnBN254PointSol = system.state_key_pair.ver_key().to_affine().into();
 
         let receipt = register_validator(
             &system.provider,
@@ -107,7 +106,7 @@ mod test {
             system.commission,
             validator_address,
             system.bls_key_pair,
-            system.schnorr_key_pair.ver_key(),
+            system.state_key_pair.ver_key(),
         )
         .await?;
         assert!(receipt.status());
@@ -145,7 +144,7 @@ mod test {
         system.register_validator().await?;
         let validator_address = system.deployer_address;
         let mut rng = StdRng::from_seed([43u8; 32]);
-        let (new_bls, new_schnorr) = TestSystem::gen_consensus_keys(&mut rng);
+        let (_, new_bls, new_schnorr) = TestSystem::gen_keys(&mut rng);
         let (bls_vk_sol, _) = prepare_bls_payload(&new_bls, validator_address);
         let schnorr_vk_sol: EdOnBN254PointSol = new_schnorr.ver_key().to_affine().into();
 


### PR DESCRIPTION
- Adds a delegation config flag to the CLI
- Support self delegations with fixed and variable amounts, or multiple delegators.
- Add basic tests to check that demo staking functions are doing what's expected


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210196463141202