### PR TITLE
CI: aggregate test jobs for GCL and hotshot

### DIFF
--- a/.github/workflows/hotshot.yml
+++ b/.github/workflows/hotshot.yml
@@ -109,9 +109,9 @@ jobs:
           echo "All results: ${{ toJson(needs) }}"
 
           if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
-            echo "All jobs succeeded."
-            exit 0
-          else
             echo "One or more jobs failed."
             exit 1
+          else
+            echo "All jobs succeeded."
+            exit 0
           fi

--- a/.github/workflows/hotshot.yml
+++ b/.github/workflows/hotshot.yml
@@ -101,7 +101,8 @@ jobs:
   aggregate-hotshot-tests:
     needs: [test, test-examples]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    # explicitly run and fail the job if dependencies failed
+    if: ${{ always() && !cancelled() }}
     steps:
       - name: Aggregate hotshot test results
         run: |

--- a/.github/workflows/hotshot.yml
+++ b/.github/workflows/hotshot.yml
@@ -96,3 +96,22 @@ jobs:
         run: |
           just hotshot::example all-push-cdn -- --config_file ./crates/hotshot/orchestrator/run-config.toml
         timeout-minutes: 20
+
+  # This job enables having a single required status check in github for all hotshot tests.
+  aggregate-hotshot-tests:
+    needs: [test, test-examples]
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Aggregate hotshot test results
+        run: |
+          # useful for debugging
+          echo "All results: ${{ toJson(needs) }}"
+
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "All jobs succeeded."
+            exit 0
+          else
+            echo "One or more jobs failed."
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,7 +300,8 @@ jobs:
   aggregate-gcl-tests:
     needs: [test-postgres, test-sqlite, demo-native, test-integration]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    # explicitly run and fail the job if dependencies failed
+    if: ${{ always() && !cancelled() }}
     steps:
       - name: Aggregate GCL test results
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -308,9 +308,9 @@ jobs:
           echo "All results: ${{ toJson(needs) }}"
 
           if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
-            echo "All jobs succeeded."
-            exit 0
-          else
             echo "One or more jobs failed."
             exit 1
+          else
+            echo "All jobs succeeded."
+            exit 0
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -295,3 +295,22 @@ jobs:
           set -o pipefail
           scripts/demo-native --tui=false &
           timeout -v 600 scripts/smoke-test-demo | sed -e 's/^/smoke-test: /;'
+
+  # This job enables having a single required status check in github for all GCL tests.
+  aggregate-gcl-tests:
+    needs: [test-postgres, test-sqlite, demo-native, test-integration]
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Aggregate GCL test results
+        run: |
+          # useful for debugging
+          echo "All results: ${{ toJson(needs) }}"
+
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "All jobs succeeded."
+            exit 0
+          else
+            echo "One or more jobs failed."
+            exit 1
+          fi


### PR DESCRIPTION
### Motivation

Github doesn't allow us to require status checks of a matrix (parent) job. We have to set a required check for each matrix value. This doesn't work with dynamic matrices and is also a pain to maintain. This change alleviates the problems by exposing a single job we can require for hotshot and the GCL tests each.

### Notes

I have manually tested this here if anyone wants to take a look

https://github.com/sveitser/gha-test/actions/runs/14967245670

The aggregate job seems to fail consistently if any of the dependencies are cancelled or fail and succeeds once all the dependent matrix jobs pass.

After we merge this we can require `aggregate-hotshot-tests` and `aggregate-gcl-tests` to pass for our branch rules and we can drop the other test job requirements (except for `test-demo` which is it's own job that runs after building in `build.yml`).