### PR TITLE
CI: build sqlite test binaries with test profile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          cache-all-crates: true
+          prefix-key: v1-rust
           cache-provider: github
 
       - name: Show memory
@@ -74,7 +74,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          cache-all-crates: true
+          prefix-key: v1-rust
           cache-provider: github
 
       - name: Show memory
@@ -106,14 +106,18 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          cache-all-crates: true
+          prefix-key: v1-rust
           cache-provider: github
 
-      - name: Build Bins
+      - name: Build binaries (postgres)
         run: |
           cargo build --locked --profile test --bins
-          cargo build --manifest-path ./sequencer-sqlite/Cargo.toml --target-dir ./target
         timeout-minutes: 60
+
+      - name: Build binaries (sqlite)
+        run: |
+          cargo build --locked --profile test --manifest-path ./sequencer-sqlite/Cargo.toml --target-dir ./target
+        timeout-minutes: 30
 
       - name: Upload archive to workflow
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Use `test` profile for sequencer-sqlite to match other jobs. This will enable a bit of optimizations which is useful and should require less re-compiliaton because it now matches the the profile for the postgres build.
- Remove `cache-all-crates`, it's not clear this helps and probably makes the cache bigger than necessary. Will revert this if found to be worse.
- Separate the two cargo build invocations to make to make CI logs easier to read.

I hope this will also help with the view timeouts due to resource constraints in:

- #3245 
