### PR TITLE
fix: demo sometimes deploys contracts to early

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,6 +300,13 @@ jobs:
           scripts/demo-native --tui=false &
           timeout -v 600 scripts/smoke-test-demo | sed -e 's/^/smoke-test: /;'
 
+      - name: Upload process compose logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: process-compose-logs-test-demo-native
+          path: ${{ env.PC_LOGS }}
+
   # This job enables having a single required status check in github for all GCL tests.
   aggregate-gcl-tests:
     needs: [test-postgres, test-sqlite, demo-native, test-integration]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,8 @@ env:
   RUST_LOG: info,libp2p=off,node=error
   CARGO_TERM_COLOR: always
   # Save the process compose logs
-  PC_LOGS: /tmp/pc.log
+  NATIVE_DEMO_LOGS: /tmp/native-demo.log
+  PC_LOG_FILE: /tmp/pc-logs.log
 
 jobs:
   build-test-artifacts-postgres:
@@ -261,14 +262,14 @@ jobs:
       - name: Show end of logs
         if: always()
         run: |
-          tail -n 1000 ${{ env.PC_LOGS }}
+          tail -n 1000 ${{ env.NATIVE_DEMO_LOGS }}
 
       - name: Upload process compose logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: process-compose-logs-integration-v${{ matrix.version  }}
-          path: ${{ env.PC_LOGS }}
+          path: ${{ env.NATIVE_DEMO_LOGS }}
 
 
   demo-native:
@@ -305,7 +306,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: process-compose-logs-test-demo-native
-          path: ${{ env.PC_LOGS }}
+          path: ${{ env.PC_LOG_FILE }}
 
   # This job enables having a single required status check in github for all GCL tests.
   aggregate-gcl-tests:

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ doc *args:
 demo *args:
     docker compose up {{args}}
 
-demo-native *args: build
+demo-native *args: (build "test")
     scripts/demo-native {{args}}
 
 fmt:

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -17,7 +17,10 @@ processes:
     command: docker compose up demo-l1-network --force-recreate --renew-anon-volumes
     readiness_probe:
       exec:
-        command: nc -zv localhost $ESPRESSO_SEQUENCER_L1_PORT
+        command: >
+          curl -H "Content-Type: application/json"
+          --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
+          ESPRESSO_SEQUENCER_L1_PROVIDER
       failure_threshold: 6
       initial_delay_seconds: 5
 

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -20,7 +20,7 @@ processes:
         command: >
           curl -H "Content-Type: application/json"
           --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
-          ESPRESSO_SEQUENCER_L1_PROVIDER
+          $ESPRESSO_SEQUENCER_L1_PROVIDER
       failure_threshold: 6
       initial_delay_seconds: 5
 

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -17,10 +17,10 @@ processes:
     command: docker compose up demo-l1-network --force-recreate --renew-anon-volumes
     readiness_probe:
       exec:
-        command: >
+        command: >-
           curl -H "Content-Type: application/json"
           --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
-          $ESPRESSO_SEQUENCER_L1_PROVIDER
+          http://localhost:$ESPRESSO_SEQUENCER_L1_PORT
       failure_threshold: 6
       initial_delay_seconds: 5
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -335,7 +335,7 @@ impl NativeDemo {
         }
 
         // Save output to file if PC_LOGS if that's set.
-        let log_path = std::env::var("PC_LOGS").unwrap_or_else(|_| {
+        let log_path = std::env::var("NATIVE_DEMO_LOGS").unwrap_or_else(|_| {
             tempfile::NamedTempFile::new()
                 .expect("tempfile creation succeeds")
                 .into_temp_path()


### PR DESCRIPTION
Using netcat to wait for the socket being open is not sufficient. We should wait until the RPC is actually responding.

Also noticed that by default the demo-native recipe builds the binaries with the dev profile which is known to be very wasteful and cause issues. This changes the default to the "test" profile which works much better due to having some optimizations turned on.
