### PR TITLE
update rust 1.86 -> 1.87, fix clippy

### DIFF
--- a/builder/src/non_permissioned.rs
+++ b/builder/src/non_permissioned.rs
@@ -247,7 +247,7 @@ mod test {
             test_helpers::{TestNetwork, TestNetworkConfigBuilder},
             Options,
         },
-        persistence::{self},
+        persistence,
         testing::TestConfigBuilder,
     };
     use sequencer_utils::test_utils::setup_test;

--- a/crates/hotshot/hotshot-fakeapi/src/fake_solver.rs
+++ b/crates/hotshot/hotshot-fakeapi/src/fake_solver.rs
@@ -1,7 +1,4 @@
-use std::{
-    io::{self},
-    time,
-};
+use std::{io, time};
 
 use anyhow::Result;
 use async_lock::RwLock;

--- a/crates/hotshot/hotshot-fakeapi/src/fake_solver.rs
+++ b/crates/hotshot/hotshot-fakeapi/src/fake_solver.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{self, ErrorKind},
+    io::{self},
     time,
 };
 
@@ -55,7 +55,7 @@ impl FakeSolverState {
     /// This panics if unable to register the api with tide disco
     pub async fn run<TYPES: NodeType>(self, url: Url) -> io::Result<()> {
         let solver_api = define_api::<TYPES, RwLock<FakeSolverState>, StaticVersion<0, 1>>()
-            .map_err(|_e| io::Error::new(ErrorKind::Other, "Failed to define api"))?;
+            .map_err(|_e| io::Error::other("Failed to define api"))?;
         let state = RwLock::new(self);
         let mut app = App::<RwLock<FakeSolverState>, ServerError>::with_state(state);
         app.register_module::<ServerError, StaticVersion<0, 1>>("api", solver_api)

--- a/crates/hotshot/libp2p-networking/src/network/cbor.rs
+++ b/crates/hotshot/libp2p-networking/src/network/cbor.rs
@@ -125,7 +125,7 @@ where
 fn decode_into_io_error(err: cbor4ii::serde::DecodeError<Infallible>) -> io::Error {
     match err {
         cbor4ii::serde::DecodeError::Core(DecodeError::Read(e)) => {
-            io::Error::new(io::ErrorKind::Other, e.to_string())
+            io::Error::other(e.to_string())
         },
         cbor4ii::serde::DecodeError::Core(e @ DecodeError::Unsupported { .. }) => {
             io::Error::new(io::ErrorKind::Unsupported, e.to_string())
@@ -137,12 +137,12 @@ fn decode_into_io_error(err: cbor4ii::serde::DecodeError<Infallible>) -> io::Err
             io::Error::new(io::ErrorKind::InvalidData, e.to_string())
         },
         cbor4ii::serde::DecodeError::Custom(e) => {
-            io::Error::new(io::ErrorKind::Other, e.to_string())
+            io::Error::other(e.to_string())
         },
     }
 }
 
 /// Convert a `cbor4ii::serde::EncodeError` into an `io::Error`
 fn encode_into_io_error(err: cbor4ii::serde::EncodeError<TryReserveError>) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, err)
+    io::Error::other(err)
 }

--- a/crates/hotshot/libp2p-networking/src/network/cbor.rs
+++ b/crates/hotshot/libp2p-networking/src/network/cbor.rs
@@ -124,9 +124,7 @@ where
 /// Convert a `cbor4ii::serde::DecodeError` into an `io::Error`
 fn decode_into_io_error(err: cbor4ii::serde::DecodeError<Infallible>) -> io::Error {
     match err {
-        cbor4ii::serde::DecodeError::Core(DecodeError::Read(e)) => {
-            io::Error::other(e.to_string())
-        },
+        cbor4ii::serde::DecodeError::Core(DecodeError::Read(e)) => io::Error::other(e.to_string()),
         cbor4ii::serde::DecodeError::Core(e @ DecodeError::Unsupported { .. }) => {
             io::Error::new(io::ErrorKind::Unsupported, e.to_string())
         },
@@ -136,9 +134,7 @@ fn decode_into_io_error(err: cbor4ii::serde::DecodeError<Infallible>) -> io::Err
         cbor4ii::serde::DecodeError::Core(e) => {
             io::Error::new(io::ErrorKind::InvalidData, e.to_string())
         },
-        cbor4ii::serde::DecodeError::Custom(e) => {
-            io::Error::other(e.to_string())
-        },
+        cbor4ii::serde::DecodeError::Custom(e) => io::Error::other(e.to_string()),
     }
 }
 

--- a/crates/hotshot/libp2p-networking/src/network/transport.rs
+++ b/crates/hotshot/libp2p-networking/src/network/transport.rs
@@ -173,7 +173,7 @@ impl<T: Transport, Types: NodeType, C: StreamMuxer + Unpin> StakeTableAuthentica
                         .await
                         .map_err(|e| {
                             warn!("Failed to authenticate with remote peer: {:?}", e);
-                            IoError::new(IoErrorKind::Other, e)
+                            IoError::other(e)
                         })?;
 
                     // Verify the remote peer's authentication
@@ -185,7 +185,7 @@ impl<T: Transport, Types: NodeType, C: StreamMuxer + Unpin> StakeTableAuthentica
                     .await
                     .map_err(|e| {
                         warn!("Failed to verify remote peer: {:?}", e);
-                        IoError::new(IoErrorKind::Other, e)
+                        IoError::other(e)
                     })?;
                 } else {
                     // If it is incoming, verify the remote peer's authentication first
@@ -197,7 +197,7 @@ impl<T: Transport, Types: NodeType, C: StreamMuxer + Unpin> StakeTableAuthentica
                     .await
                     .map_err(|e| {
                         warn!("Failed to verify remote peer: {:?}", e);
-                        IoError::new(IoErrorKind::Other, e)
+                        IoError::other(e)
                     })?;
 
                     // Authenticate with the remote peer
@@ -205,7 +205,7 @@ impl<T: Transport, Types: NodeType, C: StreamMuxer + Unpin> StakeTableAuthentica
                         .await
                         .map_err(|e| {
                             warn!("Failed to authenticate with remote peer: {:?}", e);
-                            IoError::new(IoErrorKind::Other, e)
+                            IoError::other(e)
                         })?;
                 }
 

--- a/crates/hotshot/orchestrator/src/lib.rs
+++ b/crates/hotshot/orchestrator/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     collections::{HashMap, HashSet},
     fs,
     fs::OpenOptions,
-    io::{self},
+    io,
     time::Duration,
 };
 
@@ -877,8 +877,7 @@ where
         })
         .collect();
 
-    let web_api =
-        define_api().map_err(|_e| io::Error::other("Failed to define api"));
+    let web_api = define_api().map_err(|_e| io::Error::other("Failed to define api"));
 
     let state: RwLock<OrchestratorState<TYPES>> =
         RwLock::new(OrchestratorState::new(network_config));

--- a/crates/hotshot/orchestrator/src/lib.rs
+++ b/crates/hotshot/orchestrator/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     collections::{HashMap, HashSet},
     fs,
     fs::OpenOptions,
-    io::{self, ErrorKind},
+    io::{self},
     time::Duration,
 };
 
@@ -878,7 +878,7 @@ where
         .collect();
 
     let web_api =
-        define_api().map_err(|_e| io::Error::new(ErrorKind::Other, "Failed to define api"));
+        define_api().map_err(|_e| io::Error::other("Failed to define api"));
 
     let state: RwLock<OrchestratorState<TYPES>> =
         RwLock::new(OrchestratorState::new(network_config));

--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1736320768,
-        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -331,11 +331,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1744684506,
-        "narHash": "sha256-pDPDMT1rdkTWi8MIoZ67gT3L817R7P0Jo+PP+BrnyJI=",
+        "lastModified": 1747363019,
+        "narHash": "sha256-N4dwkRBmpOosa4gfFkFf/LTD8oOcNkAyvZ07JvRDEf0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "47beae969336c05e892e1e4a9dbaac9593de34ab",
+        "rev": "0e624f2b1972a34be1a9b35290ed18ea4b419b6f",
         "type": "github"
       },
       "original": {

--- a/hotshot-query-service/src/data_source/sql.rs
+++ b/hotshot-query-service/src/data_source/sql.rs
@@ -18,7 +18,7 @@ pub use refinery::Migration;
 pub use sql::Transaction;
 
 use super::{
-    fetching::{self},
+    fetching,
     storage::sql::{self, SqlStorage},
     AvailabilityProvider, FetchingDataSource,
 };

--- a/hotshot-state-prover/src/service.rs
+++ b/hotshot-state-prover/src/service.rs
@@ -583,15 +583,13 @@ fn start_http_server<ApiVer: StaticVersionType + 'static>(
     let toml = toml::from_str::<toml::value::Value>(include_str!("../api/prover-service.toml"))
         .map_err(io::Error::other)?;
 
-    let mut api = Api::<_, ServerError, ApiVer>::new(toml)
-        .map_err(io::Error::other)?;
+    let mut api = Api::<_, ServerError, ApiVer>::new(toml).map_err(io::Error::other)?;
 
     api.get("getlightclientcontract", move |_, _| {
         async move { Ok(light_client_address) }.boxed()
     })
     .map_err(io::Error::other)?;
-    app.register_module("api", api)
-        .map_err(io::Error::other)?;
+    app.register_module("api", api).map_err(io::Error::other)?;
 
     spawn(app.serve(format!("0.0.0.0:{port}"), bind_version));
     Ok(())

--- a/hotshot-state-prover/src/service.rs
+++ b/hotshot-state-prover/src/service.rs
@@ -581,17 +581,17 @@ fn start_http_server<ApiVer: StaticVersionType + 'static>(
 ) -> io::Result<()> {
     let mut app = tide_disco::App::<_, ServerError>::with_state(());
     let toml = toml::from_str::<toml::value::Value>(include_str!("../api/prover-service.toml"))
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        .map_err(io::Error::other)?;
 
     let mut api = Api::<_, ServerError, ApiVer>::new(toml)
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        .map_err(io::Error::other)?;
 
     api.get("getlightclientcontract", move |_, _| {
         async move { Ok(light_client_address) }.boxed()
     })
-    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+    .map_err(io::Error::other)?;
     app.register_module("api", api)
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        .map_err(io::Error::other)?;
 
     spawn(app.serve(format!("0.0.0.0:{port}"), bind_version));
     Ok(())

--- a/sequencer/src/api/data_source.rs
+++ b/sequencer/src/api/data_source.rs
@@ -37,10 +37,7 @@ use super::{
     options::{Options, Query},
     sql, AccountQueryData, BlocksFrontier,
 };
-use crate::{
-    persistence::{self},
-    SeqTypes, SequencerApiVersion,
-};
+use crate::{persistence, SeqTypes, SequencerApiVersion};
 
 pub trait DataSourceOptions: PersistenceOptions {
     type DataSource: SequencerDataSource<Options = Self>;

--- a/sequencer/src/bin/espresso-dev-node.rs
+++ b/sequencer/src/bin/espresso-dev-node.rs
@@ -784,8 +784,7 @@ async fn run_dev_node_server<ApiVer: StaticVersionType + 'static>(
         toml::from_str::<toml::value::Value>(include_str!("../../api/espresso_dev_node.toml"))
             .map_err(io::Error::other)?;
 
-    let mut api = Api::<_, ServerError, ApiVer>::new(toml)
-        .map_err(io::Error::other)?;
+    let mut api = Api::<_, ServerError, ApiVer>::new(toml).map_err(io::Error::other)?;
     api.get("devinfo", move |_, _| {
         let info = dev_info.clone();
         async move { Ok(info.clone()) }.boxed()
@@ -841,8 +840,7 @@ async fn run_dev_node_server<ApiVer: StaticVersionType + 'static>(
     })
     .map_err(io::Error::other)?;
 
-    app.register_module("api", api)
-        .map_err(io::Error::other)?;
+    app.register_module("api", api).map_err(io::Error::other)?;
 
     tracing::info!("Starting dev-node API on http://0.0.0.0:{port}");
 

--- a/sequencer/src/bin/espresso-dev-node.rs
+++ b/sequencer/src/bin/espresso-dev-node.rs
@@ -782,15 +782,15 @@ async fn run_dev_node_server<ApiVer: StaticVersionType + 'static>(
     let mut app = tide_disco::App::<_, ServerError>::with_state(client_states);
     let toml =
         toml::from_str::<toml::value::Value>(include_str!("../../api/espresso_dev_node.toml"))
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+            .map_err(io::Error::other)?;
 
     let mut api = Api::<_, ServerError, ApiVer>::new(toml)
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        .map_err(io::Error::other)?;
     api.get("devinfo", move |_, _| {
         let info = dev_info.clone();
         async move { Ok(info.clone()) }.boxed()
     })
-    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?
+    .map_err(io::Error::other)?
     .at("sethotshotdown", move |req, state: &ApiState| {
         async move {
             let body = req
@@ -814,7 +814,7 @@ async fn run_dev_node_server<ApiVer: StaticVersionType + 'static>(
         }
         .boxed()
     })
-    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?
+    .map_err(io::Error::other)?
     .at("sethotshotup", move |req, state| {
         async move {
             let chain_id = req
@@ -839,10 +839,10 @@ async fn run_dev_node_server<ApiVer: StaticVersionType + 'static>(
         }
         .boxed()
     })
-    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+    .map_err(io::Error::other)?;
 
     app.register_module("api", api)
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        .map_err(io::Error::other)?;
 
     tracing::info!("Starting dev-node API on http://0.0.0.0:{port}");
 

--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -509,7 +509,7 @@ impl Inner {
         if self.legacy_anchor_leaf_path().is_file() {
             // We may have an old version of storage, where there is just a single file for the
             // anchor leaf. Read it and return the contents.
-            let mut file = File::open(self.legacy_anchor_leaf_path())?;
+            let mut file = BufReader::new(File::open(self.legacy_anchor_leaf_path())?);
 
             // The first 8 bytes just contain the height of the leaf. We can skip this.
             file.seek(SeekFrom::Start(8)).context("seek")?;

--- a/types/src/v0/impls/state.rs
+++ b/types/src/v0/impls/state.rs
@@ -1069,7 +1069,6 @@ impl HotShotState<SeqTypes> for ValidatedState {
         }
     }
     /// Construct a genesis validated state.
-    #[must_use]
     fn genesis(instance: &Self::Instance) -> (Self, Self::Delta) {
         (instance.genesis_state.clone(), Delta::default())
     }

--- a/vid/src/avid_m.rs
+++ b/vid/src/avid_m.rs
@@ -242,7 +242,7 @@ impl AvidMScheme {
                 "Weight distribution is inconsistent with the given param".to_string(),
             ));
         }
-        if distribution.iter().any(|&w| w == 0) {
+        if distribution.contains(&0) {
             return Err(VidError::Argument("Weight cannot be zero".to_string()));
         }
 


### PR DESCRIPTION
- Update rust in flake.nix

Clippy fixes:

- remove a `must_use` that has no effect.
- replace some single case matches with `if let`
- use `Error::other` instead of `Error::new(ErrorKindOther, ...)`
- wrap `File` in `BufReader` to avoid infficient byte by byte read
- replace `distribution.iter().any(...)` with `.contains(...)`
