### PR TITLE
cargo: only optimize dependencies for test profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,10 +243,18 @@ inherits = "dev"
 strip = "none"
 debug = "full"
 
-# Optimize dependencies, but not crates in the workspace. Compilation of dependencies can be cached
+# Don't optimize the binaries in the workspace. Compilation of dependencies can be cached
 # effectively on the CI because they rarely change, whereas the workspace code usually changes and
-# workspace compilation artifacts are therefore not cached.
-[profile.test.package."*"]
-opt-level = 3
+# workspace compilation artifacts are therefore not cached. However, some of our tests don't work if
+# we don't have any optimizations in the workspace.
+[profile.test]
+opt-level = 1
+
+[profile.test.package.sequencer]
+opt-level = 0
+
+[profile.test.package.hotshot-testing]
+opt-level = 0
+
 [profile.test.package.hotshot-state-prover]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,11 +243,10 @@ inherits = "dev"
 strip = "none"
 debug = "full"
 
-[profile.test]
-opt-level = 1
-[profile.test.package.tests]
-opt-level = 0
-[profile.test.package.client]
-opt-level = 0
+# Optimize dependencies, but not crates in the workspace. Compilation of dependencies can be cached
+# effectively on the CI because they rarely change, whereas the workspace code usually changes and
+# workspace compilation artifacts are therefore not cached.
+[profile.test.package."*"]
+opt-level = 3
 [profile.test.package.hotshot-state-prover]
 opt-level = 3


### PR DESCRIPTION
Bit difficult to see what's improved here but for example

- `test_epochs_failures` compilation goes from about 5 minutes to 2 min.
- sequencer build test binaries: 13 min to 10 min
- sequencer build test artifacts: [17min](https://github.com/EspressoSystems/espresso-network/actions/runs/15109605260/job/42465865249) to [12 min](https://github.com/EspressoSystems/espresso-network/actions/runs/15112571030/job/42475247035?pr=3287)