### PR TITLE
Remove unnecessary `dead_code` cfg

### DIFF
--- a/contracts/rust/adapter/src/jellyfish.rs
+++ b/contracts/rust/adapter/src/jellyfish.rs
@@ -459,7 +459,6 @@ impl From<ChallengesSol> for Challenges<Fr> {
 
 impl ChallengesSol {
     /// dummy challenges
-    #[allow(dead_code)]
     pub fn dummy<R: Rng>(rng: &mut R) -> Self {
         let alpha = Fr::rand(rng);
         let alpha_2 = alpha * alpha;


### PR DESCRIPTION
`ChallengesSol` is already public, as such, `pub fn dummy` doesn't need a `dead_code` flag.