### PR TITLE
CI: split build jobs

### DIFF
--- a/.github/workflows/build-without-lockfile.yml
+++ b/.github/workflows/build-without-lockfile.yml
@@ -28,11 +28,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Enable Rust Caching
-        uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: v1-rust
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # NOTE: no rust cache, this isn't a time critical job
 
       - name: Build without committed Cargo.lock
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,23 +46,7 @@ jobs:
 
       - name: Build ${{ matrix.binary }}
         run: |
-          case "${{ matrix.binary }}" in
-            "sequencer")
-              cargo build --locked --release --bin sequencer
-              ;;
-            "sequencer-sqlite")
-              cargo build --locked --release --manifest-path ./sequencer-sqlite/Cargo.toml --target-dir ./target
-              ;;
-            "espresso-dev-node")
-              cargo build --locked --release --features "embedded-db testing" --bin espresso-dev-node
-              ;;
-            "other")
-              cargo build --locked --release --workspace \
-                --exclude sequencer \
-                --exclude espresso-dev-node \
-                --exclude sequencer-sqlite
-              ;;
-          esac
+          scripts/ci-build-binary ${{ matrix.binary }}
 
       - name: Move binaries to upload directory
         shell: bash
@@ -106,23 +90,7 @@ jobs:
 
       - name: Build ${{ matrix.binary }}
         run: |
-          case "${{ matrix.binary }}" in
-            "sequencer")
-              cargo build --locked --release --bin sequencer
-              ;;
-            "sequencer-sqlite")
-              cargo build --locked --release --manifest-path ./sequencer-sqlite/Cargo.toml
-              ;;
-            "espresso-dev-node")
-              cargo build --locked --release --features "embedded-db testing" --bin espresso-dev-node
-              ;;
-            "other")
-              cargo build --locked --release --workspace \
-                --exclude sequencer \
-                --exclude espresso-dev-node \
-                --exclude sequencer-sqlite
-              ;;
-          esac
+          scripts/ci-build-binary ${{ matrix.binary }}
 
       - name: Move binaries to upload directory
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,11 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') || github.event_name == 'workflow_dispatch' }}
+          save-if: >
+            ${{ (matrix.binary == 'other') && (
+            github.ref == 'refs/heads/main'
+            || startsWith(github.ref, 'refs/heads/release-')
+            || github.event_name == 'workflow_dispatch' ) }}
           cache-provider: github
 
       - name: Build ${{ matrix.binary }}
@@ -82,7 +86,11 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') || github.event_name == 'workflow_dispatch' }}
+          save-if: >
+            ${{ (matrix.binary == 'other') && (
+            github.ref == 'refs/heads/main'
+            || startsWith(github.ref, 'refs/heads/release-')
+            || github.event_name == 'workflow_dispatch' ) }}
           cache-provider: buildjet
 
       - name: Build ${{ matrix.binary }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v2-rust
+          prefix-key: v3-rust
           shared-key: ${{ matrix.shared-key }}
           save-if: >
             ${{ matrix.save-cache && (
@@ -122,7 +122,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v2-rust
+          prefix-key: v3-rust
           shared-key: ${{ matrix.shared-key }}
           save-if: >
             ${{ matrix.save-cache && (

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,22 @@ jobs:
     # runs-on: ubuntu-24.04-8core
     strategy:
       matrix:
-        binary: [sequencer, sequencer-sqlite, espresso-dev-node, other]
+        include:
+          - binary: sequencer
+            shared-key:  postgres
+            save-cache: false
+
+          - binary: other
+            shared-key:  postgres
+            save-cache: true
+
+          - binary: sequencer-sqlite
+            shared-key: embedded
+            save-cache: false
+
+          - binary: espresso-dev-node
+            shared-key: embedded
+            save-cache: true
 
     steps:
       - uses: rui314/setup-mold@v1
@@ -40,6 +55,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: ${{ matrix.shared-key }}
           save-if: >
             ${{ (matrix.binary == 'other') && (
             github.ref == 'refs/heads/main'
@@ -75,7 +91,22 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     strategy:
       matrix:
-        binary: [sequencer, sequencer-sqlite, espresso-dev-node, other]
+        include:
+          - binary: sequencer
+            shared-key:  postgres
+            save-cache: false
+
+          - binary: other
+            shared-key:  postgres
+            save-cache: true
+
+          - binary: sequencer-sqlite
+            shared-key: embedded
+            save-cache: false
+
+          - binary: espresso-dev-node
+            shared-key: embedded
+            save-cache: true
 
     steps:
       - uses: rui314/setup-mold@v1
@@ -86,8 +117,9 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: ${{ matrix.shared-key }}
           save-if: >
-            ${{ (matrix.binary == 'other') && (
+            ${{ matrix.save-cache && (
             github.ref == 'refs/heads/main'
             || startsWith(github.ref, 'refs/heads/release-')
             || github.event_name == 'workflow_dispatch' ) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,11 @@ jobs:
 
           - binary: sequencer-sqlite
             shared-key: embedded
-            save-cache: false
+            save-cache: true
 
           - binary: espresso-dev-node
             shared-key: embedded
-            save-cache: true
+            save-cache: false
 
     steps:
       - uses: rui314/setup-mold@v1
@@ -55,6 +55,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: v2-rust
           shared-key: ${{ matrix.shared-key }}
           save-if: >
             ${{ matrix.save-cache && (
@@ -102,11 +103,11 @@ jobs:
 
           - binary: sequencer-sqlite
             shared-key: embedded
-            save-cache: false
+            save-cache: true
 
           - binary: espresso-dev-node
             shared-key: embedded
-            save-cache: true
+            save-cache: false
 
     steps:
       - uses: rui314/setup-mold@v1
@@ -117,6 +118,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: v2-rust
           shared-key: ${{ matrix.shared-key }}
           save-if: >
             ${{ matrix.save-cache && (

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,11 @@ env:
   DOCKER_PLATFORMS: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
 
 jobs:
-  build-matrix:
-    name: Build ${{ matrix.binary }} on ${{ matrix.arch }}
-    # runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-24.04-8core' || 'buildjet-8vcpu-ubuntu-2204-arm' }}
-    runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-latest' || 'buildjet-8vcpu-ubuntu-2204-arm' }}
-    if: ${{ matrix.arch == 'x86_64' || github.event_name != 'pull_request' }}
+  build-x86:
+    name: Build ${{ matrix.binary }}
+    runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        arch: [x86_64, aarch64]
         binary: [sequencer, sequencer-sqlite, espresso-dev-node, other]
 
     steps:
@@ -45,7 +42,7 @@ jobs:
           prefix-key: v1-rust
           shared-key: build
           save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-provider: ${{ matrix.arch == 'x86_64' && 'github' || 'buildjet' }}
+          cache-provider: github
 
       - name: Build ${{ matrix.binary }}
         run: |
@@ -70,7 +67,56 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.arch }}-${{ matrix.binary }}
+          name: x86-${{ matrix.binary }}
+          path: |
+            target/release/${{ matrix.binary == 'other' && '*' || matrix.binary }}
+
+  build-arm:
+    name: Build ${{ matrix.binary }}
+    runs-on: buildjet-8vcpu-ubuntu-2204-arm
+    if: ${{ github.event_name != 'pull_request' }}
+    strategy:
+      matrix:
+        binary: [sequencer, sequencer-sqlite, espresso-dev-node, other]
+
+    steps:
+      - uses: rui314/setup-mold@v1
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Enable Rust Caching
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          shared-key: build
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-provider: buildjet
+
+      - name: Build ${{ matrix.binary }}
+        run: |
+          case "${{ matrix.binary }}" in
+            "sequencer")
+              cargo build --locked --release --bin sequencer
+              ;;
+            "sequencer-sqlite")
+              cargo build --locked --release --manifest-path ./sequencer-sqlite/Cargo.toml
+              ;;
+            "espresso-dev-node")
+              cargo build --locked --release --features "embedded-db testing" --bin espresso-dev-node
+              ;;
+            "other")
+              cargo build --locked --release --workspace \
+                --exclude sequencer \
+                --exclude espresso-dev-node \
+                --exclude sequencer-sqlite
+              ;;
+          esac
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: arm-${{ matrix.binary }}
           path: |
             target/release/${{ matrix.binary == 'other' && '*' || matrix.binary }}
 
@@ -99,7 +145,7 @@ jobs:
           - state-relay-server
           - submit-transactions
 
-    needs: [build, build-arm]
+    needs: [build-x86, build-arm]
     # if build_arm is skipped, run this job anyway
     if: ${{ !(failure() || cancelled()) }}
     steps:
@@ -109,7 +155,7 @@ jobs:
       - name: Download executables AMD
         uses: actions/download-artifact@v4
         with:
-          pattern: x86_64-*
+          pattern: x86-*
           path: target/amd64/release
           merge_multiple: true
 
@@ -117,7 +163,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/download-artifact@v4
         with:
-          pattern: aarch64-*
+          pattern: arm-*
           path: target/arm64/release
           merge_multiple: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') || github.event_name == 'workflow_dispatch' }}
           cache-provider: github
 
       - name: Build ${{ matrix.binary }}
@@ -82,7 +82,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') || github.event_name == 'workflow_dispatch' }}
           cache-provider: buildjet
 
       - name: Build ${{ matrix.binary }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,20 +31,22 @@ jobs:
       matrix:
         include:
           - binary: sequencer
-            shared-key:  postgres
+            shared-key: postgres
             save-cache: false
 
           - binary: other
-            shared-key:  postgres
+            shared-key: postgres
             save-cache: true
 
           - binary: sequencer-sqlite
-            shared-key: embedded
+            # uses it's own lock file
+            shared-key: sequencer-embedded
             save-cache: true
 
           - binary: espresso-dev-node
-            shared-key: embedded
-            save-cache: false
+            # uses differend features testing,emdbedded-db
+            shared-key: espresso-dev-node
+            save-cache: true
 
     steps:
       - uses: rui314/setup-mold@v1
@@ -94,20 +96,22 @@ jobs:
       matrix:
         include:
           - binary: sequencer
-            shared-key:  postgres
+            shared-key: postgres
             save-cache: false
 
           - binary: other
-            shared-key:  postgres
+            shared-key: postgres
             save-cache: true
 
           - binary: sequencer-sqlite
-            shared-key: embedded
+            # uses it's own lock file
+            shared-key: sequencer-embedded
             save-cache: true
 
           - binary: espresso-dev-node
-            shared-key: embedded
-            save-cache: false
+            # uses differend features testing,emdbedded-db
+            shared-key: espresso-dev-node
+            save-cache: true
 
     steps:
       - uses: rui314/setup-mold@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,32 +21,18 @@ env:
   RUST_LOG: info,libp2p=off,node=error
   CARGO_TERM_COLOR: always
   DOCKER_PLATFORMS: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
-  ARTIFACT_PATHS: |
-    target/release/cdn-broker
-    target/release/cdn-marshal
-    target/release/cdn-whitelist
-    target/release/cli
-    target/release/deploy
-    target/release/espresso-bridge
-    target/release/espresso-dev-node
-    target/release/keygen
-    target/release/nasty-client
-    target/release/node-metrics
-    target/release/orchestrator
-    target/release/permissionless-builder
-    target/release/pub-key
-    target/release/reset-storage
-    target/release/sequencer
-    target/release/sequencer-sqlite
-    target/release/staking-cli
-    target/release/state-prover
-    target/release/state-relay-server
-    target/release/submit-transactions
-    target/release/utils
 
 jobs:
-  build:
-    runs-on: ubuntu-24.04-8core
+  build-matrix:
+    name: Build ${{ matrix.binary }} on ${{ matrix.arch }}
+    # runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-24.04-8core' || 'buildjet-8vcpu-ubuntu-2204-arm' }}
+    runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-latest' || 'buildjet-8vcpu-ubuntu-2204-arm' }}
+    if: ${{ matrix.arch == 'x86_64' || github.event_name != 'pull_request' }}
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+        binary: [sequencer, sequencer-sqlite, espresso-dev-node, other]
+
     steps:
       - uses: rui314/setup-mold@v1
 
@@ -57,62 +43,36 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-rust
+          shared-key: build
           save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-provider: github
+          cache-provider: ${{ matrix.arch == 'x86_64' && 'github' || 'buildjet' }}
 
-      - name: Build
-        # Build in release without `testing` feature, this should work without `hotshot_example` config.
+      - name: Build ${{ matrix.binary }}
         run: |
-          cargo build --locked --release --workspace
+          case "${{ matrix.binary }}" in
+            "sequencer")
+              cargo build --locked --release --bin sequencer
+              ;;
+            "sequencer-sqlite")
+              cargo build --locked --release --manifest-path ./sequencer-sqlite/Cargo.toml
+              ;;
+            "espresso-dev-node")
+              cargo build --locked --release --features "embedded-db testing" --bin espresso-dev-node
+              ;;
+            "other")
+              cargo build --locked --release --workspace \
+                --exclude sequencer \
+                --exclude espresso-dev-node \
+                --exclude sequencer-sqlite
+              ;;
+          esac
 
-      - name: Build sequencer-sqlite
-        run: cargo build --locked --release --manifest-path ./sequencer-sqlite/Cargo.toml --target-dir ./target
-
-      - name: Build Espresso Dev Node
-        # Espresso Dev Node currently requires testing feature, so it is built separately.
-        run: |
-          cargo build --locked --release --features "testing embedded-db" --bin espresso-dev-node
-
-      - name: Upload artifacts
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: x86_64-unknown-linux-gnu-services
-          path: ${{ env.ARTIFACT_PATHS }}
-
-  build-arm:
-    if: github.event_name != 'pull_request'
-    runs-on: buildjet-8vcpu-ubuntu-2204-arm
-    env:
-      CARGO_BUILD_JOBS: '6'
-    steps:
-      - uses: rui314/setup-mold@v1
-
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Enable Rust Caching
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-provider: buildjet
-
-      - name: Build
-        run: |
-          cargo build --locked --release --workspace
-
-      - name: Build sequencer-sqlite
-        run: cargo build --locked --release --manifest-path ./sequencer-sqlite/Cargo.toml --target-dir ./target
-
-      - name: Build Espresso Dev Node
-        # Espresso Dev Node currently requires testing feature, so it is built separately.
-        run: |
-          cargo build --locked --release --features "embedded-db testing" --bin espresso-dev-node
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: aarch64-unknown-linux-gnu-services
-          path: ${{ env.ARTIFACT_PATHS }}
+          name: ${{ matrix.arch }}-${{ matrix.binary }}
+          path: |
+            target/release/${{ matrix.binary == 'other' && '*' || matrix.binary }}
 
   build-dockers:
     runs-on: ubuntu-latest
@@ -149,15 +109,17 @@ jobs:
       - name: Download executables AMD
         uses: actions/download-artifact@v4
         with:
-          name: x86_64-unknown-linux-gnu-services
+          pattern: x86_64-*
           path: target/amd64/release
+          merge_multiple: true
 
       - name: Download executables ARM
         if: github.event_name != 'pull_request'
         uses: actions/download-artifact@v4
         with:
-          name: aarch64-unknown-linux-gnu-services
+          pattern: aarch64-*
           path: target/arm64/release
+          merge_multiple: true
 
       - name: Setup QEMU
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
               cargo build --locked --release --bin sequencer
               ;;
             "sequencer-sqlite")
-              cargo build --locked --release --manifest-path ./sequencer-sqlite/Cargo.toml
+              cargo build --locked --release --manifest-path ./sequencer-sqlite/Cargo.toml --target-dir ./target
               ;;
             "espresso-dev-node")
               cargo build --locked --release --features "embedded-db testing" --bin espresso-dev-node

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,18 +64,15 @@ jobs:
               ;;
           esac
 
-      - name: Remove everything except binaries from target/release directory
+      - name: Move binaries to upload directory
         shell: bash
         run: |
-          cd target/release
-          shopt -s dotglob nullglob
-          for item in *; do
+          mkdir -p upload
+          for item in target/release/*; do
             if [[ -f "$item" && -x "$item" ]]; then
-              echo "keeping $item binary"
+              mv -v "$item" ./upload
               continue
             fi
-            echo "removing $item"
-            rm -rf "$item"
           done
 
       - name: Upload Artifacts
@@ -83,7 +80,7 @@ jobs:
         with:
           name: x86-${{ matrix.binary }}
           path: |
-            target/release/${{ matrix.binary == 'other' && '*' || matrix.binary }}
+            upload/${{ matrix.binary == 'other' && '*' || matrix.binary }}
 
   build-arm:
     name: Build ${{ matrix.binary }}
@@ -127,12 +124,22 @@ jobs:
               ;;
           esac
 
+      - name: Move binaries to upload directory
+        run: |
+          mkdir -p upload
+          for item in target/release/*; do
+            if [[ -f "$item" && -x "$item" ]]; then
+              mv -v "$item" ./upload
+              continue
+            fi
+          done
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: arm-${{ matrix.binary }}
           path: |
-            target/release/${{ matrix.binary == 'other' && '*' || matrix.binary }}
+            upload/${{ matrix.binary == 'other' && '*' || matrix.binary }}
 
   build-dockers:
     runs-on: ubuntu-latest
@@ -180,6 +187,12 @@ jobs:
           pattern: arm-*
           path: target/arm64/release
           merge-multiple: true
+
+      - name: DEBUG binaries
+        run: |
+          # List the binaries in the target directory
+          echo "Binaries in target/amd64/release:"
+          ls -lah target/amd64/release
 
       - name: Setup QEMU
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,8 @@ env:
 jobs:
   build-x86:
     name: Build ${{ matrix.binary }}
-    runs-on: 'ubuntu-latest'
+    # runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-8core
     strategy:
       matrix:
         binary: [sequencer, sequencer-sqlite, espresso-dev-node, other]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           shared-key: ${{ matrix.shared-key }}
           save-if: >
-            ${{ (matrix.binary == 'other') && (
+            ${{ matrix.save-cache && (
             github.ref == 'refs/heads/main'
             || startsWith(github.ref, 'refs/heads/release-')
             || github.event_name == 'workflow_dispatch' ) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
   build-x86:
     name: Build ${{ matrix.binary }}
     runs-on: ubuntu-latest
-    # runs-on: ubuntu-24.04-8core
     strategy:
       matrix:
         include:
@@ -198,12 +197,6 @@ jobs:
           pattern: arm-*
           path: target/arm64/release
           merge-multiple: true
-
-      - name: DEBUG binaries
-        run: |
-          # List the binaries in the target directory
-          echo "Binaries in target/amd64/release:"
-          ls -lah target/amd64/release
 
       - name: Setup QEMU
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ env:
 jobs:
   build-x86:
     name: Build ${{ matrix.binary }}
-    # runs-on: ubuntu-latest
-    runs-on: ubuntu-24.04-8core
+    runs-on: ubuntu-latest
+    # runs-on: ubuntu-24.04-8core
     strategy:
       matrix:
         binary: [sequencer, sequencer-sqlite, espresso-dev-node, other]
@@ -40,9 +40,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
-          shared-key: build
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
           cache-provider: github
 
       - name: Build ${{ matrix.binary }}
@@ -84,9 +82,7 @@ jobs:
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
-          shared-key: build
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
           cache-provider: buildjet
 
       - name: Build ${{ matrix.binary }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,20 @@ jobs:
               ;;
           esac
 
+      - name: Remove everything except binaries from target/release directory
+        shell: bash
+        run: |
+          cd target/release
+          shopt -s dotglob nullglob
+          for item in *; do
+            if [[ -f "$item" && -x "$item" ]]; then
+              echo "keeping $item binary"
+              continue
+            fi
+            echo "removing $item"
+            rm -rf "$item"
+          done
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -157,7 +171,7 @@ jobs:
         with:
           pattern: x86-*
           path: target/amd64/release
-          merge_multiple: true
+          merge-multiple: true
 
       - name: Download executables ARM
         if: github.event_name != 'pull_request'
@@ -165,7 +179,7 @@ jobs:
         with:
           pattern: arm-*
           path: target/arm64/release
-          merge_multiple: true
+          merge-multiple: true
 
       - name: Setup QEMU
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -42,11 +42,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: Swatinem/rust-cache@v2
-        name: Enable Rust Caching
-        with:
-          prefix-key: v2-rust-${{ hashFiles('flake.*') }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # NOTE: no rust cache, it doesn't work out of the box our nix env
 
       - name: Check toolchain versions
         run: nix develop --accept-flake-config -c ./scripts/show-toolchain-versions

--- a/.github/workflows/doc-rust.yml
+++ b/.github/workflows/doc-rust.yml
@@ -22,10 +22,7 @@ jobs:
 
       - uses: taiki-e/install-action@just
 
-      - uses: Swatinem/rust-cache@v2
-        name: Enable Rust Caching
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # NOTE: no rust cache, not a time critical job
 
       - name: Build Docs
         run: |

--- a/.github/workflows/nix-env-macos-arm.yml
+++ b/.github/workflows/nix-env-macos-arm.yml
@@ -43,11 +43,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: Swatinem/rust-cache@v2
-        name: Enable Rust Caching
-        with:
-          prefix-key: v0-rust
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # NOTE: no rust cache this isn't a time critical job
 
       - name: Activate nix env
         run: nix develop --accept-flake-config -c echo Ok

--- a/.github/workflows/slowtest.yaml
+++ b/.github/workflows/slowtest.yaml
@@ -38,12 +38,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Enable Rust Caching
-        uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: v1-rust
-          shared-key: slow-test
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # NOTE: no rust cache, these tests are very slow anyway
 
       - name: Build slow test
         run: just nextest --features embedded-db --no-run
@@ -65,12 +60,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Enable Rust Caching
-        uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: v1-rust
-          shared-key: slow-test
-          save-if: false
+      # NOTE: no rust cache, these tests are very slow anyway
 
       - name: Build slow test
         run: just nextest --no-run

--- a/.github/workflows/slowtest.yaml
+++ b/.github/workflows/slowtest.yaml
@@ -27,6 +27,16 @@ jobs:
   slow-tests-sqlite:
     runs-on: ubuntu-latest
     steps:
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       # These tests need the `anvil` binary provided by foundry
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -40,6 +50,7 @@ jobs:
 
       # NOTE: no rust cache, these tests are very slow anyway
 
+
       - name: Build slow test
         run: just nextest --features embedded-db --no-run
 
@@ -50,6 +61,16 @@ jobs:
   slow-tests-postgres:
     runs-on: ubuntu-latest
     steps:
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,7 +265,6 @@ jobs:
         timeout-minutes: 20
 
   test-go-sdk:
-    needs: build-test-bins
     runs-on: ubuntu-latest
     steps:
       - name: Install Nix

--- a/docker/bridge.Dockerfile
+++ b/docker/bridge.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/espresso-bridge /bin/espresso-bridge
 RUN chmod +x /bin/espresso-bridge

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -1,19 +1,10 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 # Install genesis files for all supported configurations. The desired configuration can be chosen by
 # setting `ESPRESSO_BUILDER_GENESIS_FILE`.
 COPY data/genesis /genesis
-
-# Download an SRS file to avoid download at runtime
-ENV AZTEC_SRS_PATH=/kzg10-aztec20-srs-1048584.bin
-RUN curl -LO https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/$AZTEC_SRS_PATH
 
 COPY target/$TARGETARCH/release/permissionless-builder /bin/permissionless-builder
 RUN chmod +x /bin/permissionless-builder

--- a/docker/cdn-broker.Dockerfile
+++ b/docker/cdn-broker.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/cdn-broker /bin/cdn-broker
 RUN chmod +x /bin/cdn-broker

--- a/docker/cdn-marshal.Dockerfile
+++ b/docker/cdn-marshal.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/cdn-marshal /bin/cdn-marshal
 RUN chmod +x /bin/cdn-marshal

--- a/docker/cdn-whitelist.Dockerfile
+++ b/docker/cdn-whitelist.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/cdn-whitelist /bin/cdn-whitelist
 RUN chmod +x /bin/cdn-whitelist

--- a/docker/deploy.Dockerfile
+++ b/docker/deploy.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/deploy /bin/deploy
 RUN chmod +x /bin/deploy

--- a/docker/espresso-dev-node.Dockerfile
+++ b/docker/espresso-dev-node.Dockerfile
@@ -1,15 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
-
-# Download an SRS file to avoid download at runtime
-ENV AZTEC_SRS_PATH=/kzg10-aztec20-srs-1048584.bin
-RUN curl -LO https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/$AZTEC_SRS_PATH
 
 COPY target/$TARGETARCH/release/espresso-dev-node /bin/espresso-dev-node
 RUN chmod +x /bin/espresso-dev-node

--- a/docker/nasty-client.Dockerfile
+++ b/docker/nasty-client.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/nasty-client /bin/nasty-client
 RUN chmod +x /bin/nasty-client

--- a/docker/node-validator.Dockerfile
+++ b/docker/node-validator.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/node-metrics /bin/node-metrics
 RUN chmod +x /bin/node-metrics

--- a/docker/orchestrator.Dockerfile
+++ b/docker/orchestrator.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/orchestrator /bin/orchestrator
 RUN chmod +x /bin/orchestrator

--- a/docker/prover-service.Dockerfile
+++ b/docker/prover-service.Dockerfile
@@ -1,15 +1,7 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
 
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
-
-# Download an SRS file to avoid download at runtime
-ENV AZTEC_SRS_PATH=/kzg10-aztec20-srs-1048584.bin
-RUN curl -LO https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/$AZTEC_SRS_PATH
 
 # copy the binaries
 COPY target/$TARGETARCH/release/state-prover /usr/local/bin/state-prover

--- a/docker/sequencer.Dockerfile
+++ b/docker/sequencer.Dockerfile
@@ -1,13 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-# Download an SRS file to avoid download at runtime
-ENV AZTEC_SRS_PATH=/kzg10-aztec20-srs-1048584.bin
-RUN curl -LO https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/$AZTEC_SRS_PATH
 
 COPY target/$TARGETARCH/release/sequencer /bin/sequencer-postgres
 RUN chmod +x /bin/sequencer-postgres

--- a/docker/staking-cli.Dockerfile
+++ b/docker/staking-cli.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/staking-cli /bin/staking-cli
 RUN chmod +x /bin/staking-cli

--- a/docker/state-relay-server.Dockerfile
+++ b/docker/state-relay-server.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/state-relay-server /bin/state-relay-server
 RUN chmod +x /bin/state-relay-server

--- a/docker/submit-transactions.Dockerfile
+++ b/docker/submit-transactions.Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:24.04
+FROM ghcr.io/espressosystems/ubuntu-base:main
 
 ARG TARGETARCH
-
-RUN apt-get update \
-    &&  apt-get install -y curl libcurl4 wait-for-it tini \
-    &&  rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/submit-transactions /bin/submit-transactions
 RUN chmod +x /bin/submit-transactions

--- a/scripts/ci-build-binary
+++ b/scripts/ci-build-binary
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# usage:
+#
+# ./ci-build-binary <binary>
+#
+# where <binary> is one of: sequencer, sequencer-sqlite, espresso-dev-node, other
+#
+set -euo pipefail
+
+case "$1" in
+    "sequencer")
+        cargo build --locked --release --bin sequencer
+        ;;
+    "sequencer-sqlite")
+        cargo build --locked --release --manifest-path ./sequencer-sqlite/Cargo.toml --target-dir ./target
+        ;;
+    "espresso-dev-node")
+        cargo build --locked --release --features "embedded-db testing" --bin espresso-dev-node
+        ;;
+    "other")
+        BINS="$(cargo metadata --no-deps --format-version 1 \
+        | jq -r '.packages[].targets[] | select(.kind[] == "bin") | .name' \
+        | grep -v '^sequencer$\|espresso-dev-node' \
+        | xargs -I{} echo --bin {} \
+        | tr '\n' ' ')"
+        echo "Building rest binaries: $BINS"
+        cargo build --locked --release $BINS
+        ;;
+    *)
+        echo "Unknown binary: $1"
+        exit 1
+        ;;
+esac

--- a/scripts/ci-build-binary
+++ b/scripts/ci-build-binary
@@ -23,7 +23,7 @@ case "$1" in
         | grep -v '^sequencer$\|espresso-dev-node' \
         | xargs -I{} echo --bin {} \
         | tr '\n' ' ')"
-        echo "Building rest binaries: $BINS"
+        echo "Building other binaries: $BINS"
         cargo build --locked --release $BINS
         ;;
     *)


### PR DESCRIPTION
### Motivation

When we want to test a change we need the images therefore we should have a CI that builds them reasonably quickly. Currently this leaves much to be desired with build times of about half an hour.

### Changes

- Create separate jobs to build release binaries. This significantly speeds up the build.
- Configure caches to be saved on main and release branches and on `workflow_dispatch` for easier debugging.
- Switch to using ubuntu-latest: it's a bit faster on our custom 8CPU runner but we just end up having to wait for the arm build to complete.
- Add a docker base image so we don't have to `apt-get` and download the SRS during each docker build: https://github.com/EspressoSystems/docker-base-images/. These steps are very slow when building the ARM image with qemu.
- Remove caches from CI jobs that don't really need them.

### Does it work?
With a full cache hit it take a bit less than 10 minutes now until all docker images are built. Without the cache I think it takes about 17 minutes.

A run without cache: https://github.com/EspressoSystems/espresso-network/actions/runs/15163973759
A run with cache: https://github.com/EspressoSystems/espresso-network/actions/runs/15169651951
A run where we use our own base image: https://github.com/EspressoSystems/espresso-network/actions/runs/15169883727

It took me a while but we do unfortunately need separate caches for some of the jobs for max effectiveness. The sequencer-sqlite binary also has it's own lockfile so many versions don't match. This is quite annoying but maybe tricky to fix. I haven't looked into it. The log of cargo build in the [cached run](https://github.com/EspressoSystems/espresso-network/actions/runs/15169651951) shows that for all jobs only workspace crates are compiled, which means that the cache hit is as good as possible with the default setting for the rust-cache action.