### PR TITLE
Add release instructions for go sdk

### DIFF
--- a/.github/workflows/build-crypto-helper.yml
+++ b/.github/workflows/build-crypto-helper.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "go-v*.*.*"
+      - "sdks/go/v*.*.*"
   pull_request:
   workflow_dispatch:
 

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,0 +1,24 @@
+# Espresso Network Go SDK
+
+This package provides tools and interfaces for working with the
+[Espresso Global Confirmation Layer](https://github.com/EspressoSystems/espresso-network) in Go. It should (eventually)
+provide everything needed to integrate a rollup written in Go with the Espresso
+
+## How to release
+
+- Make sure your changes are committed and pushed to the main branch.
+- Choose the correct version for your release, following semantic versioning (e.g., `sdks/go/v1.2.3`).
+- In the root directory, create a new tag and push it to the remote:
+
+```sh
+git tag sdks/go/vX.Y.Z
+git push origin sdks/go/vX.Y.Z
+```
+
+Replace `X.Y.Z` with your desired version number.
+
+- This will trigger the GitHub Actions workflow to build and release the Go SDK.
+- After the workflow completes, check the
+  [GitHub Releases page](https://github.com/EspressoSystems/espresso-network/releases) for the published artifacts.
+- Verify that the crypto helper library artifacts (e.g., `.so`, `.dylib`, and their `.sha256` files) have been built and
+  are included in the release assets.

--- a/sdks/go/download/main.go
+++ b/sdks/go/download/main.go
@@ -215,6 +215,10 @@ func getFileName() string {
 		panic(fmt.Sprintf("unsupported architecture: %s", arch))
 	}
 
+	if fileName == "" {
+		panic(fmt.Sprintf("unsupported os: %s", os))
+	}
+
 	return fmt.Sprintf("libespresso_crypto_helper-%s%s", fileName, extension)
 }
 


### PR DESCRIPTION
[Go](https://go.dev/ref/mod#vcs-version-tags) only supports version tags in the format `vX.Y.Z`, and to publish a Go module located in a subdirectory like `sdks/go`, the tag must be applied to that folder using the format `sdks/go/vX.Y.Z`.

A good example of this approach is the [OpenTelemetry Collector Contrib repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/tags), which manages multiple Go modules within a monorepo. Each module is versioned independently by tagging with a combination of its path and semantic version, such as `scraper/zookeeperscraper/v0.126.0`.


### This PR:
- Adds a README.md for go sdk, containing the instructions to release new version of go sdk
- Fixes the build-crypto-helper.yml. This workflow should be triggered only by the release of the go sdk

### Key places to review:
- sdks/go/REAME.md

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
