### PR TITLE
Fix go module path

### DIFF
--- a/sdks/go/client/client.go
+++ b/sdks/go/client/client.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"strings"
 
-	types "github.com/EspressoSystems/espresso-network-go/types"
-	common "github.com/EspressoSystems/espresso-network-go/types/common"
+	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
+	common "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 )
 
 var _ QueryService = (*Client)(nil)

--- a/sdks/go/client/client_test.go
+++ b/sdks/go/client/client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	types "github.com/EspressoSystems/espresso-network-go/types"
+	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 

--- a/sdks/go/client/multiple_nodes_client.go
+++ b/sdks/go/client/multiple_nodes_client.go
@@ -10,8 +10,8 @@ import (
 	"sort"
 	"sync"
 
-	types "github.com/EspressoSystems/espresso-network-go/types"
-	common "github.com/EspressoSystems/espresso-network-go/types/common"
+	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
+	common "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 )
 
 var _ QueryService = (*MultipleNodesClient)(nil)

--- a/sdks/go/client/multiple_nodes_test.go
+++ b/sdks/go/client/multiple_nodes_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	types "github.com/EspressoSystems/espresso-network-go/types"
+	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/sdks/go/client/query.go
+++ b/sdks/go/client/query.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	types "github.com/EspressoSystems/espresso-network-go/types"
+	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 )
 
 // Interface to the Espresso Sequencer query service.

--- a/sdks/go/client/submit.go
+++ b/sdks/go/client/submit.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 
-	common "github.com/EspressoSystems/espresso-network-go/types/common"
+	common "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 )
 
 // Interface to the Espresso Sequencer submit API

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/EspressoSystems/espresso-network-go
+module github.com/EspressoSystems/espresso-network/sdks/go
 
 go 1.24
 

--- a/sdks/go/light-client/light_client_reader.go
+++ b/sdks/go/light-client/light_client_reader.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math/big"
 
-	common_types "github.com/EspressoSystems/espresso-network-go/types/common"
+	common_types "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/sdks/go/types/common/types.go
+++ b/sdks/go/types/common/types.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
-	tagged_base64 "github.com/EspressoSystems/espresso-network-go/tagged-base64"
+	tagged_base64 "github.com/EspressoSystems/espresso-network/sdks/go/tagged-base64"
 
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/sdks/go/types/common/types_test.go
+++ b/sdks/go/types/common/types_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	tagged_base64 "github.com/EspressoSystems/espresso-network-go/tagged-base64"
+	tagged_base64 "github.com/EspressoSystems/espresso-network/sdks/go/tagged-base64"
 
 	"github.com/ethereum/go-ethereum/common"
 

--- a/sdks/go/types/header.go
+++ b/sdks/go/types/header.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	common_types "github.com/EspressoSystems/espresso-network-go/types/common"
-	v01 "github.com/EspressoSystems/espresso-network-go/types/v0/v0_1"
-	v02 "github.com/EspressoSystems/espresso-network-go/types/v0/v0_2"
-	v03 "github.com/EspressoSystems/espresso-network-go/types/v0/v0_3"
+	common_types "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
+	v01 "github.com/EspressoSystems/espresso-network/sdks/go/types/v0/v0_1"
+	v02 "github.com/EspressoSystems/espresso-network/sdks/go/types/v0/v0_2"
+	v03 "github.com/EspressoSystems/espresso-network/sdks/go/types/v0/v0_3"
 )
 
 // Republic

--- a/sdks/go/types/header_test.go
+++ b/sdks/go/types/header_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	common_types "github.com/EspressoSystems/espresso-network-go/types/common"
+	common_types "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 	"github.com/stretchr/testify/require"
 )
 

--- a/sdks/go/types/v0/v0_1/chain_config.go
+++ b/sdks/go/types/v0/v0_1/chain_config.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	tagged_base64 "github.com/EspressoSystems/espresso-network-go/tagged-base64"
-	common_types "github.com/EspressoSystems/espresso-network-go/types/common"
+	tagged_base64 "github.com/EspressoSystems/espresso-network/sdks/go/tagged-base64"
+	common_types "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 	"github.com/ethereum/go-ethereum/common"
 )
 

--- a/sdks/go/types/v0/v0_1/header.go
+++ b/sdks/go/types/v0/v0_1/header.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	common_types "github.com/EspressoSystems/espresso-network-go/types/common"
+	common_types "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 )
 
 type Header struct {

--- a/sdks/go/types/v0/v0_2/header.go
+++ b/sdks/go/types/v0/v0_2/header.go
@@ -3,8 +3,8 @@ package v0_2
 import (
 	"encoding/json"
 
-	"github.com/EspressoSystems/espresso-network-go/types/common"
-	v01 "github.com/EspressoSystems/espresso-network-go/types/v0/v0_1"
+	"github.com/EspressoSystems/espresso-network/sdks/go/types/common"
+	v01 "github.com/EspressoSystems/espresso-network/sdks/go/types/v0/v0_1"
 )
 
 type Header struct {

--- a/sdks/go/types/v0/v0_3/chain_config.go
+++ b/sdks/go/types/v0/v0_3/chain_config.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	tagged_base64 "github.com/EspressoSystems/espresso-network-go/tagged-base64"
-	common_types "github.com/EspressoSystems/espresso-network-go/types/common"
+	tagged_base64 "github.com/EspressoSystems/espresso-network/sdks/go/tagged-base64"
+	common_types "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 	common "github.com/ethereum/go-ethereum/common"
 )
 

--- a/sdks/go/types/v0/v0_3/header.go
+++ b/sdks/go/types/v0/v0_3/header.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/EspressoSystems/espresso-network-go/types/common"
-	common_types "github.com/EspressoSystems/espresso-network-go/types/common"
+	"github.com/EspressoSystems/espresso-network/sdks/go/types/common"
+	common_types "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 )
 
 type Header struct {

--- a/sdks/go/verification/merkle_proof_test_data_generation_test.go
+++ b/sdks/go/verification/merkle_proof_test_data_generation_test.go
@@ -7,9 +7,9 @@ package verification
 // 	"testing"
 // 	"time"
 
-// 	espressoClient "github.com/EspressoSystems/espresso-network-go/client"
-// 	lightclient "github.com/EspressoSystems/espresso-network-go/light-client"
-// 	espressoTypes "github.com/EspressoSystems/espresso-network-go/types"
+// 	espressoClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
+// 	lightclient "github.com/EspressoSystems/espresso-network/sdks/go/light-client"
+// 	espressoTypes "github.com/EspressoSystems/espresso-network/sdks/go/types"
 // 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 // 	"github.com/ethereum/go-ethereum/common"
 // 	"github.com/ethereum/go-ethereum/ethclient"

--- a/sdks/go/verification/verify.go
+++ b/sdks/go/verification/verify.go
@@ -9,7 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 
-	espressoTypes "github.com/EspressoSystems/espresso-network-go/types"
+	espressoTypes "github.com/EspressoSystems/espresso-network/sdks/go/types"
 )
 
 func VerifyNamespace(

--- a/sdks/go/verification/verify_test.go
+++ b/sdks/go/verification/verify_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/EspressoSystems/espresso-network-go/types"
+	"github.com/EspressoSystems/espresso-network/sdks/go/types"
 )
 
 func TestVerifyNamespaceWithRealData(t *testing.T) {


### PR DESCRIPTION
### This PR:
Fix the go sdk module path.

It has to be the same as the path of `go.mod` file.