### PR TITLE
Rename add_epoch_root to store_epoch_root 

### DIFF
--- a/crates/hotshot/types/src/traits/election.rs
+++ b/crates/hotshot/types/src/traits/election.rs
@@ -168,7 +168,7 @@ pub trait Membership<TYPES: NodeType>: Debug + Send + Sync {
     /// with Some to have that callback invoked under a write lock.
     ///
     /// #3967 REVIEW NOTE: this is only called if epoch is Some. Is there any reason to do otherwise?
-    fn add_epoch_root(
+    fn store_epoch_root(
         &self,
         _epoch: TYPES::Epoch,
         _block_header: TYPES::BlockHeader,
@@ -177,7 +177,7 @@ pub trait Membership<TYPES: NodeType>: Debug + Send + Sync {
     }
 
     /// Called to notify the Membership when a new DRB result has been calculated.
-    /// Observes the same semantics as add_epoch_root
+    /// Observes the same semantics as store_epoch_root
     fn add_drb_result(&mut self, _epoch: TYPES::Epoch, _drb_result: DrbResult);
 
     /// Called to notify the Membership that Epochs are enabled.

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -1222,7 +1222,7 @@ impl Membership<SeqTypes> for EpochCommittees {
     }
 
     #[allow(refining_impl_trait)]
-    async fn add_epoch_root(
+    async fn store_epoch_root(
         &self,
         epoch: Epoch,
         block_header: Header,
@@ -1243,7 +1243,7 @@ impl Membership<SeqTypes> for EpochCommittees {
                 .store_stake(epoch, stake_tables.clone())
                 .await
             {
-                tracing::error!(?e, "`add_epoch_root`, error storing stake table");
+                tracing::error!(?e, "`store_epoch_root`, error storing stake table");
             }
         }
 


### PR DESCRIPTION

This pull request refactors the codebase by renaming the function `add_epoch_root` to `store_epoch_root` across relevant files