### PR TITLE
fix: Use only the first Docker image tag in test-demo workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Match the docker image tag built or pushed to the registry
         run: |
-          DOCKER_TAG=$(echo ${{ needs.build-dockers.outputs.tags }} | sed 's/.*://')
+          DOCKER_TAG=$(echo ${{ needs.build-dockers.outputs.tags }} | awk '{print $1}')
           echo DOCKER_TAG=$DOCKER_TAG >> $GITHUB_ENV
 
       - name: Pull remaining docker images


### PR DESCRIPTION
Closes #3110 


### This PR:
- Fixes a bug in the CI workflow where multiple Docker image tags were being used, resulting in an invalid Docker image reference.
- Ensures that only the first Docker image tag is used in the test-demo job, preventing errors during image pulling and testing.

### This PR does not:
- Change the way Docker images are built or tagged.
- Affect any other workflows or jobs outside of the tag selection logic in test-demo.

### Key places to review:

.github/workflows/build.yml — the step in the test-demo job where the Docker tag is selected.


