### PR TITLE
Increase checkpoint interval

### DIFF
--- a/crates/hotshot/types/src/drb.rs
+++ b/crates/hotshot/types/src/drb.rs
@@ -38,7 +38,7 @@ pub struct DrbInput {
 pub const DIFFICULTY_LEVEL: u64 = 10;
 
 /// Interval at which to store the results
-pub const DRB_CHECKPOINT_INTERVAL: u64 = 3;
+pub const DRB_CHECKPOINT_INTERVAL: u64 = 1000000;
 
 /// DRB seed input for epoch 1 and 2.
 pub const INITIAL_DRB_SEED_INPUT: [u8; 32] = [0; 32];


### PR DESCRIPTION
Increases the DRB checkpoint interval, which result in suppression of DRB storage logs on decaf
