### PR TITLE
Add namespace info to payload metadata and block summary

### DIFF
--- a/hotshot-query-service/src/data_source/storage/sql/queries.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries.rs
@@ -256,6 +256,9 @@ where
             num_transactions: row
                 .try_get::<Option<i32>, _>("num_transactions")?
                 .ok_or(sqlx::Error::RowNotFound)? as u64,
+
+            // Per-namespace info must be loaded in a separate query.
+            namespaces: Default::default(),
         })
     }
 }

--- a/hotshot-query-service/src/testing/mocks.rs
+++ b/hotshot-query-service/src/testing/mocks.rs
@@ -50,6 +50,15 @@ impl QueryableHeader<MockTypes> for MockHeader {
     fn timestamp(&self) -> u64 {
         self.timestamp
     }
+
+    fn namespace_size(&self, id: u32, payload_size: usize) -> u64 {
+        // Test types only support a single namespace.
+        if id == 0 {
+            payload_size as u64
+        } else {
+            0
+        }
+    }
 }
 
 impl ExplorerHeader<MockTypes> for MockHeader {

--- a/types/src/v0/impls/header.rs
+++ b/types/src/v0/impls/header.rs
@@ -39,8 +39,8 @@ use crate::{
         impls::reward::{find_validator_info, first_two_epochs},
     },
     v0_1, v0_2, v0_3, BlockMerkleCommitment, EpochVersion, FeeAccount, FeeAmount, FeeInfo,
-    FeeMerkleCommitment, Header, L1BlockInfo, L1Snapshot, Leaf2, NamespaceId, NsTable, SeqTypes,
-    UpgradeType,
+    FeeMerkleCommitment, Header, L1BlockInfo, L1Snapshot, Leaf2, NamespaceId, NsIndex, NsTable,
+    PayloadByteLen, SeqTypes, UpgradeType,
 };
 
 impl v0_1::Header {
@@ -963,6 +963,13 @@ impl BlockHeader<SeqTypes> for Header {
 impl QueryableHeader<SeqTypes> for Header {
     fn timestamp(&self) -> u64 {
         self.timestamp()
+    }
+
+    fn namespace_size(&self, id: u32, payload_size: usize) -> u64 {
+        self.ns_table()
+            .ns_range(&NsIndex(id as usize), &PayloadByteLen(payload_size))
+            .byte_len()
+            .0 as u64
     }
 }
 


### PR DESCRIPTION
See https://app.asana.com/1/1208976916964769/project/1209380117384039/task/1210253275558850?focus=true

### This PR:
* Adds namespace sizes and transaction counts to `PayloadMetadata`, where they will soon be used by the aggregator task
* Also adds them to `BlockSummaryQueryData`, because why not, it seemed useful, and this endpoint is I think only used by the explorer, using JSON, where adding new fields is non-breaking
* Exposes a function to read namespace size from the namespace table in the `QueryableHeader` trait
