### PR TITLE
Check tx hash in go sdk

### DIFF
--- a/sdks/go/client/client_test.go
+++ b/sdks/go/client/client_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
+	common "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -65,6 +66,11 @@ func TestApiWithEspressoDevNode(t *testing.T) {
 		t.Fatal("failed to submit transaction", err)
 	}
 	fmt.Println("submitted transaction with hash", hash)
+	expected := tx.Commit()
+	if common.Commitment(hash.Value()) != expected {
+		fmt.Printf("expected: %s, actual: %s\n", expected, hash.Value())
+		t.Fatal("transaction hash does not match")
+	}
 
 }
 


### PR DESCRIPTION
### This PR:
Adds a sanity check for tx hash in go sdk
