### PR TITLE
Fix incorrect function name in Update modifyStateHistoryRetentionPeri…

### DIFF
--- a/contracts/script/multisigTransactionProposals/safeSDK/modifyStateHistoryRetentionPeriod.ts
+++ b/contracts/script/multisigTransactionProposals/safeSDK/modifyStateHistoryRetentionPeriod.ts
@@ -63,10 +63,10 @@ export async function proposeSetStateHistoryRetentionTransaction(
   stateHistoryRetentionPeriod: number,
 ) {
   // Define the ABI of the function to be called
-  const abi = ["function setstateHistoryRetentionPeriod(uint32)"];
+  const abi = ["function setStateHistoryRetentionPeriod(uint32)"];
 
   // Encode the function call with the provided stateHistoryRetentionPeriod
-  const data = new ethers.Interface(abi).encodeFunctionData("setstateHistoryRetentionPeriod", [
+  const data = new ethers.Interface(abi).encodeFunctionData("setStateHistoryRetentionPeriod", [
     stateHistoryRetentionPeriod,
   ]);
 


### PR DESCRIPTION

This PR fixes a critical bug in the ABI declaration used to encode the setStateHistoryRetentionPeriod function call. The original function name was misspelled as setstateHistoryRetentionPeriod (lowercase s), which caused ethers.Interface.encodeFunctionData to throw an error due to a missing match in the contract ABI.

Without this fix, the proposal transaction fails to encode properly, preventing it from being submitted and signed via the Safe Multisig interface.
