### PR TITLE
Add validation for proxyAddress in upgrade script in Update upgradePr…

### DIFF
--- a/contracts/script/multisigTransactionProposals/safeSDK/upgradeProxy.ts
+++ b/contracts/script/multisigTransactionProposals/safeSDK/upgradeProxy.ts
@@ -65,6 +65,7 @@ function processCommandLineArguments(): UpgradeData {
     throw new Error(`Only ${UPGRADE_PROXY_CMD} command is supported.`);
   }
   const proxyAddress = args[1];
+  validateEthereumAddress(proxyAddress);
   const implementationAddress = args[2];
   validateEthereumAddress(implementationAddress);
   const initData = args[3];


### PR DESCRIPTION
Add validation for proxyAddress in upgrade script.

Description:

This PR adds a missing validation check for the proxyAddress parameter in the processCommandLineArguments function of the upgrade script.

Problem:
The proxyAddress input was not being validated using validateEthereumAddress, which could lead to:

Runtime errors when creating or signing the transaction.

Potentially critical misbehavior if the address is syntactically valid but incorrect (e.g., accidentally targeting the wrong contract).

Solution:
Added a call to validateEthereumAddress(proxyAddress) immediately after parsing the command-line arguments.

Why it matters:
Ensures correctness and prevents unintended transactions to malformed or incorrect addresses, especially important in the context of Safe multisig operations.

