### PR TITLE
CI: native docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,20 @@
 name: Build
-
+# This workflow file is pretty complex, due to optimizations and features:
+#   - using public runners
+#   - rust caching
+#   - native docker multiplatform builds (without QEMU)
+#
+# 1. We build the binaries in 4 jobs for each of the 2 architectures. The jobs are broken up so that
+#    we get a decent amount of parallelism and a low overall runtime.
+# 2. We build the native docker image for each of 2 architectures using the binary artifacts from
+#    the first step. We push the images to the registry by digest.
+# 3. We merge the native docker images into a multiplatform image and push the combined image
+#    to the registry.
+# 4. We run the docker demo test to ensure that the images work as expected.
+#
+# For PR builds we don't build anything on ARM but only on AMD64. We pay separately for ARM builds
+# because they can't use the public github runners. For PR builds we don't push to the registry but
+# instead upload the docker images as artifacts and run the demo test against the artifacts.
 on:
   push:
     # TODO: FOR TESTING, restore branch gating
@@ -253,7 +268,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: "digests-amd64"
+          name: "digests-${{ matrix.service }}-amd64"
           path: "${{ runner.temp }}/digests/*"
           if-no-files-found: error
           retention-days: 1
@@ -263,10 +278,6 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build-arm
     runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    # This is non-deterministic, a limitation of GHA. We but we only need the
-    # tag like (:main) at the end which is the same for each matrix build.
-    # outputs:
-    #   tags: ${{ steps.metadata.outputs.tags }}
     strategy:
       matrix:
         service:
@@ -337,7 +348,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: "digests-arm64"
+          name: "digests-${{ matrix.service }}-arm64"
           path: "${{ runner.temp }}/digests/*"
           if-no-files-found: error
           retention-days: 1
@@ -383,7 +394,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          pattern: "digests-*"
+          pattern: "digests-${{ matrix.service }}-*"
           path: "${{ runner.temp }}/digests"
           merge-multiple: true
 
@@ -412,7 +423,8 @@ jobs:
         run: |
           docker buildx imagetools inspect ghcr.io/espressosystems/espresso-sequencer/${{ matrix.service }}:${{ steps.meta.outputs.version }}
 
-  test-demo:
+  test-demo-pr:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: [build-dockers-amd]
     steps:
@@ -421,15 +433,13 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Download artifacts (PR only)
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/docker-images
           pattern: "*-docker-image"
 
       - name: Load docker images (PR only)
-        if: ${{ github.event_name == 'pull_request' }}
         run: |
           # load all *.tar files in the temp directory, the layout should
           # be ${{ runner.temp }}/docker-images/<artifact-name>/<service>.tar
@@ -439,10 +449,35 @@ jobs:
 
       - name: Match the docker image tag built or pushed to the registry
         run: |
-          DOCKER_TAG=$(echo ${{ needs.build-dockers.outputs.tags }} | sed 's/.*://')
+          DOCKER_TAG=$(echo ${{ needs.build-dockers-amd.outputs.tags }} | sed 's/.*://')
           echo DOCKER_TAG=$DOCKER_TAG >> $GITHUB_ENV
 
       - name: Pull remaining docker images
+        run: |
+          docker compose pull --policy missing
+
+      - name: Test docker demo
+        run: |
+          just demo --pull never &
+          set -o pipefail
+          timeout -v 600 scripts/smoke-test-demo | sed -e 's/^/smoke-test: /;'
+
+  test-demo-non-pr:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [build-dockers-amd, create-multiplatform-docker-image]
+    steps:
+      - uses: taiki-e/install-action@just
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Match the docker image tag built or pushed to the registry
+        run: |
+          DOCKER_TAG=$(echo ${{ needs.build-dockers-amd.outputs.tags }} | sed 's/.*://')
+          echo DOCKER_TAG=$DOCKER_TAG >> $GITHUB_ENV
+
+      - name: Pull the docker images
         run: |
           docker compose pull --policy missing
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,6 +229,8 @@ jobs:
           context: .
           file: ./docker/${{ matrix.service }}.Dockerfile
           labels: ${{ steps.metadata.outputs.labels  }}
+          # Note the tag is used later to run the demo test
+          tags: ${{ steps.metadata.outputs.tags }}
           platforms: linux/amd64
           outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.service }}.tar
 
@@ -248,6 +250,7 @@ jobs:
           context: .
           file: ./docker/${{ matrix.service }}.Dockerfile
           labels: ${{ steps.metadata.outputs.labels  }}
+          # Note: the final multiarch image will receive the tag
           platforms: linux/amd64
           outputs: type=image,name=ghcr.io/espressosystems/espresso-sequencer/${{ matrix.service }},push-by-digest=true,name-canonical=true,push=true
 
@@ -329,6 +332,7 @@ jobs:
           context: .
           file: ./docker/${{ matrix.service }}.Dockerfile
           labels: ${{ steps.metadata.outputs.labels  }}
+          # Note: the final multiarch image will receive the tag
           platforms: linux/arm64
           outputs: type=image,name=ghcr.io/espressosystems/espresso-sequencer/${{  matrix.service }},push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,7 +441,7 @@ jobs:
           path: ${{ runner.temp }}/docker-images
           pattern: "*-docker-image"
 
-      - name: Load docker images (PR only)
+      - name: Load docker images
         run: |
           # load all *.tar files in the temp directory, the layout should
           # be ${{ runner.temp }}/docker-images/<artifact-name>/<service>.tar
@@ -488,3 +488,22 @@ jobs:
           just demo --pull never &
           set -o pipefail
           timeout -v 600 scripts/smoke-test-demo | sed -e 's/^/smoke-test: /;'
+
+  # This job enables having a single required status check for both test-demo jobs
+  test-demo:
+    needs: [test-demo, test-demo-non-pr]
+    runs-on: ubuntu-latest
+    # explicitly run and fail the job if dependencies failed
+    if: ${{ always() && !cancelled() }}
+    steps:
+      - name: Aggregate demo test results
+        run: |
+          # useful for debugging
+          echo "All results: ${{ toJson(needs) }}"
+
+          if ${{ contains(needs.*.result, 'success') }}; then
+            echo "At least one job passed. Ok."
+          else
+            echo "No jobs passed. Failing."
+            exit 1
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
 
   build-arm:
     name: Build ${{ matrix.binary }}
-    runs-on: buildjet-8vcpu-ubuntu-2204-arm
+    runs-on: ubuntu-24.04-arm64
     if: ${{ github.event_name != 'pull_request' }}
     strategy:
       matrix:
@@ -277,7 +277,7 @@ jobs:
     # Arm builds cost money, skip on PRs
     if: github.event_name != 'pull_request'
     needs: build-arm
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    runs-on: ubuntu-24.04-arm64
     strategy:
       matrix:
         service:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,10 @@ name: Build
 
 on:
   push:
-    branches:
-      - main
-      - release-*
+    # TODO: FOR TESTING, restore branch gating
+    # branches:
+    #   - main
+    #   - release-*
     tags:
       # YYYYMMDD
       - "20[0-9][0-9][0-1][0-9][0-3][0-9]*"
@@ -20,10 +21,9 @@ concurrency:
 env:
   RUST_LOG: info,libp2p=off,node=error
   CARGO_TERM_COLOR: always
-  DOCKER_PLATFORMS: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
 
 jobs:
-  build-x86:
+  build-amd:
     name: Build ${{ matrix.binary }}
     runs-on: ubuntu-latest
     strategy:
@@ -83,7 +83,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: x86-${{ matrix.binary }}
+          name: amd-${{ matrix.binary }}
           path: |
             upload/${{ matrix.binary == 'other' && '*' || matrix.binary }}
 
@@ -151,7 +151,8 @@ jobs:
           path: |
             upload/${{ matrix.binary == 'other' && '*' || matrix.binary }}
 
-  build-dockers:
+  build-dockers-amd:
+    needs: build-amd
     runs-on: ubuntu-latest
     # This is non-deterministic, a limitation of GHA. We but we only need the
     # tag like (:main) at the end which is the same for each matrix build.
@@ -176,9 +177,6 @@ jobs:
           - state-relay-server
           - submit-transactions
 
-    needs: [build-x86, build-arm]
-    # if build_arm is skipped, run this job anyway
-    if: ${{ !(failure() || cancelled()) }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -186,24 +184,9 @@ jobs:
       - name: Download executables AMD
         uses: actions/download-artifact@v4
         with:
-          pattern: x86-*
+          pattern: amd-*
           path: target/amd64/release
           merge-multiple: true
-
-      - name: Download executables ARM
-        if: github.event_name != 'pull_request'
-        uses: actions/download-artifact@v4
-        with:
-          pattern: arm-*
-          path: target/arm64/release
-          merge-multiple: true
-
-      - name: Setup QEMU
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/setup-qemu-action@v3
-        with:
-          # Temporary fix (See https://github.com/docker/setup-qemu-action/issues/198)
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Setup Docker BuildKit (buildx)
         uses: docker/setup-buildx-action@v3
@@ -220,47 +203,218 @@ jobs:
         uses: docker/metadata-action@v5
         id: metadata
         with:
-          images: ghcr.io/espressosystems/espresso-sequencer/${{ matrix.service }}
+          images: ghcr.io/espressosystems/espresso-sequencer/${{matrix.service}}
 
       # There is no straightforward way to import a multiplatform image from a tar file with
       # docker.
       #   - On PRs: build only amd64 and upload as artifact to later run the demo test.
       #   - On main: push to the registry and fetch from the registry to run the demo test.
-
-      - name: Build and push ${{ matrix.service }} docker image (non-PR)
-        if: ${{ github.event_name != 'pull_request' }}
+      - name: Build docker image and export to file (on PRs)
+        if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/${{ matrix.service }}.Dockerfile
-          platforms: ${{ env.DOCKER_PLATFORMS }}
-          tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels  }}
-          outputs: type=registry
-
-      - name: Build and export ${{ matrix.service }} docker image (PR only)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./docker/${{ matrix.service }}.Dockerfile
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels  }}
+          platforms: linux/amd64
           outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.service }}.tar
 
-      - name: Upload artifact (PR only)
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Upload docker image artifact (on PRs)
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.service }}-docker-image
           path: ${{ runner.temp }}/${{ matrix.service }}.tar
           if-no-files-found: error
 
-  test-demo:
-    # if build_arm is skipped, run this job anyway
-    if: ${{ !(failure() || cancelled()) }}
+      - name: Build and push docker (non-PR)
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v5
+        id: build
+        with:
+          context: .
+          file: ${{ matrix.service }}.Dockerfile
+          labels: ${{ steps.metadata.outputs.labels  }}
+          platforms: linux/amd64
+          outputs: type=image,name=ghcr.io/espressosystems/espresso-sequencer/${{ matrix.service }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export docker image digest
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          set -x
+          digest_dir="${{ runner.temp }}/digests"
+          mkdir -p "${digest_dir}"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${digest_dir}/${digest#sha256:}"
+          ls -lah "${digest_dir}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: "digests-amd64"
+          path: "${{ runner.temp }}/digests/*"
+          if-no-files-found: error
+          retention-days: 1
+
+  build-dockers-arm:
+    # Arm builds cost money, skip on PRs
+    if: github.event_name != 'pull_request'
+    needs: build-arm
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    # This is non-deterministic, a limitation of GHA. We but we only need the
+    # tag like (:main) at the end which is the same for each matrix build.
+    # outputs:
+    #   tags: ${{ steps.metadata.outputs.tags }}
+    strategy:
+      matrix:
+        service:
+          - bridge
+          - builder
+          - cdn-broker
+          - cdn-marshal
+          - cdn-whitelist
+          - deploy
+          - espresso-dev-node
+          - nasty-client
+          - node-validator
+          - orchestrator
+          - prover-service
+          - sequencer
+          - staking-cli
+          - state-relay-server
+          - submit-transactions
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Download executables ARM
+        uses: actions/download-artifact@v4
+        with:
+          pattern: arm-*
+          path: target/arm64/release
+          merge-multiple: true
+
+      - name: Setup Docker BuildKit (buildx)
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Github Container Repo
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate ${{ matrix.service }} docker metadata
+        uses: docker/metadata-action@v5
+        id: metadata
+        with:
+          images: ghcr.io/espressosystems/espresso-sequencer/${{ matrix.service }}
+
+      - name: Build and push docker
+        uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: .
+          file: docker/${{ matrix.service }}.Dockerfile
+          labels: ${{ steps.metadata.outputs.labels  }}
+          platforms: linux/arm64
+          outputs: type=image,name=ghcr.io/espressosystems/espresso-sequencer/${{  matrix.service }},push-by-digest=true,name-canonical=true,push=true
+
+
+      - name: Export docker image digest
+        shell: bash
+        run: |
+          set -x
+          digest_dir="${{ runner.temp }}/digests"
+          mkdir -p "${digest_dir}"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${digest_dir}/${digest#sha256:}"
+          ls -lah "${digest_dir}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: "digests-arm64"
+          path: "${{ runner.temp }}/digests/*"
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge the AMD64 and ARM64 images into the final (multiplatform) image.
+  #
+  # For documentation refer to
+  # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
+  create-multiplatform-docker-image:
+    if: github.event_name != 'pull_request'
+    needs: [build-dockers-amd, build-dockers-arm]
     runs-on: ubuntu-latest
-    needs: [build-dockers]
+    strategy:
+      matrix:
+        service:
+          - bridge
+          - builder
+          - cdn-broker
+          - cdn-marshal
+          - cdn-whitelist
+          - deploy
+          - espresso-dev-node
+          - nasty-client
+          - node-validator
+          - orchestrator
+          - prover-service
+          - sequencer
+          - staking-cli
+          - state-relay-server
+          - submit-transactions
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Github Container Repo
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner  }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "digests-*"
+          path: "${{ runner.temp }}/digests"
+          merge-multiple: true
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/espressosystems/espresso-sequencer/${{ matrix.service }}
+
+      - name: Create manifest list and push
+        working-directory: "${{ runner.temp }}/digests"
+        run: |
+          # Count the number of files in the directory
+          file_count=$(find . -type f | wc -l)
+
+          if [ "$file_count" -ne 2 ]; then
+            echo "Should have exactly 2 digests to combine, something went wrong"
+            ls -lah
+            exit 1
+          fi
+
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/espressosystems/espresso-sequencer/${{ matrix.service }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ghcr.io/espressosystems/espresso-sequencer/${{ matrix.service }}:${{ steps.meta.outputs.version }}
+
+  test-demo:
+    runs-on: ubuntu-latest
+    needs: [build-dockers-amd]
     steps:
       - uses: taiki-e/install-action@just
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   build-amd:
-    name: Build ${{ matrix.binary }}
+    name: Build ${{ matrix.binary }} AMD
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -102,7 +102,7 @@ jobs:
             upload/${{ matrix.binary == 'other' && '*' || matrix.binary }}
 
   build-arm:
-    name: Build ${{ matrix.binary }}
+    name: Build ${{ matrix.binary }} ARM
     runs-on: ubuntu-24.04-arm
     if: ${{ github.event_name != 'pull_request' }}
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -491,7 +491,7 @@ jobs:
 
   # This job enables having a single required status check for both test-demo jobs
   test-demo:
-    needs: [test-demo, test-demo-non-pr]
+    needs: [test-demo-pr, test-demo-non-pr]
     runs-on: ubuntu-latest
     # explicitly run and fail the job if dependencies failed
     if: ${{ always() && !cancelled() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,6 @@ jobs:
             github.ref == 'refs/heads/main'
             || startsWith(github.ref, 'refs/heads/release-')
             || github.event_name == 'workflow_dispatch' ) }}
-          cache-provider: buildjet
 
       - name: Build ${{ matrix.binary }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,9 @@ name: Build
 # instead upload the docker images as artifacts and run the demo test against the artifacts.
 on:
   push:
-    # TODO: FOR TESTING, restore branch gating
-    # branches:
-    #   - main
-    #   - release-*
+    branches:
+      - main
+      - release-*
     tags:
       # YYYYMMDD
       - "20[0-9][0-9][0-1][0-9][0-3][0-9]*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
         id: build
         with:
           context: .
-          file: ${{ matrix.service }}.Dockerfile
+          file: ./docker/${{ matrix.service }}.Dockerfile
           labels: ${{ steps.metadata.outputs.labels  }}
           platforms: linux/amd64
           outputs: type=image,name=ghcr.io/espressosystems/espresso-sequencer/${{ matrix.service }},push-by-digest=true,name-canonical=true,push=true
@@ -318,7 +318,7 @@ jobs:
         id: build
         with:
           context: .
-          file: docker/${{ matrix.service }}.Dockerfile
+          file: ./docker/${{ matrix.service }}.Dockerfile
           labels: ${{ steps.metadata.outputs.labels  }}
           platforms: linux/arm64
           outputs: type=image,name=ghcr.io/espressosystems/espresso-sequencer/${{  matrix.service }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ name: Build
 #    to the registry.
 # 4. We run the docker demo test to ensure that the images work as expected.
 #
-# For PR builds we don't build anything on ARM but only on AMD64. We pay separately for ARM builds
-# because they can't use the public github runners. For PR builds we don't push to the registry but
-# instead upload the docker images as artifacts and run the demo test against the artifacts.
+# For PR builds we don't build anything on ARM but only on AMD64. For PR builds we don't push to the
+# registry but instead upload the docker images as artifacts and run the demo test against the
+# artifacts.
 on:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
 
   build-arm:
     name: Build ${{ matrix.binary }}
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     if: ${{ github.event_name != 'pull_request' }}
     strategy:
       matrix:
@@ -277,7 +277,7 @@ jobs:
     # Arm builds cost money, skip on PRs
     if: github.event_name != 'pull_request'
     needs: build-arm
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         service:


### PR DESCRIPTION
QEMU is very slow which limits us to what we can do in docker builds within reasonable time. We do want images to build quickly in order to deploy them. This PR builds native images on AMD and ARM architectures and then merges them into a multiplatform image.

Concretely in #3077 we need to add a typescript script to the deploy image and installing this takes ages with QEMU.

Since we use public arm runners now we could consider always doing the ARM and multiplatform builds. I don't have much of a preference here, it seems a bit wasteful but the workflow file would become a bit simpler, arm and amd builds would become almost the same and we could use a matrix for that too. If anyone has opinions here please weigh in. Edit: I would like to safe this for follow up work, this PR is already large, and annoying to test.

The workflow file contains some duplication, notably the github action matrix over services. I didn't want to create another job and we don't add binaries very often so I think dynamically outputting a matrix from a job isn't really worth it. Don't mind changing it tough.

### Follow up
- https://github.com/EspressoSystems/espresso-network/issues/3348


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210452759586916