### PR TITLE
fix: add missing import Update block_types.rs

### DIFF
--- a/crates/hotshot/example-types/src/block_types.rs
+++ b/crates/hotshot/example-types/src/block_types.rs
@@ -25,6 +25,9 @@ use hotshot_types::{
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use sha3::{Digest, Keccak256};
 use thiserror::Error;
 use time::OffsetDateTime;
 use vbs::version::Version;


### PR DESCRIPTION
The TestBlockHeader::builder_commitment method references sha2::Sha256, but the sha2 crate was not imported. This causes a compilation error. This PR adds the required use sha2::Sha256; import.

After this change, builder_commitment can successfully call Sha256::new() without a missing-import error.