### PR TITLE
fix: incorrect call in Update storage_types.rs

### DIFF
--- a/crates/hotshot/example-types/src/storage_types.rs
+++ b/crates/hotshot/example-types/src/storage_types.rs
@@ -273,7 +273,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
         let mut inner = self.inner.write().await;
         inner
             .proposals_wrapper
-            .insert(proposal.data.view_number(), proposal.clone());
+            .insert(proposal.data.view_number, proposal.clone());
         Ok(())
     }
 


### PR DESCRIPTION
In the append_proposal_wrapper method, we were calling proposal.data.view_number()—but QuorumProposalWrapper exposes view_number as a field, not a method. This caused a compilation error. This PR replaces the incorrect method call with a field access.

With this change, the code now compiles successfully.