### PR TITLE
fix: generator to return Arc<MemoryNetwork> instead of net.into() Upd…

### DIFF
--- a/crates/hotshot/hotshot/src/traits/networking/memory_network.rs
+++ b/crates/hotshot/hotshot/src/traits/networking/memory_network.rs
@@ -207,7 +207,7 @@ impl<TYPES: NodeType> TestableNetworkingImplementation<TYPES>
                 &subscribed_topics,
                 reliability_config.clone(),
             );
-            Box::pin(async move { net.into() })
+            Box::pin(async move { Arc::new(net) })
         })
     }
 


### PR DESCRIPTION
Description:

The TestableNetworkingImplementation::generator method for MemoryNetwork was returning net.into(), but there’s no From<MemoryNetwork<K>> for Arc<MemoryNetwork<K>> implementation. As a result, the code fails to compile with an error indicating that Arc<MemoryNetwork<K>>: From<MemoryNetwork<K>> is not satisfied.

This pull request replaces net.into() with Arc::new(net), ensuring that the generator indeed returns an Arc<MemoryNetwork<K>> as expected by the trait.

Change Details:

In the generator closure, replaced net.into() with Arc::new(net).

Now the closure correctly returns Arc<MemoryNetwork<K>>, matching the AsyncGenerator<Arc<Self>> signature.