### PR TITLE
Improve logging in Espresso go multiclient

### DIFF
--- a/sdks/go/client/multiple_nodes_test.go
+++ b/sdks/go/client/multiple_nodes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -13,6 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+var errs []error
+var defaultFetchWithMajorityError = fmt.Errorf("No majority consensus reached with potential errors. Errors: %v\n", errs)
 
 // MockClient is a mock implementation of the Client interface
 type MockClient struct {
@@ -56,7 +60,7 @@ func TestFetchWithMajority(t *testing.T) {
 	})
 
 	assert.Error(t, err)
-	assert.Equal(t, "no majority consensus reached", err.Error())
+	assert.Equal(t, defaultFetchWithMajorityError.Error(), err.Error())
 
 	// Simulate a scenario where all nodes return an error
 	mockNode1.On("FetchRawHeaderByHeight", ctx, uint64(3)).Return(json.RawMessage{}, errors.New("error"))


### PR DESCRIPTION
Closes # Appchain investigation

### This PR:
In the short term, this PR is to assist with debugging the Appchain mainnet incident, In the long term. I would like to change the return signatures for some of the functions of the `MultipleNodesClient` with partial error information for adding debugging logs in consumer programs.

Adds some improved logging to the espresso go client. It also adds an error collection array to all methods that iterate over the individual clients for the multi node client to collect error messages.
This PR also modifies the tests to account for the modified return values.

### This PR does not:

Modify the client API such that the MultipleNodesClient will capture and return errors from specific nodes so that the Caller may report individual error messages in whatever logging framework they choose.

I can't think of a particularly great/non intrusive way to propagate errors to the caller. My intuition is to modify the return signatures to return an `[]error` value. This new return value would be different not be the `error` field that indicates the function call failed. Regardless to properly propagate the errors to the caller, the return signature will need to change to avoid breaking error semantics for consumers.

### Key places to review:
All 2 files of the PR.

### How to test this PR:

from the `/espresso-network/sdks/go` repo run `go test -run ^TestFetchWithMajority$ github.com/EspressoSystems/espresso-network/sdks/go/client`