### PR TITLE
Add Metric for Proposal Latency

### DIFF
--- a/crates/hotshot/example-types/src/block_types.rs
+++ b/crates/hotshot/example-types/src/block_types.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::{Debug, Display},
     mem::size_of,
     sync::Arc,
+    time::SystemTime,
 };
 
 use async_trait::async_trait;
@@ -385,6 +386,13 @@ impl<
             self.block_number,
             self.payload_commitment.as_ref(),
         )
+    }
+
+    fn timestamp(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
     }
 }
 

--- a/crates/hotshot/task-impls/src/helpers.rs
+++ b/crates/hotshot/task-impls/src/helpers.rs
@@ -44,6 +44,7 @@ use hotshot_types::{
     vote::{Certificate, HasViewNumber},
 };
 use hotshot_utils::anytrace::*;
+use time::OffsetDateTime;
 use tokio::time::timeout;
 use tracing::instrument;
 use vbs::version::StaticVersionType;
@@ -303,6 +304,26 @@ impl<TYPES: NodeType + Default> Default for LeafChainTraversalOutcome<TYPES> {
     }
 }
 
+async fn update_metrics<TYPES: NodeType>(
+    consensus: &OuterConsensus<TYPES>,
+    leaf_views: &[LeafInfo<TYPES>],
+) {
+    for leaf_view in leaf_views {
+        let consensus_reader = consensus.read().await;
+        let now = OffsetDateTime::now_utc().unix_timestamp() as u64;
+        let proposal_timestamp = leaf_view.leaf.block_header().timestamp();
+
+        let Some(proposal_to_decide_time) = now.checked_sub(proposal_timestamp) else {
+            tracing::error!("Failed to calculate proposal to decide time: {proposal_timestamp}");
+            continue;
+        };
+        consensus_reader
+            .metrics
+            .proposal_to_decide_time
+            .add_point(proposal_to_decide_time as f64);
+    }
+}
+
 /// calculate the new decided leaf chain based on the rules of HotStuff 2
 ///
 /// # Panics
@@ -413,6 +434,7 @@ pub async fn decide_from_proposal_2<TYPES: NodeType, I: NodeImplementation<TYPES
             )
             .await;
         }
+        update_metrics(&consensus, &res.leaf_views).await;
     }
 
     res

--- a/crates/hotshot/types/src/consensus.rs
+++ b/crates/hotshot/types/src/consensus.rs
@@ -394,6 +394,12 @@ pub struct ConsensusMetricsValue {
     pub number_of_empty_blocks_proposed: Box<dyn Counter>,
     /// Number of events in the hotshot event queue
     pub internal_event_queue_len: Box<dyn Gauge>,
+    /// Time from proposal creation to decide time
+    pub proposal_to_decide_time: Box<dyn Histogram>,
+    /// Time from proposal received to proposal creation
+    pub previous_proposal_to_proposal_time: Box<dyn Histogram>,
+    /// Finalized bytes per view
+    pub finalized_bytes: Box<dyn Histogram>,
 }
 
 impl ConsensusMetricsValue {
@@ -425,6 +431,11 @@ impl ConsensusMetricsValue {
                 .create_counter(String::from("number_of_empty_blocks_proposed"), None),
             internal_event_queue_len: metrics
                 .create_gauge(String::from("internal_event_queue_len"), None),
+            proposal_to_decide_time: metrics
+                .create_histogram(String::from("proposal_to_decide_time"), None),
+            previous_proposal_to_proposal_time: metrics
+                .create_histogram(String::from("previous_proposal_to_proposal_time"), None),
+            finalized_bytes: metrics.create_histogram(String::from("finalized_bytes"), None),
         }
     }
 }

--- a/crates/hotshot/types/src/traits/block_contents.rs
+++ b/crates/hotshot/types/src/traits/block_contents.rs
@@ -188,6 +188,9 @@ pub trait BlockHeader<TYPES: NodeType>:
     /// Get the block number.
     fn block_number(&self) -> u64;
 
+    /// Get the timestamp.
+    fn timestamp(&self) -> u64;
+
     /// Get the payload commitment.
     fn payload_commitment(&self) -> VidCommitment;
 

--- a/hotshot-query-service/src/availability/query_data.rs
+++ b/hotshot-query-service/src/availability/query_data.rs
@@ -48,10 +48,6 @@ pub type TransactionInclusionProof<Types> =
 
 pub type Timestamp = time::OffsetDateTime;
 
-pub trait QueryableHeader<Types: NodeType>: BlockHeader<Types> {
-    fn timestamp(&self) -> u64;
-}
-
 #[derive(Clone, Copy, Debug)]
 pub struct TransactionIndex {
     /// Identifier of the namespace this transaction belongs to.

--- a/hotshot-query-service/src/data_source.rs
+++ b/hotshot-query-service/src/data_source.rs
@@ -775,16 +775,17 @@ pub mod node_tests {
     };
     use hotshot_types::{
         data::{vid_commitment, VidCommitment, VidShare},
-        traits::{block_contents::EncodeBytes, node_implementation::Versions},
+        traits::{
+            block_contents::{BlockHeader, EncodeBytes},
+            node_implementation::Versions,
+        },
         vid::advz::{advz_scheme, ADVZScheme},
     };
     use jf_vid::VidScheme;
     use vbs::version::StaticVersionType;
 
     use crate::{
-        availability::{
-            BlockInfo, BlockQueryData, LeafQueryData, QueryableHeader, VidCommonQueryData,
-        },
+        availability::{BlockInfo, BlockQueryData, LeafQueryData, VidCommonQueryData},
         data_source::{
             storage::{NodeStorage, UpdateAvailabilityStorage},
             update::Transaction,
@@ -1232,7 +1233,9 @@ pub mod node_tests {
             let leaf = leaves.next().await.unwrap();
             let header = leaf.header().clone();
             if let Some(last_timestamp) = test_blocks.last_mut() {
-                if last_timestamp[0].timestamp() == header.timestamp() {
+                if <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(&last_timestamp[0])
+                    == <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(&header)
+                {
                     last_timestamp.push(header);
                 } else {
                     test_blocks.push(vec![header]);
@@ -1244,33 +1247,41 @@ pub mod node_tests {
         tracing::info!("blocks for testing: {test_blocks:#?}");
 
         // Define invariants that every response should satisfy.
-        let check_invariants =
-            |res: &TimeWindowQueryData<Header<MockTypes>>, start, end, check_prev| {
-                let mut prev = res.prev.as_ref();
-                if let Some(prev) = prev {
-                    if check_prev {
-                        assert!(prev.timestamp() < start);
-                    }
-                } else {
-                    // `prev` can only be `None` if the first block in the window is the genesis
-                    // block.
-                    assert_eq!(res.from().unwrap(), 0);
-                };
-                for header in &res.window {
-                    assert!(start <= header.timestamp());
-                    assert!(header.timestamp() < end);
-                    if let Some(prev) = prev {
-                        assert!(prev.timestamp() <= header.timestamp());
-                    }
-                    prev = Some(header);
+        let check_invariants = |res: &TimeWindowQueryData<Header<MockTypes>>,
+                                start,
+                                end,
+                                check_prev| {
+            let mut prev = res.prev.as_ref();
+            if let Some(prev) = prev {
+                if check_prev {
+                    assert!(<TestBlockHeader as BlockHeader<MockTypes>>::timestamp(prev) < start);
                 }
-                if let Some(next) = &res.next {
-                    assert!(next.timestamp() >= end);
-                    // If there is a `next`, there must be at least one previous block (either `prev`
-                    // itself or the last block if the window is nonempty), so we can `unwrap` here.
-                    assert!(next.timestamp() >= prev.unwrap().timestamp());
-                }
+            } else {
+                // `prev` can only be `None` if the first block in the window is the genesis
+                // block.
+                assert_eq!(res.from().unwrap(), 0);
             };
+            for header in &res.window {
+                assert!(start <= <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(header));
+                assert!(<TestBlockHeader as BlockHeader<MockTypes>>::timestamp(header) < end);
+                if let Some(prev) = prev {
+                    assert!(
+                        <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(prev)
+                            <= <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(header)
+                    );
+                }
+                prev = Some(header);
+            }
+            if let Some(next) = &res.next {
+                assert!(<TestBlockHeader as BlockHeader<MockTypes>>::timestamp(next) >= end);
+                // If there is a `next`, there must be at least one previous block (either `prev`
+                // itself or the last block if the window is nonempty), so we can `unwrap` here.
+                assert!(
+                    <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(next)
+                        >= <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(prev.unwrap())
+                );
+            }
+        };
 
         let get_window = |start, end| {
             let ds = ds.clone();
@@ -1286,7 +1297,7 @@ pub mod node_tests {
         };
 
         // Case 0: happy path. All blocks are available, including prev and next.
-        let start = test_blocks[1][0].timestamp();
+        let start = <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(&test_blocks[1][0]);
         let end = start + 1;
         let res = get_window(start, end).await;
         assert_eq!(res.prev.unwrap(), *test_blocks[0].last().unwrap());
@@ -1295,14 +1306,14 @@ pub mod node_tests {
 
         // Case 1: no `prev`, start of window is before genesis.
         let start = 0;
-        let end = test_blocks[0][0].timestamp() + 1;
+        let end = <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(&test_blocks[0][0]) + 1;
         let res = get_window(start, end).await;
         assert_eq!(res.prev, None);
         assert_eq!(res.window, test_blocks[0]);
         assert_eq!(res.next.unwrap(), test_blocks[1][0]);
 
         // Case 2: no `next`, end of window is after the most recently sequenced block.
-        let start = test_blocks[2][0].timestamp();
+        let start = <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(&test_blocks[2][0]);
         let end = i64::MAX as u64;
         let res = get_window(start, end).await;
         assert_eq!(res.prev.unwrap(), *test_blocks[1].last().unwrap());
@@ -1344,7 +1355,7 @@ pub mod node_tests {
         assert_eq!(more2.window[..more.window.len()], more.window);
 
         // Case 3: the window is empty.
-        let start = test_blocks[1][0].timestamp();
+        let start = <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(&test_blocks[1][0]);
         let end = start;
         let res = get_window(start, end).await;
         assert_eq!(res.prev.unwrap(), *test_blocks[0].last().unwrap());
@@ -1366,8 +1377,8 @@ pub mod node_tests {
             .flatten()
             .collect::<Vec<_>>();
         // Make a query that would return everything, but gets limited.
-        let start = blocks[0].timestamp();
-        let end = test_blocks[2][0].timestamp();
+        let start = <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(&blocks[0]);
+        let end = <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(&test_blocks[2][0]);
         let res = ds
             .get_header_window(WindowStart::Time(start), end, 1)
             .await

--- a/hotshot-query-service/src/data_source/extension.rs
+++ b/hotshot-query-service/src/data_source/extension.rs
@@ -13,7 +13,10 @@
 use std::ops::{Bound, RangeBounds};
 
 use async_trait::async_trait;
-use hotshot_types::{data::VidShare, traits::node_implementation::NodeType};
+use hotshot_types::{
+    data::VidShare,
+    traits::{block_contents::BlockHeader, node_implementation::NodeType},
+};
 use jf_merkle_tree::prelude::MerkleProof;
 use tagged_base64::TaggedBase64;
 
@@ -21,9 +24,9 @@ use super::VersionedDataSource;
 use crate::{
     availability::{
         AvailabilityDataSource, BlockId, BlockInfo, BlockQueryData, Fetch, FetchStream, LeafId,
-        LeafQueryData, PayloadMetadata, PayloadQueryData, QueryableHeader, QueryablePayload,
-        StateCertQueryData, TransactionHash, TransactionQueryData, UpdateAvailabilityData,
-        VidCommonMetadata, VidCommonQueryData,
+        LeafQueryData, PayloadMetadata, PayloadQueryData, QueryablePayload, StateCertQueryData,
+        TransactionHash, TransactionQueryData, UpdateAvailabilityData, VidCommonMetadata,
+        VidCommonQueryData,
     },
     data_source::storage::pruning::PrunedHeightDataSource,
     explorer::{self, ExplorerDataSource, ExplorerHeader, ExplorerTransaction},
@@ -441,7 +444,7 @@ where
     U: Send + Sync,
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: ExplorerHeader<Types> + QueryableHeader<Types>,
+    Header<Types>: ExplorerHeader<Types> + BlockHeader<Types>,
     Transaction<Types>: ExplorerTransaction,
 {
     async fn get_block_detail(

--- a/hotshot-query-service/src/data_source/fetching.rs
+++ b/hotshot-query-service/src/data_source/fetching.rs
@@ -96,6 +96,7 @@ use futures::{
 use hotshot_types::{
     data::VidShare,
     traits::{
+        block_contents::BlockHeader,
         metrics::{Gauge, Metrics},
         node_implementation::NodeType,
     },
@@ -119,7 +120,7 @@ use super::{
 use crate::{
     availability::{
         AvailabilityDataSource, BlockId, BlockInfo, BlockQueryData, Fetch, FetchStream,
-        HeaderQueryData, LeafId, LeafQueryData, PayloadMetadata, PayloadQueryData, QueryableHeader,
+        HeaderQueryData, LeafId, LeafQueryData, PayloadMetadata, PayloadQueryData,
         QueryablePayload, StateCertQueryData, TransactionHash, TransactionQueryData,
         UpdateAvailabilityData, VidCommonMetadata, VidCommonQueryData,
     },
@@ -388,7 +389,7 @@ impl<Types, S, P> Builder<Types, S, P>
 where
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
     S: PruneStorage + VersionedDataSource + HasMetrics + MigrateTypes<Types> + 'static,
     for<'a> S::ReadOnly<'a>:
         AvailabilityStorage<Types> + PrunedHeightStorage + NodeStorage<Types> + AggregatesStorage,
@@ -501,7 +502,7 @@ impl<Types, S, P> FetchingDataSource<Types, S, P>
 where
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
     S: VersionedDataSource + PruneStorage + HasMetrics + MigrateTypes<Types> + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types> + UpdateAggregatesStorage<Types>,
     for<'a> S::ReadOnly<'a>:
@@ -1904,7 +1905,7 @@ impl<Types, S, P> ExplorerDataSource<Types> for FetchingDataSource<Types, S, P>
 where
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types> + explorer::traits::ExplorerHeader<Types>,
+    Header<Types>: BlockHeader<Types> + explorer::traits::ExplorerHeader<Types>,
     crate::Transaction<Types>: explorer::traits::ExplorerTransaction,
     S: VersionedDataSource + 'static,
     for<'a> S::ReadOnly<'a>: ExplorerStorage<Types>,

--- a/hotshot-query-service/src/data_source/fs.rs
+++ b/hotshot-query-service/src/data_source/fs.rs
@@ -15,14 +15,11 @@
 use std::path::Path;
 
 use atomic_store::AtomicStoreLoader;
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
 
 pub use super::storage::fs::Transaction;
 use super::{storage::FileSystemStorage, AvailabilityProvider, FetchingDataSource};
-use crate::{
-    availability::{query_data::QueryablePayload, QueryableHeader},
-    Header, Payload,
-};
+use crate::{availability::query_data::QueryablePayload, Header, Payload};
 
 /// A data source for the APIs provided in this crate, backed by the local file system.
 ///
@@ -161,7 +158,7 @@ pub type FileSystemDataSource<Types, P> = FetchingDataSource<Types, FileSystemSt
 impl<Types: NodeType, P> FileSystemDataSource<Types, P>
 where
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
     P: AvailabilityProvider<Types>,
 {
     /// Create a new [FileSystemDataSource] with storage at `path`.

--- a/hotshot-query-service/src/data_source/sql.rs
+++ b/hotshot-query-service/src/data_source/sql.rs
@@ -13,7 +13,7 @@
 #![cfg(feature = "sql-data-source")]
 
 pub use anyhow::Error;
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
 pub use refinery::Migration;
 pub use sql::Transaction;
 
@@ -23,10 +23,7 @@ use super::{
     AvailabilityProvider, FetchingDataSource,
 };
 pub use crate::include_migrations;
-use crate::{
-    availability::{QueryableHeader, QueryablePayload},
-    Header, Payload,
-};
+use crate::{availability::QueryablePayload, Header, Payload};
 
 pub type Builder<Types, Provider> = fetching::Builder<Types, SqlStorage, Provider>;
 
@@ -40,7 +37,7 @@ impl Config {
     ) -> Result<SqlDataSource<Types, P>, Error>
     where
         Types: NodeType,
-        Header<Types>: QueryableHeader<Types>,
+        Header<Types>: BlockHeader<Types>,
         Payload<Types>: QueryablePayload<Types>,
     {
         self.builder(provider).await?.build().await
@@ -54,7 +51,7 @@ impl Config {
     ) -> Result<Builder<Types, P>, Error>
     where
         Types: NodeType,
-        Header<Types>: QueryableHeader<Types>,
+        Header<Types>: BlockHeader<Types>,
         Payload<Types>: QueryablePayload<Types>,
     {
         SqlDataSource::connect(self, provider).await
@@ -301,7 +298,7 @@ pub type SqlDataSource<Types, P> = FetchingDataSource<Types, SqlStorage, P>;
 impl<Types, P: AvailabilityProvider<Types>> SqlDataSource<Types, P>
 where
     Types: NodeType,
-    Header<Types>: QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     /// Connect to a remote database.

--- a/hotshot-query-service/src/data_source/storage.rs
+++ b/hotshot-query-service/src/data_source/storage.rs
@@ -60,15 +60,18 @@ use std::ops::RangeBounds;
 
 use async_trait::async_trait;
 use futures::future::Future;
-use hotshot_types::{data::VidShare, traits::node_implementation::NodeType};
+use hotshot_types::{
+    data::VidShare,
+    traits::{block_contents::BlockHeader, node_implementation::NodeType},
+};
 use jf_merkle_tree::prelude::MerkleProof;
 use tagged_base64::TaggedBase64;
 
 use crate::{
     availability::{
         BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadMetadata, PayloadQueryData,
-        QueryableHeader, QueryablePayload, StateCertQueryData, TransactionHash,
-        TransactionQueryData, VidCommonMetadata, VidCommonQueryData,
+        QueryablePayload, StateCertQueryData, TransactionHash, TransactionQueryData,
+        VidCommonMetadata, VidCommonQueryData,
     },
     explorer::{
         query_data::{
@@ -287,7 +290,7 @@ where
 pub trait ExplorerStorage<Types>
 where
     Types: NodeType,
-    Header<Types>: ExplorerHeader<Types> + QueryableHeader<Types>,
+    Header<Types>: ExplorerHeader<Types> + BlockHeader<Types>,
     Transaction<Types>: ExplorerTransaction,
     Payload<Types>: QueryablePayload<Types>,
 {

--- a/hotshot-query-service/src/data_source/storage/fs.rs
+++ b/hotshot-query-service/src/data_source/storage/fs.rs
@@ -48,8 +48,8 @@ use crate::{
     availability::{
         data_source::{BlockId, LeafId},
         query_data::{
-            BlockHash, BlockQueryData, LeafHash, LeafQueryData, PayloadQueryData, QueryableHeader,
-            QueryablePayload, TransactionHash, TransactionQueryData, VidCommonQueryData,
+            BlockHash, BlockQueryData, LeafHash, LeafQueryData, PayloadQueryData, QueryablePayload,
+            TransactionHash, TransactionQueryData, VidCommonQueryData,
         },
         StateCertQueryData,
     },
@@ -158,7 +158,7 @@ where
 impl<Types: NodeType> FileSystemStorage<Types>
 where
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
 {
     /// Create a new [FileSystemStorage] with storage at `path`.
     ///
@@ -490,7 +490,7 @@ impl<Types, T> AvailabilityStorage<Types> for Transaction<T>
 where
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
     T: Revert + Deref<Target = FileSystemStorageInner<Types>> + Send + Sync,
 {
     async fn get_leaf(&mut self, id: LeafId<Types>) -> QueryResult<LeafQueryData<Types>> {
@@ -656,7 +656,7 @@ impl<Types: NodeType> UpdateAvailabilityStorage<Types>
     for Transaction<RwLockWriteGuard<'_, FileSystemStorageInner<Types>>>
 where
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
 {
     async fn insert_leaf(&mut self, leaf: LeafQueryData<Types>) -> anyhow::Result<()> {
         self.inner
@@ -749,7 +749,7 @@ impl<Types, T> NodeStorage<Types> for Transaction<T>
 where
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
     T: Revert + Deref<Target = FileSystemStorageInner<Types>> + Send,
 {
     async fn block_height(&mut self) -> QueryResult<usize> {

--- a/hotshot-query-service/src/data_source/storage/sql/queries/availability.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/availability.rs
@@ -16,7 +16,7 @@ use std::ops::RangeBounds;
 
 use async_trait::async_trait;
 use futures::stream::{StreamExt, TryStreamExt};
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
 use snafu::OptionExt;
 use sqlx::FromRow;
 
@@ -27,9 +27,8 @@ use super::{
 };
 use crate::{
     availability::{
-        BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadQueryData, QueryableHeader,
-        QueryablePayload, StateCertQueryData, TransactionHash, TransactionQueryData,
-        VidCommonQueryData,
+        BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadQueryData, QueryablePayload,
+        StateCertQueryData, TransactionHash, TransactionQueryData, VidCommonQueryData,
     },
     data_source::storage::{
         sql::sqlx::Row, AvailabilityStorage, PayloadMetadata, VidCommonMetadata,
@@ -44,7 +43,7 @@ where
     Types: NodeType,
     Mode: TransactionMode,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
 {
     async fn get_leaf(&mut self, id: LeafId<Types>) -> QueryResult<LeafQueryData<Types>> {
         let mut query = QueryBuilder::default();

--- a/hotshot-query-service/src/data_source/storage/sql/queries/explorer.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/explorer.rs
@@ -17,7 +17,7 @@ use std::{collections::VecDeque, num::NonZeroUsize};
 use async_trait::async_trait;
 use committable::{Commitment, Committable};
 use futures::stream::{self, StreamExt, TryStreamExt};
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
 use itertools::Itertools;
 use sqlx::{FromRow, Row};
 use tagged_base64::{Tagged, TaggedBase64};
@@ -27,7 +27,7 @@ use super::{
     Database, Db, DecodeError, BLOCK_COLUMNS,
 };
 use crate::{
-    availability::{BlockQueryData, QueryableHeader, QueryablePayload},
+    availability::{BlockQueryData, QueryablePayload},
     data_source::storage::{ExplorerStorage, NodeStorage},
     explorer::{
         self,
@@ -83,7 +83,7 @@ impl From<sqlx::Error> for GetSearchResultsError {
 impl<'r, Types> FromRow<'r, <Db as Database>::Row> for BlockSummary<Types>
 where
     Types: NodeType,
-    Header<Types>: QueryableHeader<Types> + ExplorerHeader<Types>,
+    Header<Types>: BlockHeader<Types> + ExplorerHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn from_row(row: &'r <Db as Database>::Row) -> sqlx::Result<Self> {
@@ -96,7 +96,7 @@ where
 impl<'r, Types> FromRow<'r, <Db as Database>::Row> for BlockDetail<Types>
 where
     Types: NodeType,
-    Header<Types>: QueryableHeader<Types> + ExplorerHeader<Types>,
+    Header<Types>: BlockHeader<Types> + ExplorerHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     BalanceAmount<Types>: Into<MonetaryValue>,
 {
@@ -270,7 +270,7 @@ where
     Mode: TransactionMode,
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types> + ExplorerHeader<Types>,
+    Header<Types>: BlockHeader<Types> + ExplorerHeader<Types>,
     crate::Transaction<Types>: explorer::traits::ExplorerTransaction,
     BalanceAmount<Types>: Into<explorer::monetary_value::MonetaryValue>,
 {

--- a/hotshot-query-service/src/data_source/storage/sql/transaction.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/transaction.rs
@@ -56,8 +56,7 @@ use super::{
 };
 use crate::{
     availability::{
-        BlockQueryData, LeafQueryData, QueryableHeader, QueryablePayload, StateCertQueryData,
-        VidCommonQueryData,
+        BlockQueryData, LeafQueryData, QueryablePayload, StateCertQueryData, VidCommonQueryData,
     },
     data_source::{
         storage::{pruning::PrunedHeightStorage, UpdateAvailabilityStorage},
@@ -464,7 +463,7 @@ impl<Types> UpdateAvailabilityStorage<Types> for Transaction<Write>
 where
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
 {
     async fn insert_leaf(&mut self, leaf: LeafQueryData<Types>) -> anyhow::Result<()> {
         let height = leaf.height();

--- a/hotshot-query-service/src/explorer.rs
+++ b/hotshot-query-service/src/explorer.rs
@@ -22,7 +22,7 @@ use std::{fmt::Display, num::NonZeroUsize, path::Path};
 pub use currency::*;
 pub use data_source::*;
 use futures::FutureExt;
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
 pub use monetary_value::*;
 pub use query_data::*;
 use serde::{Deserialize, Serialize};
@@ -31,11 +31,7 @@ pub use traits::*;
 use vbs::version::StaticVersionType;
 
 use self::errors::InvalidLimit;
-use crate::{
-    api::load_api,
-    availability::{QueryableHeader, QueryablePayload},
-    Header, Payload, Transaction,
-};
+use crate::{api::load_api, availability::QueryablePayload, Header, Payload, Transaction};
 
 /// [Error] is an enum that represents the various errors that can be returned
 /// from the Explorer API.
@@ -242,7 +238,7 @@ pub fn define_api<State, Types: NodeType, Ver: StaticVersionType + 'static>(
 ) -> Result<Api<State, Error, Ver>, ApiError>
 where
     State: 'static + Send + Sync + ReadState,
-    Header<Types>: ExplorerHeader<Types> + QueryableHeader<Types>,
+    Header<Types>: ExplorerHeader<Types> + BlockHeader<Types>,
     Transaction<Types>: ExplorerTransaction,
     Payload<Types>: QueryablePayload<Types>,
     <State as ReadState>::State: ExplorerDataSource<Types> + Send + Sync,

--- a/hotshot-query-service/src/explorer/data_source.rs
+++ b/hotshot-query-service/src/explorer/data_source.rs
@@ -11,7 +11,7 @@
 // see <https://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
 use tagged_base64::TaggedBase64;
 
 use super::{
@@ -24,10 +24,7 @@ use super::{
     },
     traits::{ExplorerHeader, ExplorerTransaction},
 };
-use crate::{
-    availability::{QueryableHeader, QueryablePayload},
-    Header, Payload, Transaction,
-};
+use crate::{availability::QueryablePayload, Header, Payload, Transaction};
 
 /// An interface for querying Data and Statistics from the HotShot Blockchain.
 ///
@@ -42,7 +39,7 @@ use crate::{
 pub trait ExplorerDataSource<Types>
 where
     Types: NodeType,
-    Header<Types>: ExplorerHeader<Types> + QueryableHeader<Types>,
+    Header<Types>: ExplorerHeader<Types> + BlockHeader<Types>,
     Transaction<Types>: ExplorerTransaction,
     Payload<Types>: QueryablePayload<Types>,
 {

--- a/hotshot-query-service/src/explorer/query_data.rs
+++ b/hotshot-query-service/src/explorer/query_data.rs
@@ -16,7 +16,7 @@ use std::{
     num::{NonZeroUsize, TryFromIntError},
 };
 
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
 use serde::{Deserialize, Serialize};
 use tide_disco::StatusCode;
 use time::format_description::well_known::Rfc3339;
@@ -27,7 +27,7 @@ use super::{
     traits::{ExplorerHeader, ExplorerTransaction},
 };
 use crate::{
-    availability::{BlockQueryData, QueryableHeader, QueryablePayload, TransactionHash},
+    availability::{BlockQueryData, QueryablePayload, TransactionHash},
     node::BlockHash,
     types::HeightIndexed,
     Header, Payload, Resolvable, Transaction,
@@ -173,7 +173,7 @@ impl<Types: NodeType> TryFrom<BlockQueryData<Types>> for BlockDetail<Types>
 where
     BlockQueryData<Types>: HeightIndexed,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types> + ExplorerHeader<Types>,
+    Header<Types>: BlockHeader<Types> + ExplorerHeader<Types>,
     BalanceAmount<Types>: Into<MonetaryValue>,
 {
     type Error = TimestampConversionError;
@@ -263,7 +263,7 @@ impl<Types: NodeType> TryFrom<BlockQueryData<Types>> for BlockSummary<Types>
 where
     BlockQueryData<Types>: HeightIndexed,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types> + ExplorerHeader<Types>,
+    Header<Types>: BlockHeader<Types> + ExplorerHeader<Types>,
 {
     type Error = TimestampConversionError;
 
@@ -349,7 +349,7 @@ impl<Types: NodeType>
 where
     BlockQueryData<Types>: HeightIndexed,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types> + ExplorerHeader<Types>,
+    Header<Types>: BlockHeader<Types> + ExplorerHeader<Types>,
     Transaction<Types>: ExplorerTransaction,
 {
     type Error = TimestampConversionError;
@@ -383,7 +383,7 @@ impl<Types: NodeType>
 where
     BlockQueryData<Types>: HeightIndexed,
     Payload<Types>: QueryablePayload<Types>,
-    Header<Types>: QueryableHeader<Types> + ExplorerHeader<Types>,
+    Header<Types>: BlockHeader<Types> + ExplorerHeader<Types>,
     <Types as NodeType>::Transaction: ExplorerTransaction,
 {
     type Error = TimestampConversionError;

--- a/hotshot-query-service/src/lib.rs
+++ b/hotshot-query-service/src/lib.rs
@@ -436,6 +436,7 @@ pub use error::Error;
 use futures::{future::BoxFuture, stream::StreamExt};
 use hotshot::types::SystemContextHandle;
 use hotshot_types::traits::{
+    block_contents::BlockHeader,
     node_implementation::{NodeImplementation, NodeType, Versions},
     BlockPayload,
 };
@@ -530,7 +531,7 @@ pub async fn run_standalone_service<
 ) -> Result<(), Error>
 where
     Payload<Types>: availability::QueryablePayload<Types>,
-    Header<Types>: availability::QueryableHeader<Types>,
+    Header<Types>: BlockHeader<Types>,
     D: availability::AvailabilityDataSource<Types>
         + data_source::UpdateDataSource<Types>
         + node::NodeDataSource<Types>

--- a/hotshot-query-service/src/testing/mocks.rs
+++ b/hotshot-query-service/src/testing/mocks.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use vbs::version::StaticVersion;
 
 use crate::{
-    availability::{QueryableHeader, QueryablePayload, TransactionIndex},
+    availability::{QueryablePayload, TransactionIndex},
     explorer::traits::{ExplorerHeader, ExplorerTransaction},
     merklized_state::MerklizedState,
     types::HeightIndexed,
@@ -44,12 +44,6 @@ pub type MockTransaction = TestTransaction;
 
 pub fn mock_transaction(payload: Vec<u8>) -> MockTransaction {
     TestTransaction::new(payload)
-}
-
-impl QueryableHeader<MockTypes> for MockHeader {
-    fn timestamp(&self) -> u64 {
-        self.timestamp
-    }
 }
 
 impl ExplorerHeader<MockTypes> for MockHeader {

--- a/node-metrics/src/service/data_state/mod.rs
+++ b/node-metrics/src/service/data_state/mod.rs
@@ -9,7 +9,7 @@ use circular_buffer::CircularBuffer;
 use espresso_types::{Header, Payload, SeqTypes};
 use futures::{channel::mpsc::SendError, Sink, SinkExt, Stream, StreamExt};
 use hotshot_query_service::{
-    availability::{BlockQueryData, Leaf1QueryData, QueryableHeader},
+    availability::{BlockQueryData, Leaf1QueryData},
     explorer::{BlockDetail, ExplorerHeader, Timestamp},
     Resolvable,
 };
@@ -349,7 +349,7 @@ async fn process_incoming_leaf_and_block<BDSink, BVSink>(
     mut voters_sender: BVSink,
 ) -> Result<(), ProcessLeafError>
 where
-    Header: BlockHeader<SeqTypes> + QueryableHeader<SeqTypes> + ExplorerHeader<SeqTypes>,
+    Header: BlockHeader<SeqTypes> + BlockHeader<SeqTypes> + ExplorerHeader<SeqTypes>,
     Payload: BlockPayload<SeqTypes>,
     BDSink: Sink<BlockDetail<SeqTypes>, Error = SendError> + Unpin,
     BVSink: Sink<BitVec<u16>, Error = SendError> + Unpin,
@@ -499,7 +499,7 @@ impl ProcessLeafAndBlockPairStreamTask {
         voters_senders: BVSink,
     ) where
         S: Stream<Item = LeafAndBlock<SeqTypes>> + Unpin,
-        Header: BlockHeader<SeqTypes> + QueryableHeader<SeqTypes> + ExplorerHeader<SeqTypes>,
+        Header: BlockHeader<SeqTypes> + BlockHeader<SeqTypes> + ExplorerHeader<SeqTypes>,
         Payload: BlockPayload<SeqTypes>,
         BDSink: Sink<BlockDetail<SeqTypes>, Error = SendError> + Clone + Unpin,
         BVSink: Sink<BitVec<u16>, Error = SendError> + Clone + Unpin,

--- a/sequencer/src/bin/verify-headers.rs
+++ b/sequencer/src/bin/verify-headers.rs
@@ -9,6 +9,7 @@ use alloy::{
 use clap::Parser;
 use espresso_types::{Header, L1BlockInfo};
 use futures::future::join_all;
+use hotshot_types::traits::block_contents::BlockHeader;
 use itertools::Itertools;
 use sequencer::SequencerApiVersion;
 use sequencer_utils::logging;

--- a/types/src/v0/impls/header.rs
+++ b/types/src/v0/impls/header.rs
@@ -4,7 +4,7 @@ use anyhow::{ensure, Context};
 use ark_serialize::CanonicalSerialize;
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use hotshot::types::BLSPubKey;
-use hotshot_query_service::{availability::QueryableHeader, explorer::ExplorerHeader};
+use hotshot_query_service::explorer::ExplorerHeader;
 use hotshot_types::{
     data::{VidCommitment, ViewNumber},
     light_client::LightClientState,
@@ -568,7 +568,7 @@ impl Header {
         &mut *field_mut!(self.height)
     }
 
-    pub fn timestamp(&self) -> u64 {
+    pub fn timestamp_internal(&self) -> u64 {
         *field!(self.timestamp)
     }
 
@@ -923,6 +923,10 @@ impl BlockHeader<SeqTypes> for Header {
         )
     }
 
+    fn timestamp(&self) -> u64 {
+        self.timestamp_internal()
+    }
+
     fn block_number(&self) -> u64 {
         self.height()
     }
@@ -957,12 +961,6 @@ impl BlockHeader<SeqTypes> for Header {
                 &block_comm_root_bytes,
             )?,
         })
-    }
-}
-
-impl QueryableHeader<SeqTypes> for Header {
-    fn timestamp(&self) -> u64 {
-        self.timestamp()
     }
 }
 


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:

Adds a new metric for which is the number of seconds between proposal creation and finalization

It also moves the `timestamp` function to be part of the `BlockHeader` trait

### This PR does not:

This is not a high enough resolution metric for detailed metrics.

### Key places to review:

Changes in helpers
