### PR TITLE
Distinguish between namespace indexes vs IDs

### DIFF
--- a/hotshot-query-service/migrations/postgres/V900__tx_separate_index.sql
+++ b/hotshot-query-service/migrations/postgres/V900__tx_separate_index.sql
@@ -16,21 +16,62 @@ BEGIN
 END;
 $$;
 
+CREATE FUNCTION read_ns_id(ns_table BYTEA, ns_index BIGINT)
+    RETURNS BIGINT
+    LANGUAGE plpgsql
+    IMMUTABLE
+AS $$
+DECLARE
+    start INT := 8*ns_index + 4;
+BEGIN
+    RETURN bytea_4byte_le_to_integer(substring(ns_table from start for 4));
+END;
+$$;
+
+CREATE FUNCTION bytea_4byte_le_to_integer(b BYTEA)
+    RETURNS BIGINT
+    LANGUAGE plpgsql
+    IMMUTABLE
+AS $$
+DECLARE
+    len INT := length(b);
+BEGIN
+    IF len <> 4 THEN
+        RAISE 'expected array of 4 bytes, got (%) instead', len;
+    END IF;
+    RETURN get_byte(b,0)::bigint
+         + get_byte(b,1)::bigint*256
+         + get_byte(b,2)::bigint*256*256
+         + get_byte(b,3)::bigint*256*256*256;
+END;
+$$;
+
 ALTER TABLE transactions
     -- Add the new columns and populate from the existing JSON `idx` field.
-    ADD COLUMN namespace BIGINT NOT NULL GENERATED ALWAYS AS (json_4byte_le_to_integer(idx -> 'ns_index')) STORED,
-    ADD COLUMN position BIGINT NOT NULL GENERATED ALWAYS AS (json_4byte_le_to_integer(idx -> 'tx_index')) STORED;
+    ADD COLUMN ns_index BIGINT NOT NULL GENERATED ALWAYS AS (json_4byte_le_to_integer(idx -> 'ns_index')) STORED,
+    ADD COLUMN position BIGINT NOT NULL GENERATED ALWAYS AS (json_4byte_le_to_integer(idx -> 'tx_index')) STORED,
+    -- Add a column for the namespace ID, which we will populate in a separate query from the
+    -- corresponding namespace table.
+    ADD COLUMN ns_id BIGINT;
+
+-- Populate the `ns_id` column.
+UPDATE transactions SET (ns_id) = (
+    SELECT read_ns_id(decode(h.data #>> '{fields,ns_table,bytes}','base64'), ns_index)
+      FROM header AS h
+     WHERE h.height = block_height
+);
+
 ALTER TABLE transactions
     -- Drop the generated expressions for subsequently added rows, where the new columns should be
     -- explicit.
-    ALTER COLUMN namespace DROP EXPRESSION,
+    ALTER COLUMN ns_index DROP EXPRESSION,
     ALTER COLUMN position DROP EXPRESSION,
+    -- Add a NOT NULL constraint for the ns_id column which we have now populated.
+    ALTER COLUMN ns_id SET NOT NULL,
     -- Now that we have explicit columns for namespace and position within namespace, the JSON blob
     -- `idx` is no longer needed.
     DROP COLUMN idx,
     -- `idx` used to be part of the primary key. Now we have a primary key that combines the new
     -- namespace and position fields with block height. We sort on namespace before position so that
     -- when iterating, we get all the transactions within a given namespace consecutively.
-    ADD PRIMARY KEY (block_height, namespace, position);
-
-DROP FUNCTION json_4byte_le_to_integer;
+    ADD PRIMARY KEY (block_height, ns_id, position);

--- a/hotshot-query-service/migrations/sqlite/V700__tx_separate_index.sql
+++ b/hotshot-query-service/migrations/sqlite/V700__tx_separate_index.sql
@@ -4,29 +4,14 @@ CREATE TABLE transactions2 (
     hash TEXT NOT NULL,
     -- Block containing this transaction.
     block_height BIGINT NOT NULL REFERENCES header(height) ON DELETE CASCADE,
+    -- Index within block of the namespace containing this transaction.
+    ns_index BIGINT NOT NULL,
     -- Namespace containing this transaction.
-    namespace BIGINT NOT NULL,
+    ns_id BIGINT NOT NULL,
     -- Position within the namespace.
     position BIGINT NOT NULL,
-    PRIMARY KEY (block_height, namespace, position)
+    PRIMARY KEY (block_height, ns_id, position)
 );
-
-INSERT INTO transactions2 (hash, block_height, namespace, position)
-SELECT
-    hash,
-    block_height,
-
-    -- SQLite doesn't support functions, so this bit is a little messier than in Postgres.
-    idx->>'$.ns_index[0]'
-  + idx->>'$.ns_index[1]'*256
-  + idx->>'$.ns_index[2]'*256*256
-  + idx->>'$.ns_index[3]'*256*256*256,
-
-    idx->>'$.tx_index[0]'
-  + idx->>'$.tx_index[1]'*256
-  + idx->>'$.tx_index[2]'*256*256
-  + idx->>'$.tx_index[3]'*256*256*256
-FROM transactions;
 
 DROP TABLE transactions;
 ALTER TABLE transactions2 RENAME TO transactions;

--- a/hotshot-query-service/src/availability.rs
+++ b/hotshot-query-service/src/availability.rs
@@ -40,7 +40,7 @@ use snafu::{OptionExt, Snafu};
 use tide_disco::{api::ApiError, method::ReadState, Api, RequestError, StatusCode};
 use vbs::version::StaticVersionType;
 
-use crate::{api::load_api, Payload, QueryError, VidCommon};
+use crate::{api::load_api, Header, Payload, QueryError, VidCommon};
 
 pub(crate) mod data_source;
 mod fetch;
@@ -231,6 +231,7 @@ where
     State: 'static + Send + Sync + ReadState,
     <State as ReadState>::State: Send + Sync + AvailabilityDataSource<Types>,
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     let id = match req.opt_integer_param("height")? {
@@ -253,6 +254,7 @@ where
     State: 'static + Send + Sync + ReadState,
     <State as ReadState>::State: Send + Sync + AvailabilityDataSource<Types>,
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     let from = req.integer_param::<_, usize>("from")?;
@@ -302,6 +304,7 @@ where
     State: 'static + Send + Sync + ReadState,
     <State as ReadState>::State: Send + Sync + AvailabilityDataSource<Types>,
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     let id = if let Some(height) = req.opt_integer_param("height")? {
@@ -325,6 +328,7 @@ pub fn define_api<State, Types: NodeType, Ver: StaticVersionType + 'static>(
 where
     State: 'static + Send + Sync + ReadState,
     <State as ReadState>::State: Send + Sync + AvailabilityDataSource<Types>,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     let mut api = load_api::<State, Error, Ver>(

--- a/hotshot-query-service/src/availability/data_source.rs
+++ b/hotshot-query-service/src/availability/data_source.rs
@@ -31,8 +31,8 @@ use super::{
     fetch::Fetch,
     query_data::{
         BlockHash, BlockQueryData, LeafHash, LeafQueryData, PayloadMetadata, PayloadQueryData,
-        QueryablePayload, TransactionHash, TransactionQueryData, VidCommonMetadata,
-        VidCommonQueryData,
+        QueryableHeader, QueryablePayload, TransactionHash, TransactionQueryData,
+        VidCommonMetadata, VidCommonQueryData,
     },
     StateCertQueryData,
 };
@@ -131,6 +131,7 @@ pub type FetchStream<T> = BoxStream<'static, Fetch<T>>;
 #[async_trait]
 pub trait AvailabilityDataSource<Types: NodeType>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     async fn get_leaf<ID>(&self, id: ID) -> Fetch<LeafQueryData<Types>>

--- a/hotshot-query-service/src/availability/query_data.rs
+++ b/hotshot-query-service/src/availability/query_data.rs
@@ -10,7 +10,7 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use std::{collections::HashMap, fmt::Debug};
+use std::{collections::HashMap, fmt::Debug, hash::Hash};
 
 use committable::{Commitment, Committable};
 use derive_more::derive::From;
@@ -45,18 +45,44 @@ pub type BlockHash<Types> = Commitment<Header<Types>>;
 pub type TransactionHash<Types> = Commitment<Transaction<Types>>;
 pub type TransactionInclusionProof<Types> =
     <Payload<Types> as QueryablePayload<Types>>::InclusionProof;
+pub type NamespaceIndex<Types> = <Header<Types> as QueryableHeader<Types>>::NamespaceIndex;
+pub type NamespaceId<Types> = <Header<Types> as QueryableHeader<Types>>::NamespaceId;
 
 pub type Timestamp = time::OffsetDateTime;
 
 pub trait QueryableHeader<Types: NodeType>: BlockHeader<Types> {
+    /// Index for looking up a namespace.
+    type NamespaceIndex: Clone + Debug + Hash + PartialEq + Eq + From<i64> + Into<i64> + Send + Sync;
+
+    /// Serialized representation of a namespace.
+    type NamespaceId: Clone
+        + Debug
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Hash
+        + PartialEq
+        + Eq
+        + From<i64>
+        + Into<i64>;
+
     fn timestamp(&self) -> u64;
-    fn namespace_size(&self, id: u32, payload_size: usize) -> u64;
+
+    /// Resolve a namespace index to the serialized identifier for that namespace.
+    fn namespace_id(&self, i: &Self::NamespaceIndex) -> Option<Self::NamespaceId>;
+
+    /// Get the size taken up by the given namespace in the payload.
+    fn namespace_size(&self, i: &Self::NamespaceIndex, payload_size: usize) -> u64;
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct TransactionIndex {
-    /// Identifier of the namespace this transaction belongs to.
-    pub namespace: u32,
+#[derive(Clone, Debug)]
+pub struct TransactionIndex<Types: NodeType>
+where
+    Header<Types>: QueryableHeader<Types>,
+{
+    /// Index for looking up the namespace this transaction belongs to.
+    pub ns_index: NamespaceIndex<Types>,
     /// Index of the transaction within its namespace in its block.
     pub position: u32,
 }
@@ -69,9 +95,12 @@ pub struct TransactionIndex {
 /// the default implementations may be inefficient (e.g. performing an O(n) search, or computing an
 /// unnecessary inclusion proof). It is good practice to override these default implementations if
 /// your block type supports more efficient implementations (e.g. sublinear indexing by hash).
-pub trait QueryablePayload<Types: NodeType>: traits::BlockPayload<Types> {
+pub trait QueryablePayload<Types: NodeType>: traits::BlockPayload<Types>
+where
+    Header<Types>: QueryableHeader<Types>,
+{
     /// Enumerate the transactions in this block.
-    type Iter<'a>: Iterator<Item = TransactionIndex>
+    type Iter<'a>: Iterator<Item = TransactionIndex<Types>>
     where
         Self: 'a;
 
@@ -100,7 +129,7 @@ pub trait QueryablePayload<Types: NodeType>: traits::BlockPayload<Types> {
     fn enumerate<'a>(
         &'a self,
         meta: &'a Self::Metadata,
-    ) -> Box<dyn 'a + Iterator<Item = (TransactionIndex, Self::Transaction)>> {
+    ) -> Box<dyn 'a + Iterator<Item = (TransactionIndex<Types>, Self::Transaction)>> {
         Box::new(self.iter(meta).map(|ix| {
             // `self.transaction` should always return `Some` if we are using an index which was
             // yielded by `self.iter`.
@@ -113,14 +142,14 @@ pub trait QueryablePayload<Types: NodeType>: traits::BlockPayload<Types> {
     fn transaction_with_proof(
         &self,
         meta: &Self::Metadata,
-        index: &TransactionIndex,
+        index: &TransactionIndex<Types>,
     ) -> Option<(Self::Transaction, Self::InclusionProof)>;
 
     /// Get a transaction by its block-specific index.
     fn transaction(
         &self,
         meta: &Self::Metadata,
-        index: &TransactionIndex,
+        index: &TransactionIndex<Types>,
     ) -> Option<Self::Transaction> {
         Some(self.transaction_with_proof(meta, index)?.0)
     }
@@ -129,13 +158,13 @@ pub trait QueryablePayload<Types: NodeType>: traits::BlockPayload<Types> {
     fn proof(
         &self,
         meta: &Self::Metadata,
-        index: &TransactionIndex,
+        index: &TransactionIndex<Types>,
     ) -> Option<Self::InclusionProof> {
         Some(self.transaction_with_proof(meta, index)?.1)
     }
 
     /// Get the index of the `nth` transaction.
-    fn nth(&self, meta: &Self::Metadata, n: usize) -> Option<TransactionIndex> {
+    fn nth(&self, meta: &Self::Metadata, n: usize) -> Option<TransactionIndex<Types>> {
         self.iter(meta).nth(n)
     }
 
@@ -158,7 +187,7 @@ pub trait QueryablePayload<Types: NodeType>: traits::BlockPayload<Types> {
         &self,
         meta: &Self::Metadata,
         hash: Commitment<Self::Transaction>,
-    ) -> Option<TransactionIndex> {
+    ) -> Option<TransactionIndex<Types>> {
         self.iter(meta).find(|i| {
             if let Some(tx) = self.transaction(meta, i) {
                 tx.commit() == hash
@@ -403,6 +432,7 @@ pub struct BlockQueryData<Types: NodeType> {
 impl<Types: NodeType> BlockQueryData<Types> {
     pub fn new(header: Header<Types>, payload: Payload<Types>) -> Self
     where
+        Header<Types>: QueryableHeader<Types>,
         Payload<Types>: QueryablePayload<Types>,
     {
         Self {
@@ -419,6 +449,7 @@ impl<Types: NodeType> BlockQueryData<Types> {
         instance_state: &Types::InstanceState,
     ) -> Self
     where
+        Header<Types>: QueryableHeader<Types>,
         Payload<Types>: QueryablePayload<Types>,
     {
         let leaf = Leaf2::<Types>::genesis::<HsVer>(validated_state, instance_state).await;
@@ -453,13 +484,22 @@ impl<Types: NodeType> BlockQueryData<Types> {
         self.num_transactions
     }
 
-    pub fn namespace_info(&self) -> HashMap<u32, NamespaceInfo>
+    pub fn namespace_info(&self) -> NamespaceMap<Types>
     where
+        Header<Types>: QueryableHeader<Types>,
         Payload<Types>: QueryablePayload<Types>,
     {
-        let mut map = HashMap::<u32, NamespaceInfo>::new();
+        let mut map = NamespaceMap::<Types>::new();
         for tx in self.payload.iter(self.header.metadata()) {
-            map.entry(tx.namespace).or_default().num_transactions += 1;
+            let Some(ns_id) = self.header.namespace_id(&tx.ns_index) else {
+                continue;
+            };
+            map.entry(ns_id)
+                .or_insert_with(|| NamespaceInfo {
+                    num_transactions: 0,
+                    size: self.header.namespace_size(&tx.ns_index, self.size as usize),
+                })
+                .num_transactions += 1;
         }
         map
     }
@@ -467,16 +507,17 @@ impl<Types: NodeType> BlockQueryData<Types> {
 
 impl<Types: NodeType> BlockQueryData<Types>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
-    pub fn transaction(&self, ix: &TransactionIndex) -> Option<Transaction<Types>> {
+    pub fn transaction(&self, ix: &TransactionIndex<Types>) -> Option<Transaction<Types>> {
         self.payload().transaction(self.metadata(), ix)
     }
 
     pub fn transaction_by_hash(
         &self,
         hash: Commitment<Transaction<Types>>,
-    ) -> Option<TransactionIndex> {
+    ) -> Option<TransactionIndex<Types>> {
         self.payload().by_hash(self.metadata(), hash)
     }
 
@@ -488,7 +529,9 @@ where
         self.len() == 0
     }
 
-    pub fn enumerate(&self) -> impl '_ + Iterator<Item = (TransactionIndex, Transaction<Types>)> {
+    pub fn enumerate(
+        &self,
+    ) -> impl '_ + Iterator<Item = (TransactionIndex<Types>, Transaction<Types>)> {
         self.payload.enumerate(self.metadata())
     }
 }
@@ -551,6 +594,7 @@ impl<Types: NodeType> PayloadQueryData<Types> {
         instance_state: &Types::InstanceState,
     ) -> Self
     where
+        Header<Types>: QueryableHeader<Types>,
         Payload<Types>: QueryablePayload<Types>,
     {
         BlockQueryData::genesis::<HsVer>(validated_state, instance_state)
@@ -705,6 +749,7 @@ impl<Types: NodeType> HeightIndexed for (VidCommonQueryData<Types>, Option<VidSh
 #[serde(bound = "")]
 pub struct TransactionQueryData<Types: NodeType>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     transaction: Transaction<Types>,
@@ -713,17 +758,18 @@ where
     proof: TransactionInclusionProof<Types>,
     block_hash: BlockHash<Types>,
     block_height: u64,
-    namespace: u32,
+    namespace: NamespaceId<Types>,
     pos_in_namespace: u32,
 }
 
 impl<Types: NodeType> TransactionQueryData<Types>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     pub(crate) fn new(
         block: &BlockQueryData<Types>,
-        i: TransactionIndex,
+        i: TransactionIndex<Types>,
         index: u64,
     ) -> Option<Self> {
         let (transaction, proof) = block
@@ -736,7 +782,7 @@ where
             proof,
             block_hash: block.hash(),
             block_height: block.height(),
-            namespace: i.namespace,
+            namespace: block.header().namespace_id(&i.ns_index)?,
             pos_in_namespace: i.position,
         })
     }
@@ -795,16 +841,22 @@ pub(crate) fn payload_size<Types: NodeType>(payload: &Payload<Types>) -> u64 {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(bound = "")]
-pub struct BlockSummaryQueryData<Types: NodeType> {
+pub struct BlockSummaryQueryData<Types: NodeType>
+where
+    Header<Types>: QueryableHeader<Types>,
+{
     pub(crate) header: Header<Types>,
     pub(crate) hash: BlockHash<Types>,
     pub(crate) size: u64,
     pub(crate) num_transactions: u64,
-    pub(crate) namespaces: HashMap<u32, NamespaceInfo>,
+    pub(crate) namespaces: NamespaceMap<Types>,
 }
 
 // Add some basic getters to the BlockSummaryQueryData type.
-impl<Types: NodeType> BlockSummaryQueryData<Types> {
+impl<Types: NodeType> BlockSummaryQueryData<Types>
+where
+    Header<Types>: QueryableHeader<Types>,
+{
     pub fn header(&self) -> &Header<Types> {
         &self.header
     }
@@ -821,12 +873,15 @@ impl<Types: NodeType> BlockSummaryQueryData<Types> {
         self.num_transactions
     }
 
-    pub fn namespaces(&self) -> &HashMap<u32, NamespaceInfo> {
+    pub fn namespaces(&self) -> &NamespaceMap<Types> {
         &self.namespaces
     }
 }
 
-impl<Types: NodeType> HeightIndexed for BlockSummaryQueryData<Types> {
+impl<Types: NodeType> HeightIndexed for BlockSummaryQueryData<Types>
+where
+    Header<Types>: QueryableHeader<Types>,
+{
     fn height(&self) -> u64 {
         self.header.block_number()
     }
@@ -848,6 +903,7 @@ pub struct TransactionSummaryQueryData<Types: NodeType> {
 // contentions.
 impl<Types: NodeType> From<BlockQueryData<Types>> for BlockSummaryQueryData<Types>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn from(value: BlockQueryData<Types>) -> Self {
@@ -867,6 +923,8 @@ pub struct NamespaceInfo {
     pub size: u64,
 }
 
+pub type NamespaceMap<Types> = HashMap<NamespaceId<Types>, NamespaceInfo>;
+
 /// A summary of a payload without all the data.
 ///
 /// This type is useful when you only want information about a payload, such as its size or
@@ -875,18 +933,20 @@ pub struct NamespaceInfo {
 pub struct PayloadMetadata<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
 {
     pub height: u64,
     pub block_hash: BlockHash<Types>,
     pub hash: VidCommitment,
     pub size: u64,
     pub num_transactions: u64,
-    pub namespaces: HashMap<u32, NamespaceInfo>,
+    pub namespaces: NamespaceMap<Types>,
 }
 
 impl<Types> HeightIndexed for PayloadMetadata<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
 {
     fn height(&self) -> u64 {
         self.height
@@ -896,6 +956,7 @@ where
 impl<Types> From<BlockQueryData<Types>> for PayloadMetadata<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn from(block: BlockQueryData<Types>) -> Self {

--- a/hotshot-query-service/src/data_source.rs
+++ b/hotshot-query-service/src/data_source.rs
@@ -266,7 +266,7 @@ pub mod availability_tests {
                 // available locally.
                 let ix = seen_transactions
                     .entry(txn.commit())
-                    .or_insert((i as u64, j));
+                    .or_insert((i as u64, j.clone()));
                 if let Ok(tx_data) = ds.get_transaction(txn.commit()).await.try_resolve() {
                     assert_eq!(tx_data.transaction(), &txn);
                     assert_eq!(tx_data.block_height(), ix.0);

--- a/hotshot-query-service/src/data_source/extension.rs
+++ b/hotshot-query-service/src/data_source/extension.rs
@@ -158,6 +158,7 @@ where
     D: AvailabilityDataSource<Types> + Send + Sync,
     U: Send + Sync,
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     async fn get_leaf<ID>(&self, id: ID) -> Fetch<LeafQueryData<Types>>
@@ -442,7 +443,7 @@ where
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
     Header<Types>: ExplorerHeader<Types> + QueryableHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
 {
     async fn get_block_detail(
         &self,

--- a/hotshot-query-service/src/data_source/fetching.rs
+++ b/hotshot-query-service/src/data_source/fetching.rs
@@ -448,6 +448,7 @@ where
 impl<Types, S> Pruner<Types, S>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: PruneStorage + Send + Sync + 'static,
 {
@@ -636,6 +637,7 @@ where
 impl<Types, S, P> AvailabilityDataSource<Types> for FetchingDataSource<Types, S, P>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
@@ -813,6 +815,7 @@ where
 impl<Types, S, P> UpdateAvailabilityData<Types> for FetchingDataSource<Types, S, P>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
@@ -972,6 +975,7 @@ where
 impl<Types, S, P> Fetcher<Types, S, P>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
@@ -1586,6 +1590,7 @@ where
 impl<Types, S, P> Fetcher<Types, S, P>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types> + UpdateAggregatesStorage<Types>,
@@ -1821,6 +1826,7 @@ where
 impl<Types, S, P> MerklizedStateHeightPersistence for FetchingDataSource<Types, S, P>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::ReadOnly<'a>: MerklizedStateHeightStorage,
@@ -1905,7 +1911,7 @@ where
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
     Header<Types>: QueryableHeader<Types> + explorer::traits::ExplorerHeader<Types>,
-    crate::Transaction<Types>: explorer::traits::ExplorerTransaction,
+    crate::Transaction<Types>: explorer::traits::ExplorerTransaction<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::ReadOnly<'a>: ExplorerStorage<Types>,
     P: Send + Sync,
@@ -2029,6 +2035,7 @@ trait FetchRequest: Copy + Debug + Send + Sync + 'static {
 trait Fetchable<Types>: Clone + Send + Sync + 'static
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     /// A succinct specification of the object to be fetched.
@@ -2085,6 +2092,7 @@ type PassiveFetch<T> = BoxFuture<'static, Option<T>>;
 trait RangedFetchable<Types>: Fetchable<Types, Request = Self::RangedRequest> + HeightIndexed
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type RangedRequest: FetchRequest + From<usize> + Send;

--- a/hotshot-query-service/src/data_source/fetching/block.rs
+++ b/hotshot-query-service/src/data_source/fetching/block.rs
@@ -26,7 +26,10 @@ use super::{
     Storable,
 };
 use crate::{
-    availability::{BlockId, BlockQueryData, PayloadMetadata, PayloadQueryData, QueryablePayload},
+    availability::{
+        BlockId, BlockQueryData, PayloadMetadata, PayloadQueryData, QueryableHeader,
+        QueryablePayload,
+    },
     data_source::{
         storage::{
             pruning::PrunedHeightStorage, AvailabilityStorage, NodeStorage,
@@ -62,6 +65,7 @@ where
 impl<Types> Fetchable<Types> for BlockQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Request = BlockId<Types>;
@@ -120,6 +124,7 @@ where
 impl<Types> RangedFetchable<Types> for BlockQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type RangedRequest = BlockId<Types>;
@@ -163,6 +168,7 @@ pub(super) fn fetch_block_with_header<Types, S, P>(
     header: Header<Types>,
 ) where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
@@ -193,6 +199,7 @@ pub(super) fn fetch_block_with_header<Types, S, P>(
 impl<Types> Fetchable<Types> for PayloadQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Request = BlockId<Types>;
@@ -248,6 +255,7 @@ where
 impl<Types> RangedFetchable<Types> for PayloadQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type RangedRequest = BlockId<Types>;
@@ -291,6 +299,7 @@ impl<Types: NodeType, S, P> PartialOrd for PayloadCallback<Types, S, P> {
 
 impl<Types: NodeType, S, P> Callback<Payload<Types>> for PayloadCallback<Types, S, P>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: 'static + VersionedDataSource,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
@@ -307,6 +316,7 @@ where
 impl<Types> Fetchable<Types> for PayloadMetadata<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Request = BlockId<Types>;
@@ -361,6 +371,7 @@ where
 impl<Types> RangedFetchable<Types> for PayloadMetadata<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type RangedRequest = BlockId<Types>;

--- a/hotshot-query-service/src/data_source/fetching/header.rs
+++ b/hotshot-query-service/src/data_source/fetching/header.rs
@@ -26,7 +26,7 @@ use super::{
     vid::fetch_vid_common_with_header, AvailabilityProvider, Fetcher,
 };
 use crate::{
-    availability::{BlockId, QueryablePayload},
+    availability::{BlockId, QueryableHeader, QueryablePayload},
     data_source::{
         fetching::{Fetchable, HeaderQueryData, LeafQueryData, Notifiers},
         storage::{
@@ -49,6 +49,7 @@ impl<Types: NodeType> From<LeafQueryData<Types>> for HeaderQueryData<Types> {
 fn satisfies_header_req_from_leaf<Types>(leaf: &LeafQueryData<Types>, req: BlockId<Types>) -> bool
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     HeaderQueryData::satisfies(&HeaderQueryData::new(leaf.header().clone()), req)
@@ -58,6 +59,7 @@ where
 impl<Types> Fetchable<Types> for HeaderQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Request = BlockId<Types>;
@@ -163,6 +165,7 @@ impl<Types: NodeType, S, P> Ord for HeaderCallback<Types, S, P> {
 impl<Types, S, P> HeaderCallback<Types, S, P>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
@@ -202,6 +205,7 @@ pub(super) async fn fetch_header_and_then<Types, S, P>(
 ) -> anyhow::Result<()>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,

--- a/hotshot-query-service/src/data_source/fetching/leaf.rs
+++ b/hotshot-query-service/src/data_source/fetching/leaf.rs
@@ -29,7 +29,7 @@ use super::{
     Notifiers, RangedFetchable, Storable,
 };
 use crate::{
-    availability::{LeafId, LeafQueryData, QueryablePayload},
+    availability::{LeafId, LeafQueryData, QueryableHeader, QueryablePayload},
     data_source::{
         storage::{
             pruning::PrunedHeightStorage, AvailabilityStorage, NodeStorage,
@@ -39,7 +39,7 @@ use crate::{
     },
     fetching::{self, request, Callback},
     types::HeightIndexed,
-    Payload, QueryError, QueryResult,
+    Header, Payload, QueryError, QueryResult,
 };
 
 pub(super) type LeafFetcher<Types, S, P> =
@@ -62,6 +62,7 @@ where
 impl<Types> Fetchable<Types> for LeafQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Request = LeafId<Types>;
@@ -116,6 +117,7 @@ pub(super) async fn fetch_leaf_with_callbacks<Types, S, P, I>(
 ) -> anyhow::Result<()>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
@@ -224,6 +226,7 @@ pub(super) fn trigger_fetch_for_parent<Types, S, P>(
     leaf: &LeafQueryData<Types>,
 ) where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
@@ -304,6 +307,7 @@ pub(super) fn trigger_fetch_for_parent<Types, S, P>(
 impl<Types> RangedFetchable<Types> for LeafQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type RangedRequest = LeafId<Types>;
@@ -384,6 +388,7 @@ impl<Types: NodeType, S, P> PartialOrd for LeafCallback<Types, S, P> {
 
 impl<Types: NodeType, S, P> Callback<LeafQueryData<Types>> for LeafCallback<Types, S, P>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,

--- a/hotshot-query-service/src/data_source/fetching/state_cert.rs
+++ b/hotshot-query-service/src/data_source/fetching/state_cert.rs
@@ -20,7 +20,7 @@ use hotshot_types::traits::node_implementation::{ConsensusTime, NodeType};
 
 use super::Storable;
 use crate::{
-    availability::{QueryablePayload, StateCertQueryData},
+    availability::{QueryableHeader, QueryablePayload, StateCertQueryData},
     data_source::{
         fetching::{
             AvailabilityProvider, FetchRequest, Fetchable, Fetcher, Notifiers, PassiveFetch,
@@ -32,7 +32,7 @@ use crate::{
         VersionedDataSource,
     },
     fetching::request::StateCertRequest,
-    Payload, QueryResult,
+    Header, Payload, QueryResult,
 };
 
 impl FetchRequest for StateCertRequest {}
@@ -41,6 +41,7 @@ impl FetchRequest for StateCertRequest {}
 impl<Types> Fetchable<Types> for StateCertQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Request = StateCertRequest;

--- a/hotshot-query-service/src/data_source/fetching/transaction.rs
+++ b/hotshot-query-service/src/data_source/fetching/transaction.rs
@@ -21,7 +21,7 @@ use hotshot_types::traits::node_implementation::NodeType;
 
 use super::{AvailabilityProvider, FetchRequest, Fetchable, Fetcher, Notifiers};
 use crate::{
-    availability::{QueryablePayload, TransactionHash, TransactionQueryData},
+    availability::{QueryableHeader, QueryablePayload, TransactionHash, TransactionQueryData},
     data_source::{
         storage::{
             pruning::PrunedHeightStorage, AvailabilityStorage, NodeStorage,
@@ -29,7 +29,7 @@ use crate::{
         },
         update::VersionedDataSource,
     },
-    Payload, QueryResult,
+    Header, Payload, QueryResult,
 };
 
 #[derive(Clone, Copy, Debug, From)]
@@ -41,6 +41,7 @@ impl<Types: NodeType> FetchRequest for TransactionRequest<Types> {}
 impl<Types> Fetchable<Types> for TransactionQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Request = TransactionRequest<Types>;

--- a/hotshot-query-service/src/data_source/fetching/vid.rs
+++ b/hotshot-query-service/src/data_source/fetching/vid.rs
@@ -29,7 +29,9 @@ use super::{
     Storable,
 };
 use crate::{
-    availability::{BlockId, QueryablePayload, VidCommonMetadata, VidCommonQueryData},
+    availability::{
+        BlockId, QueryableHeader, QueryablePayload, VidCommonMetadata, VidCommonQueryData,
+    },
     data_source::{
         storage::{
             pruning::PrunedHeightStorage, AvailabilityStorage, NodeStorage,
@@ -67,6 +69,7 @@ where
 impl<Types> Fetchable<Types> for VidCommonQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Request = VidCommonRequest<Types>;
@@ -125,6 +128,7 @@ where
 impl<Types> RangedFetchable<Types> for VidCommonQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type RangedRequest = VidCommonRequest<Types>;
@@ -185,6 +189,7 @@ pub(super) fn fetch_vid_common_with_header<Types, S, P>(
     header: Header<Types>,
 ) where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
@@ -241,6 +246,7 @@ impl<Types: NodeType, S, P> PartialOrd for VidCommonCallback<Types, S, P> {
 
 impl<Types: NodeType, S, P> Callback<VidCommon> for VidCommonCallback<Types, S, P>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
@@ -256,6 +262,7 @@ where
 impl<Types> Fetchable<Types> for VidCommonMetadata<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Request = VidCommonRequest<Types>;
@@ -314,6 +321,7 @@ where
 impl<Types> RangedFetchable<Types> for VidCommonMetadata<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type RangedRequest = VidCommonRequest<Types>;

--- a/hotshot-query-service/src/data_source/storage.rs
+++ b/hotshot-query-service/src/data_source/storage.rs
@@ -116,6 +116,7 @@ pub use sql::SqlStorage;
 pub trait AvailabilityStorage<Types>: Send + Sync
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     async fn get_leaf(&mut self, id: LeafId<Types>) -> QueryResult<LeafQueryData<Types>>;
@@ -265,6 +266,7 @@ pub trait AggregatesStorage {
 pub trait UpdateAggregatesStorage<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
 {
     /// Update aggregate statistics based on a new block.
     fn update_aggregates(
@@ -288,7 +290,7 @@ pub trait ExplorerStorage<Types>
 where
     Types: NodeType,
     Header<Types>: ExplorerHeader<Types> + QueryableHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     /// `get_block_detail` is a method that retrieves the details of a specific

--- a/hotshot-query-service/src/data_source/storage/fail_storage.rs
+++ b/hotshot-query-service/src/data_source/storage/fail_storage.rs
@@ -27,8 +27,9 @@ use super::{
 };
 use crate::{
     availability::{
-        BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadQueryData, QueryablePayload,
-        StateCertQueryData, TransactionHash, TransactionQueryData, VidCommonQueryData,
+        BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadQueryData, QueryableHeader,
+        QueryablePayload, StateCertQueryData, TransactionHash, TransactionQueryData,
+        VidCommonQueryData,
     },
     data_source::{
         storage::{PayloadMetadata, VidCommonMetadata},
@@ -329,6 +330,7 @@ where
 impl<Types, T> AvailabilityStorage<Types> for Transaction<T>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     T: AvailabilityStorage<Types>,
 {
@@ -471,6 +473,7 @@ where
 impl<Types, T> UpdateAvailabilityStorage<Types> for Transaction<T>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
     T: UpdateAvailabilityStorage<Types> + Send + Sync,
 {
@@ -582,6 +585,7 @@ where
 impl<T, Types> UpdateAggregatesStorage<Types> for Transaction<T>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     T: UpdateAggregatesStorage<Types> + Send + Sync,
 {
     async fn update_aggregates(

--- a/hotshot-query-service/src/data_source/storage/fs.rs
+++ b/hotshot-query-service/src/data_source/storage/fs.rs
@@ -70,6 +70,7 @@ const CACHED_STATE_CERT_COUNT: usize = 5;
 pub struct FileSystemStorageInner<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     index_by_leaf_hash: HashMap<LeafHash<Types>, u64>,
@@ -90,6 +91,7 @@ where
 impl<Types> FileSystemStorageInner<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn get_block_index(&self, id: BlockId<Types>) -> QueryResult<usize> {
@@ -128,18 +130,22 @@ where
 #[derive(Debug)]
 pub struct FileSystemStorage<Types: NodeType>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     inner: RwLock<FileSystemStorageInner<Types>>,
     metrics: PrometheusMetrics,
 }
 
-impl<Types: NodeType> PrunerConfig for FileSystemStorage<Types> where
-    Payload<Types>: QueryablePayload<Types>
+impl<Types: NodeType> PrunerConfig for FileSystemStorage<Types>
+where
+    Header<Types>: QueryableHeader<Types>,
+    Payload<Types>: QueryablePayload<Types>,
 {
 }
 impl<Types: NodeType> PruneStorage for FileSystemStorage<Types>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Pruner = ();
@@ -148,6 +154,7 @@ where
 #[async_trait]
 impl<Types: NodeType> MigrateTypes<Types> for FileSystemStorage<Types>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     async fn migrate_types(&self, _batch_size: u64) -> anyhow::Result<()> {
@@ -351,6 +358,7 @@ pub trait Revert {
 impl<Types> Revert for RwLockWriteGuard<'_, FileSystemStorageInner<Types>>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn revert(&mut self) {
@@ -364,6 +372,7 @@ where
 impl<Types> Revert for RwLockReadGuard<'_, FileSystemStorageInner<Types>>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn revert(&mut self) {
@@ -384,6 +393,7 @@ impl<T: Revert> Drop for Transaction<T> {
 impl<Types> update::Transaction for Transaction<RwLockWriteGuard<'_, FileSystemStorageInner<Types>>>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     async fn commit(mut self) -> anyhow::Result<()> {
@@ -406,6 +416,7 @@ where
 impl<Types> update::Transaction for Transaction<RwLockReadGuard<'_, FileSystemStorageInner<Types>>>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     async fn commit(self) -> anyhow::Result<()> {
@@ -421,6 +432,7 @@ where
 
 impl<Types: NodeType> VersionedDataSource for FileSystemStorage<Types>
 where
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     type Transaction<'a>
@@ -888,6 +900,7 @@ impl<T: Revert + Send> AggregatesStorage for Transaction<T> {
 impl<Types, T: Revert + Send> UpdateAggregatesStorage<Types> for Transaction<T>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
 {
     async fn update_aggregates(
         &mut self,
@@ -903,6 +916,7 @@ impl<T: Revert> PrunedHeightStorage for Transaction<T> {}
 impl<Types> HasMetrics for FileSystemStorage<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn metrics(&self) -> &PrometheusMetrics {

--- a/hotshot-query-service/src/data_source/storage/sql/queries.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries.rs
@@ -32,8 +32,8 @@ use sqlx::{Arguments, FromRow, Row};
 use super::{Database, Db, Query, QueryAs, Transaction};
 use crate::{
     availability::{
-        BlockId, BlockQueryData, LeafQueryData, PayloadQueryData, QueryablePayload,
-        StateCertQueryData, VidCommonQueryData,
+        BlockId, BlockQueryData, LeafQueryData, PayloadQueryData, QueryableHeader,
+        QueryablePayload, StateCertQueryData, VidCommonQueryData,
     },
     data_source::storage::{PayloadMetadata, VidCommonMetadata},
     Header, Leaf2, Payload, QueryError, QueryResult,
@@ -189,6 +189,7 @@ const BLOCK_COLUMNS: &str =
 impl<'r, Types> FromRow<'r, <Db as Database>::Row> for BlockQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn from_row(row: &'r <Db as Database>::Row) -> sqlx::Result<Self> {
@@ -225,6 +226,7 @@ const PAYLOAD_COLUMNS: &str = BLOCK_COLUMNS;
 impl<'r, Types> FromRow<'r, <Db as Database>::Row> for PayloadQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn from_row(row: &'r <Db as Database>::Row) -> sqlx::Result<Self> {
@@ -238,6 +240,7 @@ const PAYLOAD_METADATA_COLUMNS: &str =
 impl<'r, Types> FromRow<'r, <Db as Database>::Row> for PayloadMetadata<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
 {
     fn from_row(row: &'r <Db as Database>::Row) -> sqlx::Result<Self> {
         Ok(Self {
@@ -268,6 +271,7 @@ const VID_COMMON_COLUMNS: &str = "h.height AS height, h.hash AS block_hash, h.pa
 impl<'r, Types> FromRow<'r, <Db as Database>::Row> for VidCommonQueryData<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn from_row(row: &'r <Db as Database>::Row) -> sqlx::Result<Self> {
@@ -296,6 +300,7 @@ const VID_COMMON_METADATA_COLUMNS: &str =
 impl<'r, Types> FromRow<'r, <Db as Database>::Row> for VidCommonMetadata<Types>
 where
     Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     fn from_row(row: &'r <Db as Database>::Row) -> sqlx::Result<Self> {

--- a/hotshot-query-service/src/data_source/storage/sql/queries/explorer.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/explorer.rs
@@ -41,6 +41,7 @@ use crate::{
         MonetaryValue, SearchResult, TransactionIdentifier, TransactionRange, TransactionSummary,
         TransactionSummaryFilter,
     },
+    types::HeightIndexed,
     Header, Payload, QueryError, QueryResult, Transaction as HotshotTransaction,
 };
 
@@ -178,20 +179,36 @@ lazy_static::lazy_static! {
     };
 
 
-    static ref GET_TRANSACTION_SUMMARIES_QUERY_FOR_NO_FILTER: String = {
+    static ref GET_BLOCKS_CONTAINING_TRANSACTIONS_NO_FILTER_QUERY: String = {
         format!(
             "SELECT {BLOCK_COLUMNS}
-                FROM header AS h
-                JOIN payload AS p ON h.height = p.height
-                WHERE h.height IN (
-                    SELECT t.block_height
-                        FROM transactions AS t
-                        WHERE
-                            (t.block_height, t.namespace, t.position) <= ($1, $2, $3)
-                        ORDER BY t.block_height DESC, t.namespace DESC, t.position DESC
-                        LIMIT $4
-                )
-                ORDER BY h.height DESC"
+               FROM header AS h
+               JOIN payload AS p ON h.height = p.height
+               WHERE h.height IN (
+                   SELECT t.block_height
+                       FROM transactions AS t
+                       WHERE (t.block_height, t.ns_id, t.position) <= ($1, $2, $3)
+                       ORDER BY t.block_height DESC, t.ns_id DESC, t.position DESC
+                       LIMIT $4
+               )
+               ORDER BY h.height DESC"
+        )
+    };
+
+    static ref GET_BLOCKS_CONTAINING_TRANSACTIONS_IN_NAMESPACE_QUERY: String = {
+        format!(
+            "SELECT {BLOCK_COLUMNS}
+               FROM header AS h
+               JOIN payload AS p ON h.height = p.height
+               WHERE h.height IN (
+                   SELECT t.block_height
+                       FROM transactions AS t
+                       WHERE (t.block_height, t.ns_id, t.position) <= ($1, $2, $3)
+                         AND t.ns_id = $5
+                       ORDER BY t.block_height DESC, t.ns_id DESC, t.position DESC
+                       LIMIT $4
+               )
+               ORDER BY h.height DESC"
         )
     };
 
@@ -227,7 +244,7 @@ lazy_static::lazy_static! {
                     SELECT t1.block_height
                         FROM transactions AS t1
                         WHERE t1.block_height = $1
-                        ORDER BY t1.block_height, t1.namespace, t1.position
+                        ORDER BY t1.block_height, t1.ns_id, t1.position
                         OFFSET $2
                         LIMIT 1
                 )
@@ -244,7 +261,7 @@ lazy_static::lazy_static! {
                     SELECT t1.block_height
                         FROM transactions AS t1
                         WHERE t1.hash = $1
-                        ORDER BY t1.block_height DESC, t1.namespace DESC, t1.position DESC
+                        ORDER BY t1.block_height DESC, t1.ns_id DESC, t1.position DESC
                         LIMIT 1
                 )
                 ORDER BY h.height DESC"
@@ -271,7 +288,7 @@ where
     Types: NodeType,
     Payload<Types>: QueryablePayload<Types>,
     Header<Types>: QueryableHeader<Types> + ExplorerHeader<Types>,
-    crate::Transaction<Types>: explorer::traits::ExplorerTransaction,
+    crate::Transaction<Types>: explorer::traits::ExplorerTransaction<Types>,
     BalanceAmount<Types>: Into<explorer::monetary_value::MonetaryValue>,
 {
     async fn get_block_summaries(
@@ -330,14 +347,14 @@ where
         // returned results based on.
         let transaction_target_query = match target {
             TransactionIdentifier::Latest => query(
-                "SELECT block_height AS height, namespace, position FROM transactions ORDER BY block_height DESC, namespace DESC, position DESC LIMIT 1",
+                "SELECT block_height AS height, ns_id, position FROM transactions ORDER BY block_height DESC, ns_id DESC, position DESC LIMIT 1",
             ),
             TransactionIdentifier::HeightAndOffset(height, _) => query(
-                "SELECT block_height AS height, namespace, position FROM transactions WHERE block_height = $1 ORDER BY namespace DESC, position DESC LIMIT 1",
+                "SELECT block_height AS height, ns_id, position FROM transactions WHERE block_height = $1 ORDER BY ns_id DESC, position DESC LIMIT 1",
             )
             .bind(*height as i64),
             TransactionIdentifier::Hash(hash) => query(
-                "SELECT block_height AS height, namespace, position FROM transactions WHERE hash = $1 ORDER BY block_height DESC, namespace DESC, position DESC LIMIT 1",
+                "SELECT block_height AS height, ns_id, position FROM transactions WHERE hash = $1 ORDER BY block_height DESC, ns_id DESC, position DESC LIMIT 1",
             )
             .bind(hash.to_string()),
         };
@@ -351,7 +368,7 @@ where
         };
 
         let block_height = transaction_target.get::<i64, _>("height") as usize;
-        let namespace = transaction_target.get::<i64, _>("namespace");
+        let namespace = transaction_target.get::<i64, _>("ns_id");
         let position = transaction_target.get::<i64, _>("position");
         let offset = if let TransactionIdentifier::HeightAndOffset(_, offset) = target {
             *offset
@@ -367,13 +384,21 @@ where
         // identified transactions, as only those blocks are needed to pull all
         // of the relevant transactions.
         let query_stmt = match filter {
-            TransactionSummaryFilter::RollUp(_) => return Ok(vec![]),
-
-            TransactionSummaryFilter::None => query(&GET_TRANSACTION_SUMMARIES_QUERY_FOR_NO_FILTER)
-                .bind(block_height as i64)
-                .bind(namespace)
-                .bind(position)
-                .bind((range.num_transactions.get() + offset) as i64),
+            TransactionSummaryFilter::RollUp(ns) => {
+                query(&GET_BLOCKS_CONTAINING_TRANSACTIONS_IN_NAMESPACE_QUERY)
+                    .bind(block_height as i64)
+                    .bind(namespace)
+                    .bind(position)
+                    .bind((range.num_transactions.get() + offset) as i64)
+                    .bind(ns.clone().into())
+            },
+            TransactionSummaryFilter::None => {
+                query(&GET_BLOCKS_CONTAINING_TRANSACTIONS_NO_FILTER_QUERY)
+                    .bind(block_height as i64)
+                    .bind(namespace)
+                    .bind(position)
+                    .bind((range.num_transactions.get() + offset) as i64)
+            },
 
             TransactionSummaryFilter::Block(block) => {
                 query(&GET_TRANSACTION_SUMMARIES_QUERY_FOR_BLOCK).bind(*block as i64)
@@ -385,22 +410,36 @@ where
             .map(|row| BlockQueryData::from_row(&row?));
 
         let transaction_summary_stream = block_stream.flat_map(|row| match row {
-            Ok(block) => stream::iter(
-                block
-                    .enumerate()
-                    .enumerate()
-                    .map(|(index, (_, txn))| {
-                        TransactionSummary::try_from((&block, index, txn)).map_err(|err| {
-                            QueryError::Error {
-                                message: err.to_string(),
+            Ok(block) => {
+                tracing::info!(height = block.height(), "selected block");
+                stream::iter(
+                    block
+                        .enumerate()
+                        .filter(|(ix, _)| {
+                            if let TransactionSummaryFilter::RollUp(ns) = filter {
+                                let tx_ns = QueryableHeader::<Types>::namespace_id(
+                                    block.header(),
+                                    &ix.ns_index,
+                                );
+                                tx_ns.as_ref() == Some(ns)
+                            } else {
+                                true
                             }
                         })
-                    })
-                    .collect::<Vec<QueryResult<TransactionSummary<Types>>>>()
-                    .into_iter()
-                    .rev()
-                    .collect::<Vec<QueryResult<TransactionSummary<Types>>>>(),
-            ),
+                        .enumerate()
+                        .map(|(index, (_, txn))| {
+                            TransactionSummary::try_from((&block, index, txn)).map_err(|err| {
+                                QueryError::Error {
+                                    message: err.to_string(),
+                                }
+                            })
+                        })
+                        .collect::<Vec<QueryResult<TransactionSummary<Types>>>>()
+                        .into_iter()
+                        .rev()
+                        .collect::<Vec<QueryResult<TransactionSummary<Types>>>>(),
+                )
+            },
             Err(err) => stream::iter(vec![Err(err.into())]),
         });
 

--- a/hotshot-query-service/src/data_source/storage/sql/queries/node.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/node.rs
@@ -29,6 +29,7 @@ use super::{
     parse_header, DecodeError, QueryBuilder, HEADER_COLUMNS,
 };
 use crate::{
+    availability::QueryableHeader,
     data_source::storage::{
         Aggregate, AggregatesStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
     },
@@ -309,7 +310,10 @@ impl<Mode: TransactionMode> AggregatesStorage for Transaction<Mode> {
     }
 }
 
-impl<Types: NodeType> UpdateAggregatesStorage<Types> for Transaction<Write> {
+impl<Types: NodeType> UpdateAggregatesStorage<Types> for Transaction<Write>
+where
+    Header<Types>: QueryableHeader<Types>,
+{
     async fn update_aggregates(
         &mut self,
         prev: Aggregate,

--- a/hotshot-query-service/src/data_source/storage/sql/transaction.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/transaction.rs
@@ -565,21 +565,23 @@ where
         )
         .await?;
 
-        // Index the transactions in the block.
+        // Index the transactions and namespaces in the block.
         let mut rows = vec![];
         for (txn_ix, txn) in block.enumerate() {
+            let ns_id = block.header().namespace_id(&txn_ix.ns_index).unwrap();
             rows.push((
                 txn.commit().to_string(),
                 height as i64,
-                txn_ix.namespace as i64,
+                txn_ix.ns_index.into(),
+                ns_id.into(),
                 txn_ix.position as i64,
             ));
         }
         if !rows.is_empty() {
             self.upsert(
                 "transactions",
-                ["hash", "block_height", "namespace", "position"],
-                ["block_height", "namespace", "position"],
+                ["hash", "block_height", "ns_index", "ns_id", "position"],
+                ["block_height", "ns_id", "position"],
                 rows,
             )
             .await?;

--- a/hotshot-query-service/src/data_source/update.rs
+++ b/hotshot-query-service/src/data_source/update.rs
@@ -33,10 +33,10 @@ use jf_vid::VidScheme;
 
 use crate::{
     availability::{
-        BlockInfo, BlockQueryData, LeafQueryData, QueryablePayload, StateCertQueryData,
-        UpdateAvailabilityData, VidCommonQueryData,
+        BlockInfo, BlockQueryData, LeafQueryData, QueryableHeader, QueryablePayload,
+        StateCertQueryData, UpdateAvailabilityData, VidCommonQueryData,
     },
-    Payload, VidCommon,
+    Header, Payload, VidCommon,
 };
 
 /// An extension trait for types which implement the update trait for each API module.
@@ -75,6 +75,7 @@ pub trait UpdateDataSource<Types: NodeType>: UpdateAvailabilityData<Types> {
 impl<Types: NodeType, T> UpdateDataSource<Types> for T
 where
     T: UpdateAvailabilityData<Types> + Send + Sync,
+    Header<Types>: QueryableHeader<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     async fn update(&self, event: &Event<Types>) -> Result<(), u64> {

--- a/hotshot-query-service/src/explorer.rs
+++ b/hotshot-query-service/src/explorer.rs
@@ -152,7 +152,7 @@ impl<Types: NodeType> From<query_data::TransactionDetailResponse<Types>>
 pub struct TransactionSummariesResponse<Types: NodeType>
 where
     Header<Types>: ExplorerHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
 {
     pub transaction_summaries: Vec<TransactionSummary<Types>>,
 }
@@ -160,7 +160,7 @@ where
 impl<Types: NodeType> From<Vec<TransactionSummary<Types>>> for TransactionSummariesResponse<Types>
 where
     Header<Types>: ExplorerHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
 {
     fn from(transaction_summaries: Vec<TransactionSummary<Types>>) -> Self {
         Self {
@@ -176,7 +176,7 @@ where
 pub struct ExplorerSummaryResponse<Types: NodeType>
 where
     Header<Types>: ExplorerHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
 {
     pub explorer_summary: ExplorerSummary<Types>,
 }
@@ -184,7 +184,7 @@ where
 impl<Types: NodeType> From<ExplorerSummary<Types>> for ExplorerSummaryResponse<Types>
 where
     Header<Types>: ExplorerHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
 {
     fn from(explorer_summary: ExplorerSummary<Types>) -> Self {
         Self { explorer_summary }
@@ -198,7 +198,7 @@ where
 pub struct SearchResultResponse<Types: NodeType>
 where
     Header<Types>: ExplorerHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
 {
     pub search_results: SearchResult<Types>,
 }
@@ -206,7 +206,7 @@ where
 impl<Types: NodeType> From<SearchResult<Types>> for SearchResultResponse<Types>
 where
     Header<Types>: ExplorerHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
 {
     fn from(search_results: SearchResult<Types>) -> Self {
         Self { search_results }
@@ -243,7 +243,7 @@ pub fn define_api<State, Types: NodeType, Ver: StaticVersionType + 'static>(
 where
     State: 'static + Send + Sync + ReadState,
     Header<Types>: ExplorerHeader<Types> + QueryableHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
     Payload<Types>: QueryablePayload<Types>,
     <State as ReadState>::State: ExplorerDataSource<Types> + Send + Sync,
 {
@@ -329,10 +329,10 @@ where
 
                 let filter = match (
                     req.opt_integer_param("block"),
-                    req.opt_integer_param("namespace"),
+                    req.opt_integer_param::<_, i64>("namespace"),
                 ) {
                     (Ok(Some(block)), _) => TransactionSummaryFilter::Block(block),
-                    (_, Ok(Some(namespace))) => TransactionSummaryFilter::RollUp(namespace),
+                    (_, Ok(Some(namespace))) => TransactionSummaryFilter::RollUp(namespace.into()),
                     _ => TransactionSummaryFilter::None,
                 };
 

--- a/hotshot-query-service/src/explorer/data_source.rs
+++ b/hotshot-query-service/src/explorer/data_source.rs
@@ -43,7 +43,7 @@ pub trait ExplorerDataSource<Types>
 where
     Types: NodeType,
     Header<Types>: ExplorerHeader<Types> + QueryableHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
     Payload<Types>: QueryablePayload<Types>,
 {
     /// `get_block_detail` is a method that retrieves the details of a specific

--- a/hotshot-query-service/src/explorer/query_data.rs
+++ b/hotshot-query-service/src/explorer/query_data.rs
@@ -27,7 +27,9 @@ use super::{
     traits::{ExplorerHeader, ExplorerTransaction},
 };
 use crate::{
-    availability::{BlockQueryData, QueryableHeader, QueryablePayload, TransactionHash},
+    availability::{
+        BlockQueryData, NamespaceId, QueryableHeader, QueryablePayload, TransactionHash,
+    },
     node::BlockHash,
     types::HeightIndexed,
     Header, Payload, Resolvable, Transaction,
@@ -146,8 +148,6 @@ impl<'de> Deserialize<'de> for Timestamp {
 }
 
 pub type WalletAddress<Types> = <Header<Types> as ExplorerHeader<Types>>::WalletAddress;
-pub type BlockNamespaceId<Types> = <Header<Types> as ExplorerHeader<Types>>::NamespaceId;
-pub type TransactionNamespaceId<Types> = <Transaction<Types> as ExplorerTransaction>::NamespaceId;
 pub type ProposerId<Types> = <Header<Types> as ExplorerHeader<Types>>::ProposerId;
 pub type BalanceAmount<Types> = <Header<Types> as ExplorerHeader<Types>>::BalanceAmount;
 
@@ -330,10 +330,9 @@ pub struct TransactionDetailResponse<Types: NodeType> {
 pub struct TransactionSummary<Types: NodeType>
 where
     Header<Types>: ExplorerHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
 {
     pub hash: TransactionHash<Types>,
-    pub rollups: Vec<TransactionNamespaceId<Types>>,
+    pub rollups: Vec<NamespaceId<Types>>,
     pub height: u64,
     pub offset: u64,
     pub num_transactions: u64,
@@ -350,7 +349,7 @@ where
     BlockQueryData<Types>: HeightIndexed,
     Payload<Types>: QueryablePayload<Types>,
     Header<Types>: QueryableHeader<Types> + ExplorerHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
 {
     type Error = TimestampConversionError;
 
@@ -384,7 +383,7 @@ where
     BlockQueryData<Types>: HeightIndexed,
     Payload<Types>: QueryablePayload<Types>,
     Header<Types>: QueryableHeader<Types> + ExplorerHeader<Types>,
-    <Types as NodeType>::Transaction: ExplorerTransaction,
+    <Types as NodeType>::Transaction: ExplorerTransaction<Types>,
 {
     type Error = TimestampConversionError;
 
@@ -423,9 +422,14 @@ pub struct GetBlockSummariesRequest<Types: NodeType>(pub BlockRange<Types>);
 /// [TransactionSummaryFilter] represents the various filters that can be
 /// applied when retrieving a list of [TransactionSummary] entries.
 #[derive(Debug, Deserialize, Serialize)]
-pub enum TransactionSummaryFilter {
+#[serde(bound = "")]
+pub enum TransactionSummaryFilter<Types>
+where
+    Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
+{
     None,
-    RollUp(usize),
+    RollUp(NamespaceId<Types>),
     Block(usize),
 }
 
@@ -434,12 +438,20 @@ pub enum TransactionSummaryFilter {
 /// endpoint will be mapped to this struct in order for the request to be
 /// processed.
 #[derive(Debug)]
-pub struct GetTransactionSummariesRequest<Types: NodeType> {
+pub struct GetTransactionSummariesRequest<Types>
+where
+    Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
+{
     pub range: TransactionRange<Types>,
-    pub filter: TransactionSummaryFilter,
+    pub filter: TransactionSummaryFilter<Types>,
 }
 
-impl<Types: NodeType> Default for GetTransactionSummariesRequest<Types> {
+impl<Types> Default for GetTransactionSummariesRequest<Types>
+where
+    Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
+{
     fn default() -> Self {
         Self {
             range: TransactionRange {
@@ -492,7 +504,7 @@ pub struct ExplorerHistograms {
 pub struct ExplorerSummary<Types: NodeType>
 where
     Header<Types>: ExplorerHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
 {
     pub latest_block: BlockDetail<Types>,
     pub genesis_overview: GenesisOverview,
@@ -510,7 +522,7 @@ where
 pub struct SearchResult<Types: NodeType>
 where
     Header<Types>: ExplorerHeader<Types>,
-    Transaction<Types>: ExplorerTransaction,
+    Transaction<Types>: ExplorerTransaction<Types>,
 {
     pub blocks: Vec<BlockSummary<Types>>,
     pub transactions: Vec<TransactionSummary<Types>>,

--- a/hotshot-query-service/src/testing/mocks.rs
+++ b/hotshot-query-service/src/testing/mocks.rs
@@ -47,13 +47,25 @@ pub fn mock_transaction(payload: Vec<u8>) -> MockTransaction {
 }
 
 impl QueryableHeader<MockTypes> for MockHeader {
+    type NamespaceId = i64;
+    type NamespaceIndex = i64;
+
     fn timestamp(&self) -> u64 {
         self.timestamp
     }
 
-    fn namespace_size(&self, id: u32, payload_size: usize) -> u64 {
+    fn namespace_id(&self, i: &i64) -> Option<i64> {
         // Test types only support a single namespace.
-        if id == 0 {
+        if *i == 0 {
+            Some(0)
+        } else {
+            None
+        }
+    }
+
+    fn namespace_size(&self, i: &i64, payload_size: usize) -> u64 {
+        // Test types only support a single namespace.
+        if *i == 0 {
             payload_size as u64
         } else {
             0
@@ -65,7 +77,6 @@ impl ExplorerHeader<MockTypes> for MockHeader {
     type BalanceAmount = i128;
     type WalletAddress = [u8; 32];
     type ProposerId = [u8; 32];
-    type NamespaceId = u64;
 
     fn proposer_id(&self) -> Self::ProposerId {
         [0; 32]
@@ -83,15 +94,13 @@ impl ExplorerHeader<MockTypes> for MockHeader {
         0
     }
 
-    fn namespace_ids(&self) -> Vec<Self::NamespaceId> {
+    fn namespace_ids(&self) -> Vec<i64> {
         vec![0]
     }
 }
 
-impl ExplorerTransaction for MockTransaction {
-    type NamespaceId = u64;
-
-    fn namespace_id(&self) -> Self::NamespaceId {
+impl ExplorerTransaction<MockTypes> for MockTransaction {
+    fn namespace_id(&self) -> i64 {
         0
     }
 
@@ -106,8 +115,8 @@ impl HeightIndexed for MockHeader {
     }
 }
 
-impl<Types: NodeType> QueryablePayload<Types> for MockPayload {
-    type Iter<'a> = <Vec<TransactionIndex> as IntoIterator>::IntoIter;
+impl QueryablePayload<MockTypes> for MockPayload {
+    type Iter<'a> = <Vec<TransactionIndex<MockTypes>> as IntoIterator>::IntoIter;
     type InclusionProof = ();
 
     fn len(&self, _meta: &Self::Metadata) -> usize {
@@ -115,9 +124,9 @@ impl<Types: NodeType> QueryablePayload<Types> for MockPayload {
     }
 
     fn iter(&self, meta: &Self::Metadata) -> Self::Iter<'_> {
-        (0..<TestBlockPayload as QueryablePayload<Types>>::len(self, meta))
+        (0..<TestBlockPayload as QueryablePayload<MockTypes>>::len(self, meta))
             .map(|i| TransactionIndex {
-                namespace: 0,
+                ns_index: 0,
                 position: i as u32,
             })
             .collect::<Vec<_>>()
@@ -127,7 +136,7 @@ impl<Types: NodeType> QueryablePayload<Types> for MockPayload {
     fn transaction_with_proof(
         &self,
         _meta: &Self::Metadata,
-        index: &TransactionIndex,
+        index: &TransactionIndex<MockTypes>,
     ) -> Option<(Self::Transaction, Self::InclusionProof)> {
         self.transactions
             .get(index.position as usize)

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2014,7 +2014,7 @@ mod test {
         v0_1::{block_reward, RewardAmount, COMMISSION_BASIS_POINTS},
         v0_3::StakeTableFetcher,
         validators_from_l1_events, EpochVersion, FeeAmount, FeeVersion, Header, L1ClientOptions,
-        MockSequencerVersions, SequencerVersions, ValidatedState,
+        MockSequencerVersions, NamespaceId, SequencerVersions, ValidatedState,
     };
     use futures::{
         future::{self, join_all},
@@ -2023,8 +2023,9 @@ mod test {
     use hotshot::types::EventType;
     use hotshot_example_types::node_types::EpochsTestVersions;
     use hotshot_query_service::{
-        availability::{BlockQueryData, LeafQueryData, VidCommonQueryData},
+        availability::{BlockQueryData, BlockSummaryQueryData, LeafQueryData, VidCommonQueryData},
         data_source::{sql::Config, storage::SqlStorage, VersionedDataSource},
+        explorer::TransactionSummariesResponse,
         types::HeightIndexed,
     };
     use hotshot_types::{
@@ -2060,7 +2061,7 @@ mod test {
         },
         catchup::{NullStateCatchup, StatePeers},
         persistence::no_storage,
-        testing::{TestConfig, TestConfigBuilder},
+        testing::{wait_for_decide_on_handle, TestConfig, TestConfigBuilder},
     };
 
     #[tokio::test(flavor = "multi_thread")]
@@ -4513,6 +4514,84 @@ mod test {
                 if epoch > Some(EpochNumber::new(target_epoch)) {
                     break;
                 }
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_tx_metadata() {
+        setup_test();
+
+        let port = pick_unused_port().expect("No ports free");
+
+        let url = format!("http://localhost:{port}").parse().unwrap();
+        let client: Client<ServerError, StaticVersion<0, 1>> = Client::new(url);
+
+        let storage = SqlDataSource::create_storage().await;
+        let network_config = TestConfigBuilder::default().build();
+        let config = TestNetworkConfigBuilder::default()
+            .api_config(
+                SqlDataSource::options(&storage, Options::with_port(port))
+                    .submit(Default::default())
+                    .explorer(Default::default()),
+            )
+            .network_config(network_config)
+            .build();
+        let network = TestNetwork::new(config, MockSequencerVersions::new()).await;
+        let mut events = network.server.event_stream().await;
+
+        client.connect(None).await;
+
+        // Submit a few transactions in different namespaces.
+        let namespace_counts = [(101, 1), (102, 2), (103, 3)];
+        for (ns, count) in &namespace_counts {
+            for i in 0..*count {
+                let ns_id = NamespaceId::from(*ns as u64);
+                let txn = Transaction::new(ns_id, vec![*ns, i]);
+                client
+                    .post::<()>("submit/submit")
+                    .body_json(&txn)
+                    .unwrap()
+                    .send()
+                    .await
+                    .unwrap();
+                let block = wait_for_decide_on_handle(&mut events, &txn).await;
+
+                // Block summary should contain information about the namespace.
+                let summary: BlockSummaryQueryData<SeqTypes> = client
+                    .get(&format!("availability/block/summary/{block}"))
+                    .send()
+                    .await
+                    .unwrap();
+                let ns_info = summary.namespaces();
+                assert_eq!(ns_info.len(), 1);
+                assert_eq!(ns_info.keys().copied().collect::<Vec<_>>(), vec![ns_id]);
+                assert_eq!(ns_info[&ns_id].num_transactions, 1);
+                assert_eq!(ns_info[&ns_id].size, txn.size_in_block(true));
+            }
+        }
+
+        // List transactions in each namespace.
+        for (ns, count) in &namespace_counts {
+            tracing::info!(ns, "list transactions in namespace");
+
+            let ns_id = NamespaceId::from(*ns as u64);
+            let summaries: TransactionSummariesResponse<SeqTypes> = client
+                .get(&format!(
+                    "explorer/transactions/latest/{count}/namespace/{ns_id}"
+                ))
+                .send()
+                .await
+                .unwrap();
+            let txs = summaries.transaction_summaries;
+            assert_eq!(txs.len(), *count as usize);
+
+            // Check that transactions are listed in descending order.
+            for i in 0..*count {
+                let summary = &txs[i as usize];
+                let expected = Transaction::new(ns_id, vec![*ns, count - i - 1]);
+                assert_eq!(summary.rollups, vec![ns_id]);
+                assert_eq!(summary.hash, expected.commit());
             }
         }
     }

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -1321,6 +1321,7 @@ pub mod testing {
                         None
                     }
                 }) {
+                    tracing::info!(height, "transaction {commitment} sequenced");
                     return height;
                 }
             } else {

--- a/types/src/v0/impls/block/full_payload/ns_table.rs
+++ b/types/src/v0/impls/block/full_payload/ns_table.rs
@@ -307,6 +307,18 @@ impl NsIndex {
     }
 }
 
+impl From<i64> for NsIndex {
+    fn from(i: i64) -> Self {
+        Self(i as usize)
+    }
+}
+
+impl From<NsIndex> for i64 {
+    fn from(i: NsIndex) -> i64 {
+        i.0 as i64
+    }
+}
+
 impl NumNss {
     pub fn in_bounds(&self, index: &NsIndex) -> bool {
         index.0 < self.0

--- a/types/src/v0/impls/block/full_payload/payload.rs
+++ b/types/src/v0/impls/block/full_payload/payload.rs
@@ -44,9 +44,9 @@ impl Payload {
     /// Like [`QueryablePayload::transaction_with_proof`] except without the
     /// proof.
     pub fn transaction(&self, index: &Index) -> Option<Transaction> {
-        let ns = NsIndex(index.namespace as usize);
-        let ns_id = self.ns_table.read_ns_id(&ns)?;
-        let ns_payload = self.ns_payload(&ns);
+        let ns = &index.ns_index;
+        let ns_id = self.ns_table.read_ns_id(ns)?;
+        let ns_payload = self.ns_payload(ns);
         ns_payload.export_tx(&ns_id, &TxIndex(index.position as usize))
     }
 
@@ -80,7 +80,7 @@ impl Payload {
     > {
         // accounting for block byte length limit
         let max_block_byte_len = u64::from(chain_config.max_block_size);
-        let mut block_byte_len = NsTableBuilder::header_byte_len() as u64;
+        let mut block_byte_len = 0;
 
         // add each tx to its namespace
         let mut ns_builders = BTreeMap::<NamespaceId, NsPayloadBuilder>::new();

--- a/types/src/v0/impls/block/namespace_payload/iter.rs
+++ b/types/src/v0/impls/block/namespace_payload/iter.rs
@@ -25,7 +25,7 @@ impl Iterator for Iter<'_> {
                 .next()
             {
                 break Some(Index {
-                    namespace: ns_index.0 as u32,
+                    ns_index: ns_index.clone(),
                     position: tx_index.0 as u32,
                 });
             }

--- a/types/src/v0/impls/block/namespace_payload/tx_proof.rs
+++ b/types/src/v0/impls/block/namespace_payload/tx_proof.rs
@@ -8,7 +8,7 @@ use jf_vid::{
 };
 
 use crate::{
-    Index, NsIndex, NsTable, NumTxs, NumTxsRange, Payload, PayloadByteLen, Transaction, TxIndex,
+    Index, NsTable, NumTxs, NumTxsRange, Payload, PayloadByteLen, Transaction, TxIndex,
     TxPayloadRange, TxProof, TxTableEntriesRange,
 };
 
@@ -20,7 +20,7 @@ impl TxProof {
         payload: &Payload,
         common: &ADVZCommon,
     ) -> Option<(Transaction, Self)> {
-        let ns_index = &NsIndex(index.namespace as usize);
+        let ns_index = &index.ns_index;
         let tx_index = &TxIndex(index.position as usize);
 
         let payload_byte_len = payload.byte_len();

--- a/types/src/v0/impls/block/test.rs
+++ b/types/src/v0/impls/block/test.rs
@@ -117,9 +117,7 @@ async fn enforce_max_block_size() {
     let tx_count_expected = test.all_txs().len();
 
     let chain_config = ChainConfig {
-        max_block_size: BlockSize::from(
-            (payload_byte_len_expected + ns_table_byte_len_expected) as u64,
-        ),
+        max_block_size: BlockSize::from(payload_byte_len_expected as u64),
         ..Default::default()
     };
 
@@ -142,9 +140,7 @@ async fn enforce_max_block_size() {
     // WARN log should be emitted
 
     let chain_config = ChainConfig {
-        max_block_size: BlockSize::from(
-            (payload_byte_len_expected + ns_table_byte_len_expected - 1) as u64,
-        ),
+        max_block_size: BlockSize::from((payload_byte_len_expected - 1) as u64),
         ..Default::default()
     };
     let instance_state = NodeState::default().with_chain_config(chain_config);

--- a/types/src/v0/impls/header.rs
+++ b/types/src/v0/impls/header.rs
@@ -961,13 +961,20 @@ impl BlockHeader<SeqTypes> for Header {
 }
 
 impl QueryableHeader<SeqTypes> for Header {
+    type NamespaceId = NamespaceId;
+    type NamespaceIndex = NsIndex;
+
     fn timestamp(&self) -> u64 {
         self.timestamp()
     }
 
-    fn namespace_size(&self, id: u32, payload_size: usize) -> u64 {
+    fn namespace_id(&self, i: &NsIndex) -> Option<NamespaceId> {
+        self.ns_table().read_ns_id(i)
+    }
+
+    fn namespace_size(&self, i: &NsIndex, payload_size: usize) -> u64 {
         self.ns_table()
-            .ns_range(&NsIndex(id as usize), &PayloadByteLen(payload_size))
+            .ns_range(i, &PayloadByteLen(payload_size))
             .byte_len()
             .0 as u64
     }
@@ -977,7 +984,6 @@ impl ExplorerHeader<SeqTypes> for Header {
     type BalanceAmount = FeeAmount;
     type WalletAddress = Vec<FeeAccount>;
     type ProposerId = Vec<FeeAccount>;
-    type NamespaceId = NamespaceId;
 
     // TODO what are these expected values w/ multiple Fees
     fn proposer_id(&self) -> Self::ProposerId {
@@ -1002,7 +1008,7 @@ impl ExplorerHeader<SeqTypes> for Header {
         FeeAmount::from(0)
     }
 
-    fn namespace_ids(&self) -> Vec<Self::NamespaceId> {
+    fn namespace_ids(&self) -> Vec<NamespaceId> {
         self.ns_table()
             .iter()
             .map(|i| self.ns_table().read_ns_id_unchecked(&i))

--- a/types/src/v0/v0_1/block.rs
+++ b/types/src/v0/v0_1/block.rs
@@ -145,6 +145,9 @@ pub struct NsTableBuilder {
     pub(crate) num_entries: usize,
 }
 
+/// Index of a transaction.
+pub type Index = hotshot_query_service::availability::TransactionIndex<crate::SeqTypes>;
+
 /// Index for an entry in a ns table.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct NsIndex(pub(crate) usize);
@@ -190,8 +193,6 @@ pub struct Payload {
 /// namespace table.
 #[derive(Clone, Debug, Display, Eq, Hash, PartialEq)]
 pub struct PayloadByteLen(pub(crate) usize);
-
-pub use hotshot_query_service::availability::TransactionIndex as Index;
 
 /// Cartesian product of [`NsIter`], [`TxIter`].
 pub struct Iter<'a> {


### PR DESCRIPTION
Does [this](https://app.asana.com/1/1208976916964769/project/1210128724229719/task/1210253275558855?focus=true), among other things.

The earlier change to separate namespace information in transactions in the database was incorrect, because it conflated namespace indexes (i.e. the offset of a given namespace within the namespace table, which may vary from block to block for a given namespace) with global namespace IDs.

I discovered this when I tried to implement transaction filtering by namespace for the explorer, which should have been easy after the previous change. It turned out not to be possible, because what was stored in the database was only the namespace index, not the ID.

### This PR:

This change addresses the problem and hopefully reduces confusion by creating separate types for namespace index vs ID. Both are now stored in the database (the migration to populate the namespace ID is a little gross, but thankfully the information is all there in the namespace table).

We add a test for the new functionality, and implement the explorer namespace filtering feature as a sanity check that the database schema is now correct and sufficently expressive. Thus, in addition to running unit tests, you can test this change by running a local demo, opening the block explorer in a browser, and clicking on a namespace link in the transactions panel. This will take you to a page listing transactions in that namespace, which should be correctly populated. Prior to this change, that page was empty.

Incidentally, this change also fixes what I believe is a bug: when building a block, bytes added to the namespace table are counted against the total block size for the purpose of truncating, but these bytes actually live in the header, and don't count when enforcing maximum block size in the actual proposal validation. I discovered this while working on the new unit test, since that also deals with transaction and namespace sizes.

### This PR does not:

Note that the updated migration for Postgres populates all the new fields using a coputation on existing data, but the sqlite migration creates a new _empty_ table. This is basically because sqlite doesn't have a base64 decode function, which is needed to get the namespace ID out of the namespace table. There are extensions for this, but there is not a good package manager, so it's difficult to install and manage these extensions in a nice way. For now, I think it's ok for the migration to adjust the schema but not populate old data, since we don't have any sqlite nodes in production anyway.

### Key places to review:
* Both database migrations
* New unit test in `api.rs`
* New queries and filtering in `queries/explorer.rs`
