### PR TITLE
Rewrite GCL stake table state and add unittests

### DIFF
--- a/contracts/rust/adapter/src/stake_table.rs
+++ b/contracts/rust/adapter/src/stake_table.rs
@@ -17,7 +17,9 @@ use jf_signature::{
 };
 
 use crate::sol_types::{
-    StakeTableV2::{getVersionReturn, ConsensusKeysUpdatedV2, ValidatorRegisteredV2},
+    StakeTableV2::{
+        getVersionReturn, ConsensusKeysUpdatedV2, StakeTableV2Events, ValidatorRegisteredV2,
+    },
     *,
 };
 

--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -19,7 +19,7 @@ use super::{
     state::ValidatedState,
     traits::{EventsPersistenceRead, MembershipPersistence},
     v0_1::NoStorage,
-    v0_3::{EventKey, IndexedStake, StakeTableEvent, Validator},
+    v0_3::{EventKey, IndexedStake, StakeTableEvent, StakeTableEventType, Validator, ValidatorMap},
     SeqTypes, UpgradeType, ViewBasedUpgrade,
 };
 use crate::v0::{
@@ -67,10 +67,7 @@ pub struct NodeState {
 
 #[async_trait]
 impl MembershipPersistence for NoStorage {
-    async fn load_stake(
-        &self,
-        _epoch: EpochNumber,
-    ) -> anyhow::Result<Option<IndexMap<alloy::primitives::Address, Validator<BLSPubKey>>>> {
+    async fn load_stake(&self, _epoch: EpochNumber) -> anyhow::Result<Option<ValidatorMap>> {
         Ok(None)
     }
 
@@ -78,29 +75,19 @@ impl MembershipPersistence for NoStorage {
         Ok(None)
     }
 
-    async fn store_stake(
-        &self,
-        _epoch: EpochNumber,
-        _stake: IndexMap<alloy::primitives::Address, Validator<BLSPubKey>>,
-    ) -> anyhow::Result<()> {
+    async fn store_stake(&self, _epoch: EpochNumber, _stake: ValidatorMap) -> anyhow::Result<()> {
         Ok(())
     }
 
     async fn store_events(
         &self,
         _l1_finalized: u64,
-        _events: Vec<(EventKey, StakeTableEvent)>,
+        _events: Vec<StakeTableEventType>,
     ) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn load_events(
-        &self,
-        _l1_block: u64,
-    ) -> anyhow::Result<(
-        Option<EventsPersistenceRead>,
-        Vec<(EventKey, StakeTableEvent)>,
-    )> {
+    async fn load_events(&self, _l1_block: u64) -> anyhow::Result<Option<EventsPersistenceRead>> {
         bail!("unimplemented")
     }
 }

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -829,9 +829,9 @@ impl StakeTableFetcher {
         let mut events: Result<Vec<StakeTableEventType>, StakeTableEventHandlerError> =
             events.iter().map(StakeTableEventType::try_from).collect();
 
-        events
-            .as_mut()
-            .map(|e| e.sort_by_key(|event| event.block_number));
+        if let Ok(e) = events.as_mut() {
+            e.sort_by_key(|event| event.block_number)
+        }
         events
     }
 

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -84,59 +84,6 @@ pub struct StakeTableEvents {
     keys_v2: Vec<(ConsensusKeysUpdatedV2, Log)>,
 }
 
-impl StakeTableEvents {
-    /// Creates a new instance of `StakeTableEvents` with the provided events.
-    ///
-    /// Remove unauthenticated registration and key update events
-    fn from_l1_logs(
-        registrations: Vec<(ValidatorRegistered, Log)>,
-        registrations_v2: Vec<(ValidatorRegisteredV2, Log)>,
-        deregistrations: Vec<(ValidatorExit, Log)>,
-        delegated: Vec<(Delegated, Log)>,
-        undelegated: Vec<(Undelegated, Log)>,
-        keys: Vec<(ConsensusKeysUpdated, Log)>,
-        keys_v2: Vec<(ConsensusKeysUpdatedV2, Log)>,
-    ) -> Self {
-        let registrations_v2 = registrations_v2
-            .into_iter()
-            .filter(|(event, log)| {
-                event
-                    .authenticate()
-                    .map_err(|_| {
-                        tracing::warn!(
-                            "Failed to authenticate ValidatorRegisteredV2 event {}",
-                            log.display()
-                        );
-                    })
-                    .is_ok()
-            })
-            .collect();
-        let keys_v2 = keys_v2
-            .into_iter()
-            .filter(|(event, log)| {
-                event
-                    .authenticate()
-                    .map_err(|_| {
-                        tracing::warn!(
-                            "Failed to authenticate ConsensusKeysUpdatedV2 event {}",
-                            log.display()
-                        );
-                    })
-                    .is_ok()
-            })
-            .collect();
-        Self {
-            registrations,
-            registrations_v2,
-            deregistrations,
-            delegated,
-            undelegated,
-            keys,
-            keys_v2,
-        }
-    }
-}
-
 /// Extract all validators from L1 stake table events.
 // TODO: MA we should reject ValidatorRegistered and ConsensusKeysUpdated events after the stake
 // table contract has been updated to V2, this is currently however not a safety issue because the

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -1048,7 +1048,7 @@ impl StakeTableFetcher {
         Self::new(peers, Arc::new(Mutex::new(persistence)), l1, chain_config)
     }
 }
-/// Holds Stake table and da stake
+/// Holds Stake table and DA members
 #[derive(Clone, Debug)]
 struct NonEpochCommittee {
     /// The nodes eligible for leadership.
@@ -1069,16 +1069,19 @@ struct NonEpochCommittee {
     indexed_da_members: HashMap<PubKey, PeerConfig<SeqTypes>>,
 }
 
-/// Holds Stake table and da stake
+/// Holds Stake table and DA members
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct EpochCommittee {
     /// The nodes eligible for leadership.
     /// NOTE: This is currently a hack because the DA leader needs to be the quorum
     /// leader but without voting rights.
     eligible_leaders: Vec<PeerConfig<SeqTypes>>,
-    /// Keys for nodes participating in the network
+    /// Ordered keys for nodes participating in the network
     stake_table: IndexMap<PubKey, PeerConfig<SeqTypes>>,
+    /// Ordered keys for nodes participating in the network
     validators: IndexMap<Address, Validator<BLSPubKey>>,
+    /// Mapping of BLS keys used to sign consensus to etherium addresses holding
+    /// stake on the l1.
     address_mapping: HashMap<BLSPubKey, Address>,
 }
 
@@ -1294,10 +1297,9 @@ enum GetStakeTablesError {
 }
 
 #[derive(Error, Debug)]
-#[error("Could not lookup leader")] // TODO error variants? message?
+#[error("Could not lookup leader")]
 pub struct LeaderLookupError;
 
-// #[async_trait]
 impl Membership<SeqTypes> for EpochCommittees {
     type Error = LeaderLookupError;
     // DO NOT USE. Dummy constructor to comply w/ trait.
@@ -2015,7 +2017,7 @@ mod tests {
         }
         .into();
 
-        // first ensure that wan build a valid stake table
+        // first ensure that we build a valid stake table
         assert!(active_validator_set_from_l1_events(
             vec![register.clone(), delegate.clone()].into_iter()
         )

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -423,16 +423,13 @@ impl EpochCommittees {
         })
     }
 
-    /// Update state to either create a new stake table for the given epoch or
-    /// insert the given validator into the already existing stake table.
+    /// Update state to either create a new stake table for the given epoch
+    /// containing the given validator, or update the existing stake table with the given validator
     pub fn add_validator_to_epoch(
         &mut self,
         epoch: EpochNumber,
         validator: Validator<PubKey>,
     ) -> Result<(), StakeTableStateInsertError> {
-        // Similar to `update_stake_table` but
-        // 1. only take a single validator
-        // 2. insert_or_update map for epoch
         if let Some(stake_table) = self.state.get_mut(&epoch) {
             stake_table.update(validator)?;
         } else {

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -1232,13 +1232,6 @@ impl EpochCommittees {
 }
 
 #[derive(Error, Debug)]
-/// Error representing fail cases for retrieving the stake table.
-enum GetStakeTablesError {
-    #[error("Error fetching from L1: {0}")]
-    L1ClientFetchError(anyhow::Error),
-}
-
-#[derive(Error, Debug)]
 #[error("Could not lookup leader")]
 pub struct LeaderLookupError;
 

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -1045,7 +1045,7 @@ impl EpochCommittees {
     /// to be called before calling `self.stake()` so that
     /// `Self.stake_table` only needs to be updated once in a given
     /// life-cycle but may be read from many times.
-    fn update_stake_table(&mut self, epoch: EpochNumber, validators: ValidatorMap) {
+    fn _update_stake_table(&mut self, epoch: EpochNumber, validators: ValidatorMap) {
         let mut address_mapping = HashMap::new();
         // TODO figure out why, if we
         // really need this. `Validator` should hold all the info.
@@ -1217,8 +1217,9 @@ impl EpochCommittees {
             },
         };
 
+        // TODO think about persistence
         for (epoch, stake_table) in loaded_stake {
-            self.update_stake_table(epoch, stake_table);
+            self._update_stake_table(epoch, stake_table);
         }
     }
 
@@ -1465,8 +1466,6 @@ impl Membership<SeqTypes> for EpochCommittees {
 
         let fetcher = Arc::clone(&membership_reader.fetcher);
 
-        // TODO instead of getting back stake tables, get back events.
-        // then event.map(mmembership.apply).
         let events = fetcher.fetch(epoch, block_header).await?;
 
         // TODO remove, will be replaced by apply. also, we should be able to
@@ -1494,7 +1493,7 @@ impl Membership<SeqTypes> for EpochCommittees {
         events
             .into_iter()
             .map(|event| membership_writer.apply_event(epoch, event));
-        membership_writer.update_stake_table(epoch, stake_tables);
+        // membership_writer.update_stake_table(epoch, stake_tables);
 
         Ok(())
     }

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -423,8 +423,9 @@ impl EpochCommittees {
         })
     }
 
-    /// Update state to either create a new stake table for the given epoch
-    /// containing the given validator, or update the existing stake table with the given validator
+    /// Update state by either creating a new stake table for the given epoch
+    /// containing only the given validator, or update the existing stake table with
+    /// the given validator.
     pub fn add_validator_to_epoch(
         &mut self,
         epoch: EpochNumber,

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -135,87 +135,6 @@ impl StakeTableEvents {
             keys_v2,
         }
     }
-
-    pub fn _sort_events(self) -> anyhow::Result<Vec<(EventKey, StakeTableEvent)>> {
-        let mut events: Vec<(EventKey, StakeTableEvent)> = Vec::new();
-        let Self {
-            registrations,
-            registrations_v2,
-            deregistrations,
-            delegated,
-            undelegated,
-            keys,
-            keys_v2,
-        } = self;
-
-        for (registration, log) in registrations {
-            events.push((
-                (
-                    log.block_number.context("block number")?,
-                    log.log_index.context("log index")?,
-                ),
-                registration.into(),
-            ));
-        }
-        for (registration, log) in registrations_v2 {
-            events.push((
-                (
-                    log.block_number.context("block number")?,
-                    log.log_index.context("log index")?,
-                ),
-                registration.into(),
-            ));
-        }
-        for (dereg, log) in deregistrations {
-            events.push((
-                (
-                    log.block_number.context("block number")?,
-                    log.log_index.context("log index")?,
-                ),
-                dereg.into(),
-            ));
-        }
-        for (delegation, log) in delegated {
-            events.push((
-                (
-                    log.block_number.context("block number")?,
-                    log.log_index.context("log index")?,
-                ),
-                delegation.into(),
-            ));
-        }
-        for (undelegated, log) in undelegated {
-            events.push((
-                (
-                    log.block_number.context("block number")?,
-                    log.log_index.context("log index")?,
-                ),
-                undelegated.into(),
-            ));
-        }
-
-        for (update, log) in keys {
-            events.push((
-                (
-                    log.block_number.context("block number")?,
-                    log.log_index.context("log index")?,
-                ),
-                update.into(),
-            ));
-        }
-        for (update, log) in keys_v2 {
-            events.push((
-                (
-                    log.block_number.context("block number")?,
-                    log.log_index.context("log index")?,
-                ),
-                update.into(),
-            ));
-        }
-
-        events.sort_by_key(|(key, _)| *key);
-        Ok(events)
-    }
 }
 
 /// Extract all validators from L1 stake table events.
@@ -1550,7 +1469,8 @@ impl Membership<SeqTypes> for EpochCommittees {
         // then event.map(mmembership.apply).
         let events = fetcher.fetch(epoch, block_header).await?;
 
-        // TODO remove, will be replaced by apply. also, we should be able to query validators from state.
+        // TODO remove, will be replaced by apply. also, we should be able to
+        // query validators from state.
         let stake_tables =
             active_validator_set_from_l1_events(events.clone().into_iter().map(|e| e.data))
                 .map_err(|e| StakeTableFetchError::StakeTableConstructionError)?;

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -45,9 +45,8 @@ use super::v0_3::DAMembers;
 use super::{
     traits::{MembershipPersistence, StateCatchup},
     v0_3::{
-        ChainConfig, EventKey, OrderedValidators, StakeTableEvent, StakeTableEventHandlerError,
-        StakeTableEventType, StakeTableFetchError, StakeTableFetcher, StakeTableUpdateTask,
-        Validator,
+        ChainConfig, EventKey, StakeTableEvent, StakeTableEventHandlerError, StakeTableEventType,
+        StakeTableFetchError, StakeTableFetcher, StakeTableUpdateTask, Validator, ValidatorMap,
     },
     Header, L1Client, Leaf2, PubKey, SeqTypes,
 };
@@ -223,7 +222,7 @@ impl StakeTableEvents {
 // V2 contract will not generate the V1 events after the upgrade to V2.
 pub fn validators_from_l1_events<I: Iterator<Item = StakeTableEvent>>(
     events: I,
-) -> anyhow::Result<IndexMap<Address, Validator<BLSPubKey>>> {
+) -> anyhow::Result<ValidatorMap> {
     let mut validators = IndexMap::new();
     let mut bls_keys = HashSet::new();
     let mut schnorr_keys = HashSet::new();
@@ -498,7 +497,7 @@ pub(crate) fn select_active_validator_set(
 /// Extract the active validator set from the L1 stake table events.
 pub(crate) fn active_validator_set_from_l1_events<I: Iterator<Item = StakeTableEvent>>(
     events: I,
-) -> anyhow::Result<OrderedValidators> {
+) -> anyhow::Result<ValidatorMap> {
     let mut validators = validators_from_l1_events(events)?;
     select_active_validator_set(&mut validators)?;
     Ok(validators)
@@ -828,7 +827,7 @@ impl StakeTableFetcher {
         &self,
         epoch: Epoch,
         header: Header,
-    ) -> Result<OrderedValidators, StakeTableFetchError> {
+    ) -> Result<ValidatorMap, StakeTableFetchError> {
         let chain_config = self.get_chain_config(&header).await?;
         // update chain config
         *self.chain_config.lock().await = chain_config;

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -1486,9 +1486,10 @@ impl Membership<SeqTypes> for EpochCommittees {
         }
 
         let mut membership_writer = membership.write().await;
-        events
+        let _: Vec<_> = events
             .into_iter()
-            .map(|event| membership_writer.apply_event(epoch, event));
+            .map(|event| membership_writer.apply_event(epoch, event))
+            .collect();
         // membership_writer.update_stake_table(epoch, stake_tables);
 
         Ok(())

--- a/types/src/v0/traits.rs
+++ b/types/src/v0/traits.rs
@@ -40,9 +40,7 @@ use super::{
     impls::NodeState,
     utils::BackoffParams,
     v0_1::{RewardAccount, RewardAccountProof, RewardMerkleCommitment},
-    v0_3::{
-        EventKey, IndexedStake, OrderedValidators, StakeTableEvent, StakeTableEventType, Validator,
-    },
+    v0_3::{EventKey, IndexedStake, StakeTableEvent, StakeTableEventType, Validator, ValidatorMap},
 };
 use crate::{
     v0::impls::ValidatedState, v0_3::ChainConfig, BlockMerkleTree, Event, FeeAccount,
@@ -404,8 +402,7 @@ pub trait MembershipPersistence: Send + Sync + 'static {
     async fn load_latest_stake(&self, limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>>;
 
     /// Store stake table at `epoch` in the persistence layer
-    async fn store_stake(&self, epoch: EpochNumber, stake: OrderedValidators)
-        -> anyhow::Result<()>;
+    async fn store_stake(&self, epoch: EpochNumber, stake: ValidatorMap) -> anyhow::Result<()>;
 
     async fn store_events(
         &self,

--- a/types/src/v0/v0_3/stake_table.rs
+++ b/types/src/v0/v0_3/stake_table.rs
@@ -146,15 +146,15 @@ pub enum StakeTableEvent {
     KeyUpdateV2(ConsensusKeysUpdatedV2),
 }
 
-#[derive(Error, Debug, derive_more::From)]
+#[derive(thiserror::Error, Debug)]
 pub enum StakeTableEventHandlerError {
     #[error("Authentication Error: {0}.")]
-    FailedToAuthenticate(StakeTableSolError),
+    FailedToAuthenticate(#[from] StakeTableSolError),
     #[error("ABI Error: {0}.")]
-    ABIError(ABIError),
+    ABIError(#[from] ABIError),
 }
 
-#[derive(Error, Debug, derive_more::From)]
+#[derive(thiserror::Error, Debug, derive_more::From)]
 pub enum StakeTableStateInsertError {
     #[error("`insert` called and `Validator` already present in validator state")]
     UpdateOnInsertValidator,
@@ -166,12 +166,12 @@ pub enum StakeTableStateInsertError {
     UpdateOnInsertEpochCommittee,
 }
 
-#[derive(Error, Debug, derive_more::From)]
+#[derive(thiserror::Error, Debug)]
 pub enum StakeTableApplyEventError {
     #[error("BLS key already used: {0}")]
     DuplicateBlsKey(BLSPubKey),
     #[error("Authentication Error: {0}.")]
-    FailedToAuthenticate(StakeTableSolError),
+    FailedToAuthenticate(#[from] StakeTableSolError),
 }
 
 impl TryFrom<&Log> for StakeTableEventType {

--- a/types/src/v0/v0_3/stake_table.rs
+++ b/types/src/v0/v0_3/stake_table.rs
@@ -144,6 +144,14 @@ pub enum StakeTableEventHandlerError {
     ABIError(ABIError),
 }
 
+#[derive(Error, Debug, derive_more::From)]
+pub enum StakeTableApplyEventError {
+    #[error("BLS key already used: {0}")]
+    DuplicateBlsKey(PubKey),
+    #[error("Authentication Error: {0}.")]
+    FailedToAuthenticate(StakeTableSolError),
+}
+
 impl TryFrom<&Log> for StakeTableEventType {
     type Error = StakeTableEventHandlerError;
 

--- a/types/src/v0/v0_3/stake_table.rs
+++ b/types/src/v0/v0_3/stake_table.rs
@@ -72,17 +72,27 @@ pub type ValidatorMap = IndexMap<Address, Validator<BLSPubKey>>;
 /// Type for holding result sets matching epochs to stake tables.
 pub type IndexedStake = (EpochNumber, ValidatorMap);
 
-#[derive(Debug, PartialEq, Eq, Error, derive_more::From)]
+#[derive(Debug, PartialEq, Eq, Error)]
 /// Possible errors from fetching stake table from contract.
 pub enum StakeTableFetchError {
-    #[error("Failed to fetch stake table events: {0}.")]
-    FetchError(anyhow::Error), // TODO real error
+    #[error("Failed to fetch stake table events.")]
+    FetchError,
     #[error("No stake table contract address found in Chain config.")]
     ContractAddressNotFound,
     #[error("The epoch root for epoch {0} is missing the L1 finalized block info. This is a fatal error. Consensus is blocked and will not recover.")]
     MissingL1BlockInfo(EpochNumber),
-    #[error("Failed to construct stake table: {0}")]
-    StakeTableConstructionError(anyhow::Error),
+    #[error("Failed to construct stake table")]
+    StakeTableConstructionError,
+    #[error("Failed to load from persistence")]
+    PersistenceLoadError(String),
+    #[error("Failed to events")]
+    PersistenceStoreError,
+    #[error("Evnt Handling Error: {0}")]
+    StakeTableEventHandleError(String),
+    #[error("To block greater than from_block")]
+    ToBlockTooTall,
+    #[error("Failed to fetch ChainConfig")]
+    FailedToFetchChainConfig,
 }
 
 #[derive(Clone, derive_more::derive::Debug)]
@@ -147,7 +157,7 @@ pub enum StakeTableEventHandlerError {
 #[derive(Error, Debug, derive_more::From)]
 pub enum StakeTableApplyEventError {
     #[error("BLS key already used: {0}")]
-    DuplicateBlsKey(PubKey),
+    DuplicateBlsKey(BLSPubKey),
     #[error("Authentication Error: {0}.")]
     FailedToAuthenticate(StakeTableSolError),
 }

--- a/types/src/v0/v0_3/stake_table.rs
+++ b/types/src/v0/v0_3/stake_table.rs
@@ -155,6 +155,18 @@ pub enum StakeTableEventHandlerError {
 }
 
 #[derive(Error, Debug, derive_more::From)]
+pub enum StakeTableStateInsertError {
+    #[error("`insert` called and `Validator` already present in validator state")]
+    UpdateOnInsertValidator,
+    #[error("`insert` called and `Validator` already present in address mapping")]
+    UpdateOnInsertAddressMapping,
+    #[error("`insert` called and `Peer` already present in stake table")]
+    UpdateOnInsertStakeTable,
+    #[error("`insert` called and `EpochCommittee` already present in for epoch")]
+    UpdateOnInsertEpochCommittee,
+}
+
+#[derive(Error, Debug, derive_more::From)]
 pub enum StakeTableApplyEventError {
     #[error("BLS key already used: {0}")]
     DuplicateBlsKey(BLSPubKey),

--- a/types/src/v0/v0_3/stake_table.rs
+++ b/types/src/v0/v0_3/stake_table.rs
@@ -67,10 +67,10 @@ pub struct Delegator {
 }
 
 /// Validators mapped to `Address`s
-pub type OrderedValidators = IndexMap<Address, Validator<BLSPubKey>>;
+pub type ValidatorMap = IndexMap<Address, Validator<BLSPubKey>>;
 
 /// Type for holding result sets matching epochs to stake tables.
-pub type IndexedStake = (EpochNumber, OrderedValidators);
+pub type IndexedStake = (EpochNumber, ValidatorMap);
 
 #[derive(Debug, PartialEq, Eq, Error, derive_more::From)]
 /// Possible errors from fetching stake table from contract.
@@ -135,8 +135,6 @@ pub enum StakeTableEvent {
     KeyUpdate(ConsensusKeysUpdated),
     KeyUpdateV2(ConsensusKeysUpdatedV2),
 }
-
-type ValidatorMap = IndexMap<Address, Validator<BLSPubKey>>;
 
 #[derive(Error, Debug, derive_more::From)]
 pub enum StakeTableEventHandlerError {

--- a/types/src/v0/v0_3/stake_table.rs
+++ b/types/src/v0/v0_3/stake_table.rs
@@ -221,51 +221,6 @@ impl From<(EventKey, StakeTableEvent)> for StakeTableEventType {
     }
 }
 
-impl Validator {
-    pub fn from_event(event: StakeTableEvent) {
-        match event {
-            StakeTableEvent::Register(ValidatorRegistered {
-                account,
-                blsVk,
-                schnorrVk,
-                commission,
-            }) => {
-                let stake_table_key = BLSPubKey::from(blsVk);
-                let state_ver_key = SchnorrPubKey::from(schnorrVk);
-
-                Validator {
-                    account,
-                    stake_table_key,
-                    state_ver_key,
-                    stake: U256::from(0_u64),
-                    commission,
-                    delegators: HashMap::default(),
-                }
-            },
-            StakeTableEvent::RegisterV2(ValidatorRegisteredV2 {
-                account,
-                blsVK,
-                schnorrVK,
-                commission,
-                ..
-            }) => {
-                let stake_table_key: BLSPubKey = blsVK.into();
-                let state_ver_key: SchnorrPubKey = schnorrVK.into();
-
-                Validator {
-                    account,
-                    stake_table_key,
-                    state_ver_key,
-                    stake: U256::from(0_u64),
-                    commission,
-                    delegators: HashMap::default(),
-                }
-            },
-            _ => panic!("A `Validator` can only be built from a Registration Event"),
-        }
-    }
-}
-
 // TODO move to impl folder
 impl StakeTableEvent {
     pub fn handle(&self) -> Result<(), StakeTableEventHandlerError> {
@@ -275,7 +230,7 @@ impl StakeTableEvent {
                 event
                     .authenticate()
                     .map_err(StakeTableEventHandlerError::FailedToAuthenticate)?;
-                let validator = Validator::from_event(event);
+                // let validator = Validator::from_event(event);
                 // self.register(validators);
             },
             _ => todo!(),


### PR DESCRIPTION
Some changes which I hope begins to demonstrate general approach. I'm working my way backward to the end result, but we can imagine adding an `fn apply(event: Log)` to our current `EpochCommittees` which will take in an l1 event, validate / authenticate, and finally add to the correct stake table. Part of the validation is to compare the keys in the event to the keys already present in the fields of `EpochCommittees` and act accordingly.  `EpochCommittees` itself may require some reworking. 

Creates a new type to hold the event variant, block_height and log index, to clean up processing and sorting. It also replaces many individual call to contract with a single call for all event types. This will allow us to clean up a lot of  code to better evaluate what is actually required from stake stable state and how we can clean it up. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210440860565304