### PR TITLE
fix: fixes for docker demo UX

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -220,6 +220,7 @@
             nixpkgs-fmt
             entr
             process-compose
+            lazydocker # a docker compose TUI
             # `postgresql` defaults to an older version (15), so we select the latest version (16)
             # explicitly.
             postgresql_16

--- a/justfile
+++ b/justfile
@@ -7,7 +7,14 @@ doc *args:
     cargo doc --no-deps --document-private-items {{args}}
 
 demo *args:
-    docker compose up {{args}}
+    #!/usr/bin/env bash
+    trap "exit" INT TERM
+    trap cleanup EXIT
+    cleanup(){
+        docker compose down -v
+    }
+    >/dev/null 2>&1 docker compose up {{args}} &
+    lazydocker
 
 demo-native *args: (build "test")
     scripts/demo-native {{args}}

--- a/scripts/build-docker-images-native
+++ b/scripts/build-docker-images-native
@@ -42,7 +42,14 @@ while [[ $# -gt 0 ]]; do
       usage
       exit 0
       ;;
-    --image)
+    -i|--image)
+      # abort if specified multiple times
+      if [[ -n "${image:-}" ]]; then
+        >&2 echo "Error: --image option specified multiple times"
+        >&2 echo ""
+        usage
+        exit 1
+      fi
       image="$2"
       shift 2
       ;;

--- a/sequencer/src/bin/deploy.rs
+++ b/sequencer/src/bin/deploy.rs
@@ -222,7 +222,12 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let mut contracts = Contracts::from(opt.contracts);
-    let provider = build_provider(opt.mnemonic, opt.account_index, opt.rpc_url.clone());
+    let provider = build_provider(
+        opt.mnemonic,
+        opt.account_index,
+        opt.rpc_url.clone(),
+        Some(opt.l1_polling_interval),
+    );
 
     // First use builder to build constructor input arguments
     let mut args_builder = DeployerArgsBuilder::default();

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -276,6 +276,7 @@ pub async fn stake_for_demo(
         config.signer.mnemonic.clone().unwrap(),
         config.signer.account_index.unwrap(),
         config.rpc_url.clone(),
+        /* polling_interval */ None,
     );
 
     tracing::info!(

--- a/staking-cli/src/registration.rs
+++ b/staking-cli/src/registration.rs
@@ -247,6 +247,7 @@ mod test {
             "test test test test test test test test test test test junk".to_string(),
             1,
             system.rpc_url.clone(),
+            /* polling_interval */ None,
         );
         let validator_address = provider.default_signer_address();
         let (_, bls_key_pair, schnorr_key_pair) =


### PR DESCRIPTION
- fix: deployer polling interval ignored
- fix: silently ignore building images if multiple images specified
- feat: lazydocker TUI for docker demo

We ran into these working on https://github.com/EspressoSystems/espresso-network/pull/3306