### PR TITLE
fix typos in comments

### DIFF
--- a/crates/hotshot/types/src/epoch_membership.rs
+++ b/crates/hotshot/types/src/epoch_membership.rs
@@ -37,13 +37,13 @@ type EpochSender<TYPES> = (
 
 /// Struct to Coordinate membership catchup
 pub struct EpochMembershipCoordinator<TYPES: NodeType> {
-    /// The underlying membhersip
+    /// The underlying membership
     membership: Arc<RwLock<TYPES::Membership>>,
 
     /// Any in progress attempts at catching up are stored in this map
-    /// Any new callers wantin an `EpochMembership` will await on the signal
+    /// Any new callers wanting an `EpochMembership` will await on the signal
     /// alerting them the membership is ready.  The first caller for an epoch will
-    /// wait for the actual catchup and allert future callers when it's done
+    /// wait for the actual catchup and alert future callers when it's done
     catchup_map: Arc<Mutex<EpochMap<TYPES>>>,
 
     /// Number of blocks in an epoch

--- a/marketplace-builder-shared/src/utils/event_service_wrapper.rs
+++ b/marketplace-builder-shared/src/utils/event_service_wrapper.rs
@@ -31,7 +31,7 @@ pub struct EventServiceStream<Types: NodeType, V: StaticVersionType> {
 
 impl<Types: NodeType, ApiVer: StaticVersionType + 'static> EventServiceStream<Types, ApiVer> {
     /// Maximum period between events, once it elapsed we assume
-    /// udnerlying connection silently went down and attempt to reconnect
+    /// underlying connection silently went down and attempt to reconnect
     const MAX_WAIT_PERIOD: Duration = Duration::from_secs(10);
     const RETRY_PERIOD: Duration = Duration::from_secs(1);
     const CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);


### PR DESCRIPTION


**Description:**  
This pull request corrects several typos in code comments to improve clarity and maintain code quality.  
- "wantin" → "wanting"  
- "membhersip" → "membership"  
- "allert" → "alert"  
- "udnerlying" → "underlying"  
