### PR TITLE
fix: correct function naming and inheritance in LightClient contracts

### DIFF
--- a/contracts/src/LightClient.sol
+++ b/contracts/src/LightClient.sol
@@ -463,7 +463,7 @@ contract LightClient is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     /// the current state history retention period and must be at least 1 hour and max 365 days.
     /// @dev Reverts with `InvalidMaxStateHistory` if the provided value is less than 1 hour,
     /// more than 365 days or less than or equal to the current state history retention period.
-    function setstateHistoryRetentionPeriod(uint32 historySeconds) public onlyOwner {
+    function setStateHistoryRetentionPeriod(uint32 historySeconds) public virtual onlyOwner {
         if (
             historySeconds < 1 hours || historySeconds > 365 days
                 || historySeconds <= stateHistoryRetentionPeriod

--- a/contracts/src/LightClientV2.sol
+++ b/contracts/src/LightClientV2.sol
@@ -63,10 +63,10 @@ contract LightClientV2 is LightClient {
         revert DeprecatedApi();
     }
 
-    /// @notice identical as LightClientV1's `setstateHistoryRetentionPeriod()`
+    /// @notice identical as LightClientV1's `setStateHistoryRetentionPeriod()`
     /// but this function name has the correct camelCase
-    function setStateHistoryRetentionPeriod(uint32 historySeconds) public virtual onlyOwner {
-        setstateHistoryRetentionPeriod(historySeconds);
+    function setStateHistoryRetentionPeriod(uint32 historySeconds) public virtual override onlyOwner {
+        super.setStateHistoryRetentionPeriod(historySeconds);
     }
 
     function updateEpochStartBlock(uint64 newEpochStartBlock) public virtual onlyOwner {
@@ -220,7 +220,7 @@ contract LightClientV2 is LightClient {
         }
     }
 
-    /// @notice Decide if a block height is the an "epoch root" (defined as last block in epoch - 5)
+    /// @notice Decide if a block height is an "epoch root" (defined as last block in epoch - 5)
     /// @dev see
     /// <https://github.com/EspressoSystems/espresso-network/blob/2a904fa17838961cef130d0e87d7b371acaaea42/hotshot-types/src/utils.rs#L475>
     function isEpochRoot(uint64 blockHeight) public view virtual returns (bool) {

--- a/contracts/test/LightClientV2.t.sol
+++ b/contracts/test/LightClientV2.t.sol
@@ -747,7 +747,7 @@ contract LightClient_StateHistoryTest is LightClientCommonTest {
 
         uint32 curDuration = lc.stateHistoryRetentionPeriod();
         vm.expectRevert(LC.InvalidMaxStateHistory.selector);
-        lc.setstateHistoryRetentionPeriod(curDuration - 1);
+        lc.setStateHistoryRetentionPeriod(curDuration - 1);
     }
 
     function test_CorrectStateHistoryHandling() public {


### PR DESCRIPTION
### This PR:
* Fixes function naming and inheritance in LightClient contracts
* Renames `setstateHistoryRetentionPeriod` to `setStateHistoryRetentionPeriod` in LightClient.sol for proper camelCase naming convention
* Adds `virtual` keyword to the function in LightClient.sol to allow proper inheritance
* Adds `override` keyword in the child implementation in LightClientV2.sol
* Fixes potential infinite recursion by changing self-call to super-call in LightClientV2.sol
* Fixes grammar in function documentation comment ("is the an" -> "is an")

### Key places to review:
* contracts/src/LightClient.sol, `setStateHistoryRetentionPeriod` function
* contracts/src/LightClientV2.sol, `setStateHistoryRetentionPeriod` function
* contracts/src/LightClientV2.sol, comment for `isEpochRoot` function

- [x] Issue linked or PR description mentions why this change is necessary. 
- [x] PR description is clear enough for reviewers. 
- [x] Documentation for changes (additions) has been updated (added).  
- [ ] If this is a draft it is marked as "draft". 



