### PR TITLE
add transaction stream endpoints

### DIFF
--- a/hotshot-query-service/api/availability.toml
+++ b/hotshot-query-service/api/availability.toml
@@ -263,6 +263,18 @@ Returns
 ```
 """
 
+[route.stream_transactions]
+PATH = ["stream/transactions/:height/namespace/:namespace", "stream/transactions/:height"]
+METHOD = "SOCKET"
+":namespace" = "Integer"
+":height" = "Integer"
+DOC = """
+Subscribe to a stream of transactions starting at the given `:height`.
+
+If a `:namespace` is specified, the stream includes only transactions belonging to that namespace.
+Otherwise, the stream includes all transactions in the block.
+"""
+
 [route.get_stake_table]
 PATH = ["stake-table/:height", "stake-table/view/:view_number"]
 ":height" = "Integer"

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2051,7 +2051,10 @@ mod test {
     use hotshot_contract_adapter::sol_types::{EspToken, StakeTableV2};
     use hotshot_example_types::node_types::EpochsTestVersions;
     use hotshot_query_service::{
-        availability::{BlockQueryData, BlockSummaryQueryData, LeafQueryData, VidCommonQueryData},
+        availability::{
+            BlockQueryData, BlockSummaryQueryData, LeafQueryData, TransactionQueryData,
+            VidCommonQueryData,
+        },
         data_source::{sql::Config, storage::SqlStorage, VersionedDataSource},
         explorer::TransactionSummariesResponse,
         types::HeightIndexed,
@@ -4981,5 +4984,126 @@ mod test {
             total_payload_size, expected_total_size,
             "Incorrect total payload size: expected {expected_total_size}, got {total_payload_size}"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stream_transactions_endpoint() {
+        // This test submits transactions to a sequencer for multiple namespaces,
+        // waits for them to be decided, and then verifies that:
+        // 1. All transactions appear in the transaction stream.
+        // 2. Each namespace-specific transaction stream only includes the transactions of that namespace.
+        setup_test();
+
+        let mut rng = thread_rng();
+
+        let port = pick_unused_port().expect("No ports free");
+
+        let url = format!("http://localhost:{port}").parse().unwrap();
+        tracing::info!("Sequencer URL = {url}");
+        let client: Client<ServerError, StaticVersion<0, 1>> = Client::new(url);
+
+        let options = Options::with_port(port).submit(Default::default());
+        const NUM_NODES: usize = 2;
+        // Initialize storage for each node
+        let storage = join_all((0..NUM_NODES).map(|_| SqlDataSource::create_storage())).await;
+
+        let persistence_options: [_; NUM_NODES] = storage
+            .iter()
+            .map(<SqlDataSource as TestableSequencerDataSource>::persistence_options)
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        let network_config = TestConfigBuilder::default().build();
+
+        let config = TestNetworkConfigBuilder::<NUM_NODES, _, _>::with_num_nodes()
+            .api_config(SqlDataSource::options(&storage[0], options))
+            .network_config(network_config)
+            .persistences(persistence_options.clone())
+            .build();
+        let network = TestNetwork::new(config, MockSequencerVersions::new()).await;
+        let mut events = network.server.event_stream().await;
+        let mut all_transactions = HashMap::new();
+        let mut namespace_tx: HashMap<_, HashSet<_>> = HashMap::new();
+
+        // Submit transactions to namespaces 1 through 4
+
+        for namespace in 1..=4 {
+            for _count in 0..namespace {
+                let payload_len = rng.gen_range(4..=10);
+                let payload: Vec<u8> = (0..payload_len).map(|_| rng.gen()).collect();
+
+                let txn = Transaction::new(NamespaceId::from(namespace as u32), payload);
+
+                client.connect(None).await;
+
+                let hash = client
+                    .post("submit/submit")
+                    .body_json(&txn)
+                    .unwrap()
+                    .send()
+                    .await
+                    .unwrap();
+                assert_eq!(txn.commit(), hash);
+
+                // Wait for a Decide event containing transaction matching the one we sent
+                wait_for_decide_on_handle(&mut events, &txn).await;
+                // Store transaction for later validation
+
+                all_transactions.insert(txn.commit(), txn.clone());
+                namespace_tx.entry(namespace).or_default().insert(txn);
+            }
+        }
+
+        let mut transactions = client
+            .socket("availability/stream/transactions/0")
+            .subscribe::<TransactionQueryData<SeqTypes>>()
+            .await
+            .expect("failed to subscribe to transactions endpoint");
+
+        let mut count = 0;
+        while let Some(tx) = transactions.next().await {
+            let tx = tx.unwrap();
+            let expected = all_transactions
+                .get(&tx.transaction().commit())
+                .expect("txn not found ");
+            assert_eq!(tx.transaction(), expected, "invalid transaction");
+            count += 1;
+
+            if count == all_transactions.len() {
+                break;
+            }
+        }
+
+        // Validate namespace-specific stream endpoint
+
+        for (namespace, expected_ns_txns) in &namespace_tx {
+            let mut api_namespace_txns = client
+                .socket(&format!(
+                    "availability/stream/transactions/0/namespace/{}",
+                    namespace
+                ))
+                .subscribe::<TransactionQueryData<SeqTypes>>()
+                .await
+                .unwrap_or_else(|_| {
+                    panic!("failed to subscribe to transactions namespace {namespace}")
+                });
+
+            let mut received = HashSet::new();
+
+            while let Some(res) = api_namespace_txns.next().await {
+                let tx = res.expect("stream error");
+                received.insert(tx.transaction().clone());
+
+                if received.len() == expected_ns_txns.len() {
+                    break;
+                }
+            }
+
+            assert_eq!(
+                received, *expected_ns_txns,
+                "Mismatched transactions for namespace {namespace}"
+            );
+        }
     }
 }


### PR DESCRIPTION
This PR adds two endpoints to stream transactions: one streams all transactions, and the other streams transactions for a specific namespace. Internally, it uses the block stream to get transactions from each block and filters them by namespace if specified. It also includes a test that submits transactions for multiple namespaces and asserts that both endpoints return the expected results.