### PR TITLE
fix: staking-cli needlessly require token address

### DIFF
--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1029,14 +1029,10 @@ pub mod test_helpers {
             let stake_table_address = contracts
                 .address(Contract::StakeTableProxy)
                 .expect("StakeTableProxy address not found");
-            let token_addr = contracts
-                .address(Contract::EspTokenProxy)
-                .expect("EspTokenProxy address not found");
             setup_stake_table_contract_for_test(
                 l1_url.clone(),
                 &deployer,
                 stake_table_address,
-                token_addr,
                 network_config.staking_priv_keys(),
                 delegation_config,
             )

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -926,14 +926,10 @@ pub mod testing {
                     let st_addr = contracts
                         .address(Contract::StakeTableProxy)
                         .expect("StakeTableProxy address not found");
-                    let token_addr = contracts
-                        .address(Contract::EspTokenProxy)
-                        .expect("EspTokenProxy address not found");
                     setup_stake_table_contract_for_test(
                         self.l1_url.clone(),
                         &deployer,
                         st_addr,
-                        token_addr,
                         validators,
                         DelegationConfig::default(),
                     )

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -1502,9 +1502,6 @@ mod tests {
         let st_addr = contracts
             .address(Contract::StakeTableProxy)
             .expect("StakeTableProxy deployed");
-        let token_addr = contracts
-            .address(Contract::EspTokenProxy)
-            .expect("EspTokenProxy deployed");
         let l1_url = network_config.l1_url().clone();
 
         // new block every 1s
@@ -1524,7 +1521,6 @@ mod tests {
                         l1_url,
                         &deployer,
                         st_addr,
-                        token_addr,
                         validators,
                         DelegationConfig::MultipleDelegators,
                     )

--- a/sequencer/src/restart_tests.rs
+++ b/sequencer/src/restart_tests.rs
@@ -872,7 +872,6 @@ impl TestNetwork {
             l1_url.clone(),
             &deployer,
             stake_table_address,
-            token_addr,
             staking_priv_keys,
             delegation_config,
         )

--- a/staking-cli/README.md
+++ b/staking-cli/README.md
@@ -86,11 +86,6 @@ Options:
 
             [env: L1_PROVIDER=]
 
-        --token-address <TOKEN_ADDRESS>
-            Deployed ESP token contract address
-
-            [env: ESP_TOKEN_ADDRESS=]
-
         --stake-table-address <STAKE_TABLE_ADDRESS>
             Deployed stake table contract address
 

--- a/staking-cli/config.decaf.toml
+++ b/staking-cli/config.decaf.toml
@@ -1,5 +1,4 @@
 rpc_url = "https://ethereum-sepolia-rpc.publicnode.com"
-token_address = "0xb3e655a030e2e34a18b72757b40be086a8f43f3b"
 stake_table_address = "0x40304fbe94d5e7d1492dd90c53a2d63e8506a037"
 
 [signer]

--- a/staking-cli/config.demo.toml
+++ b/staking-cli/config.demo.toml
@@ -2,5 +2,4 @@
 mnemonic = "test test test test test test test test test test test junk"
 account_index = 0
 rpc_url = "http://127.0.0.1:8545"
-token_address = "0x0000000000000000000000000000000000000000"
 stake_table_address = "0x0000000000000000000000000000000000000000"

--- a/staking-cli/config.dev.toml
+++ b/staking-cli/config.dev.toml
@@ -2,5 +2,4 @@
 mnemonic = "test test test test test test test test test test test junk"
 account_index = 0
 rollup_rpc_url = "http://127.0.0.1:8545"
-token_address = "0x0000000000000000000000000000000000000000"
 stake_table_address = "0x0000000000000000000000000000000000000000"

--- a/staking-cli/src/deploy.rs
+++ b/staking-cli/src/deploy.rs
@@ -267,8 +267,6 @@ impl TestSystem {
     pub fn args(&self, cmd: &mut Command, signer: Signer) {
         cmd.arg("--rpc-url")
             .arg(self.rpc_url.to_string())
-            .arg("--token-address")
-            .arg(self.token.to_string())
             .arg("--stake-table-address")
             .arg(self.stake_table.to_string())
             .arg("--account-index")

--- a/staking-cli/src/info.rs
+++ b/staking-cli/src/info.rs
@@ -1,9 +1,13 @@
-use alloy::primitives::{utils::format_ether, Address};
-use anyhow::Result;
+use alloy::{
+    primitives::{utils::format_ether, Address},
+    providers::ProviderBuilder,
+};
+use anyhow::{Context as _, Result};
 use espresso_types::{
     v0_3::{Fetcher, Validator},
     L1Client,
 };
+use hotshot_contract_adapter::sol_types::StakeTableV2;
 use hotshot_types::signature_key::BLSPubKey;
 use url::Url;
 
@@ -60,4 +64,18 @@ pub fn display_stake_table(stake_table: Vec<Validator<BLSPubKey>>, compact: bool
         }
     }
     Ok(())
+}
+
+pub async fn fetch_token_address(rpc_url: Url, stake_table_address: Address) -> Result<Address> {
+    let provider = ProviderBuilder::new().on_http(rpc_url);
+    Ok(StakeTableV2::new(stake_table_address, provider)
+        .token()
+        .call()
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to fetch token address from stake table contract at {stake_table_address}"
+            )
+        })?
+        ._0)
 }

--- a/staking-cli/src/lib.rs
+++ b/staking-cli/src/lib.rs
@@ -37,10 +37,6 @@ pub struct Config {
     #[default(Url::parse("http://localhost:8545").unwrap())]
     pub rpc_url: Url,
 
-    /// Deployed ESP token contract address.
-    #[clap(long, env = "ESP_TOKEN_ADDRESS")]
-    pub token_address: Address,
-
     /// Deployed stake table contract address.
     #[clap(long, env = "STAKE_TABLE_ADDRESS")]
     pub stake_table_address: Address,
@@ -146,13 +142,6 @@ impl Default for Commands {
 impl Config {
     pub fn apply_env_var_overrides(self) -> Result<Self> {
         let mut config = self.clone();
-        if self.token_address == Address::ZERO {
-            let token_env_var = "ESPRESSO_SEQUENCER_ESP_TOKEN_PROXY_ADDRESS";
-            if let Ok(token_address) = std::env::var(token_env_var) {
-                config.token_address = token_address.parse()?;
-                tracing::info!("Using ESP token address from env {token_env_var}: {token_address}",);
-            }
-        }
         if self.stake_table_address == Address::ZERO {
             let stake_table_env_var = "ESPRESSO_SEQUENCER_STAKE_TABLE_PROXY_ADDRESS";
             if let Ok(stake_table_address) = std::env::var(stake_table_env_var) {


### PR DESCRIPTION
solution: fetch it from the stake table contract
