### PR TITLE
Fix unimplemented reset method in file system persistence

### DIFF
--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -128,7 +128,10 @@ impl PersistenceOptions for Options {
     }
 
     async fn reset(self) -> anyhow::Result<()> {
-        todo!()
+        let inner = self.inner.read().await;
+        fs::remove_dir_all(&inner.path)?;
+        fs::create_dir_all(&inner.path)?;
+        Ok(())
     }
 }
 
@@ -1504,8 +1507,9 @@ impl SequencerPersistence for Persistence {
         Ok(result)
     }
 
-    fn enable_metrics(&mut self, _metrics: &dyn Metrics) {
+    fn enable_metrics(&mut self, metrics: &dyn Metrics) {
         // todo!()
+        self.metrics.set_metrics(metrics);
     }
 }
 


### PR DESCRIPTION
Implemented the missing reset method in fs.rs that was causing panics, now properly removing and recreating the storage directory when called.