### PR TITLE
Fix broken link to docker-compose file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To generate the documentation locally and view it in the browser, run
 
 ## Building and running
 
-Docker images and the [docker-compose-demo.yaml](docker-compose-demo.yaml) file are provided for convenience. The
+Docker images and the [docker-compose.yaml](docker-compose.yaml) file are provided for convenience. The
 Docker-based demo fetches the images from the `ghcr` repository, where they are updated with every push to `main` on
 GitHub. For testing uncommitted changes, you can also run the binaries by manually building and running the services.
 


### PR DESCRIPTION


**Description:**  
Replaced the outdated link to `docker-compose-demo.yaml` with the correct `docker-compose.yaml` in the README for improved documentation accuracy and user experience.