### PR TITLE
fix: cargo test does not capture tracing logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "sequencer-utils",
  "surf-disco",
  "tempfile",
+ "test-log",
  "tide-disco",
  "tokio",
  "tracing",
@@ -4042,6 +4043,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4095,6 +4117,7 @@ dependencies = [
  "sequencer-utils",
  "serde_json",
  "surf-disco",
+ "test-log",
  "tide-disco",
  "tokio",
  "tracing",
@@ -4193,6 +4216,7 @@ dependencies = [
  "static_assertions",
  "surf-disco",
  "tagged-base64",
+ "test-log",
  "thiserror 1.0.69",
  "tide-disco",
  "time 0.3.41",
@@ -5523,6 +5547,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "tagged-base64",
+ "test-log",
  "tide-disco",
  "tokio",
  "tracing",
@@ -5760,6 +5785,7 @@ dependencies = [
  "surf-disco",
  "tagged-base64",
  "tempfile",
+ "test-log",
  "tide-disco",
  "time 0.3.41",
  "tokio",
@@ -5805,6 +5831,7 @@ dependencies = [
  "sequencer-utils",
  "serde",
  "surf-disco",
+ "test-log",
  "tide-disco",
  "time 0.3.41",
  "tokio",
@@ -5895,6 +5922,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "tagged-base64",
+ "test-log",
  "thiserror 1.0.69",
  "tide-disco",
  "tokio",
@@ -8234,6 +8262,7 @@ dependencies = [
  "serde",
  "serde_json",
  "surf-disco",
+ "test-log",
  "tide-disco",
  "time 0.3.41",
  "tokio",
@@ -10234,7 +10263,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10634,6 +10663,7 @@ dependencies = [
  "surf-disco",
  "tagged-base64",
  "tempfile",
+ "test-log",
  "tide-disco",
  "time 0.3.41",
  "tokio",
@@ -10674,6 +10704,7 @@ dependencies = [
  "serde",
  "serde_json",
  "surf",
+ "test-log",
  "tokio",
  "toml",
  "tracing",
@@ -11378,6 +11409,7 @@ dependencies = [
  "sysinfo",
  "tagged-base64",
  "tempfile",
+ "test-log",
  "thiserror 1.0.69",
  "tokio",
  "toml",
@@ -11839,6 +11871,28 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber 0.3.19",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,7 @@ serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "^1.0.113"
 staking-cli = { path = "./staking-cli" }
 tempfile = "3.10"
+test-log = { version = "0.2", features = ["color", "trace"], default-features = false }
 toml = "0.8"
 url = { version = "2.3", features = ["serde"] }
 vbs = "0.1"

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -44,6 +44,7 @@ vec1 = { workspace = true }
 jf-signature = { workspace = true, features = ["bls"] }
 sequencer = { path = "../sequencer", features = ["testing"] }
 tempfile = { workspace = true }
+test-log = { workspace = true }
 
 [lints]
 workspace = true

--- a/builder/src/non_permissioned.rs
+++ b/builder/src/non_permissioned.rs
@@ -256,7 +256,6 @@ mod test {
         persistence,
         testing::TestConfigBuilder,
     };
-    use sequencer_utils::test_utils::setup_test;
     use surf_disco::Client;
     use tempfile::TempDir;
 
@@ -266,10 +265,8 @@ mod test {
     /// Test the non-permissioned builder core
     /// It creates a memory hotshot network and launches the hotshot event streaming api
     /// Builder subscrived to this api, and server the hotshot client request and the private mempool tx submission
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_non_permissioned_builder() {
-        setup_test();
-
         let query_port = pick_unused_port().expect("No ports free");
 
         let event_port = pick_unused_port().expect("No ports free");

--- a/contracts/rust/deployer/Cargo.toml
+++ b/contracts/rust/deployer/Cargo.toml
@@ -24,6 +24,7 @@ vbs = { workspace = true }
  
 [dev-dependencies]
 sequencer-utils = { version = "0.1.0", path = "../../../utils" }
+test-log = { workspace = true }
 
 [lints]
 workspace = true

--- a/contracts/rust/deployer/src/lib.rs
+++ b/contracts/rust/deployer/src/lib.rs
@@ -1152,7 +1152,6 @@ mod tests {
         node_bindings::Anvil, primitives::utils::parse_ether, providers::ProviderBuilder,
         sol_types::SolValue,
     };
-    use sequencer_utils::test_utils::setup_test;
 
     use super::*;
     use crate::proposals::{
@@ -1167,9 +1166,8 @@ mod tests {
         },
     };
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_is_contract() -> Result<(), anyhow::Error> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
 
         // test with zero address returns false
@@ -1188,9 +1186,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_is_proxy_contract() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let deployer = provider.get_accounts().await?[0];
 
@@ -1203,9 +1200,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_deploy_light_client() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
 
@@ -1221,9 +1217,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_deploy_mock_light_client_proxy() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
 
@@ -1271,9 +1266,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_deploy_light_client_proxy() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
 
@@ -1324,9 +1318,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_deploy_fee_contract_proxy() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
         let admin = provider.get_accounts().await?[0];
@@ -1359,7 +1352,6 @@ mod tests {
     }
 
     async fn test_upgrade_light_client_to_v2_helper(is_mock: bool) -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
         let blocks_per_epoch = 10; // for test
@@ -1439,15 +1431,13 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_upgrade_light_client_to_v2() -> Result<()> {
-        setup_test();
         test_upgrade_light_client_to_v2_helper(false).await
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_upgrade_mock_light_client_v2() -> Result<()> {
-        setup_test();
         test_upgrade_light_client_to_v2_helper(true).await
     }
     #[derive(Debug, Clone, Copy)]
@@ -1613,7 +1603,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_upgrade_light_client_to_v2_multisig_owner_dry_run() -> Result<()> {
         test_upgrade_light_client_to_v2_multisig_owner_helper(UpgradeTestOptions {
             is_mock: false,
@@ -1624,7 +1614,7 @@ mod tests {
     }
 
     // We expect no init data for the second upgrade because the proxy was already initialized
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_upgrade_light_client_to_v2_twice_multisig_owner_dry_run() -> Result<()> {
         test_upgrade_light_client_to_v2_multisig_owner_helper(UpgradeTestOptions {
             is_mock: false,
@@ -1634,7 +1624,7 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[ignore]
     async fn test_upgrade_light_client_to_v2_multisig_owner_live_eth_network() -> Result<()> {
         test_upgrade_light_client_to_v2_multisig_owner_helper(UpgradeTestOptions {
@@ -1645,9 +1635,8 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_deploy_token_proxy() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
 
@@ -1685,9 +1674,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_deploy_stake_table_proxy() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
 
@@ -1735,9 +1723,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_upgrade_stake_table_v2() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
 
@@ -1889,14 +1876,13 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_upgrade_stake_table_to_v2_multisig_owner_dry_run() -> Result<()> {
         test_upgrade_stake_table_to_v2_multisig_owner_helper(true).await
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_deploy_ops_timelock() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
 
@@ -1949,9 +1935,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_deploy_safe_exit_timelock() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
 
@@ -2004,9 +1989,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_upgrade_esp_token_v2() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
 
@@ -2060,7 +2044,7 @@ mod tests {
     }
 
     // We expect no init data for the upgrade because there is no reinitializer for v2
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_upgrade_esp_token_v2_multisig_owner_dry_run() -> Result<()> {
         test_upgrade_esp_token_v2_multisig_owner_helper(UpgradeTestOptions {
             is_mock: false,
@@ -2189,9 +2173,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_schedule_and_execute_timelock_operation() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
         let delay = U256::from(0);
@@ -2472,7 +2455,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_encode_function_call() -> Result<()> {
         let function_signature = "transfer(address,uint256)".to_string();
         let values = vec![
@@ -2486,7 +2469,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_encode_function_call_upgrade_to_and_call() -> Result<()> {
         let function_signature = "upgradeToAndCall(address,bytes)".to_string();
         let values = vec![
@@ -2500,7 +2483,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_encode_function_call_with_bytes32() -> Result<()> {
         let function_signature = "setHash(bytes32)".to_string();
         let values =
@@ -2513,7 +2496,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_encode_function_call_with_bytes() -> Result<()> {
         let function_signature = "emitData(bytes)".to_string();
         let values = vec!["0xdeadbeef".to_string()];
@@ -2524,7 +2507,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_encode_function_call_with_bool() -> Result<()> {
         let function_signature = "setFlag(bool)".to_string();
         let mut values = vec!["true".to_string()];
@@ -2545,7 +2528,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_encode_function_call_with_string() -> Result<()> {
         let function_signature = "logMessage(string)".to_string();
         let values = vec!["Hello, world!".to_string()];
@@ -2556,7 +2539,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_transfer_ownership_light_client_proxy() -> Result<()> {
         test_transfer_ownership_helper(
             Contract::LightClientProxy,
@@ -2569,7 +2552,7 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_transfer_ownership_fee_contract_proxy() -> Result<()> {
         test_transfer_ownership_helper(
             Contract::FeeContractProxy,
@@ -2582,7 +2565,7 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     #[ignore]
     async fn test_transfer_ownership_fee_contract_proxy_real_proposal() -> Result<()> {
         println!("Starting test_transfer_ownership_fee_contract_proxy_real_proposal");
@@ -2599,7 +2582,7 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_transfer_ownership_esp_token_proxy() -> Result<()> {
         test_transfer_ownership_helper(
             Contract::EspTokenProxy,
@@ -2612,7 +2595,7 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_transfer_ownership_stake_table_proxy() -> Result<()> {
         test_transfer_ownership_helper(
             Contract::StakeTableProxy,

--- a/crates/hotshot/macros/src/lib.rs
+++ b/crates/hotshot/macros/src/lib.rs
@@ -201,11 +201,9 @@ impl TestData {
         quote! {
             #[cfg(test)]
             #slow_attribute
-            #[tokio::test(flavor = "multi_thread")]
+            #[test_log::test(tokio::test(flavor = "multi_thread"))]
             #[tracing::instrument]
             async fn #test_name() {
-                hotshot::helpers::initialize_logging();
-
                 hotshot_testing::test_builder::TestDescription::<#ty, #imply, #version>::gen_launcher((#metadata)).launch().run_test::<#builder_impl>().await;
             }
         }

--- a/crates/hotshot/testing/Cargo.toml
+++ b/crates/hotshot/testing/Cargo.toml
@@ -50,5 +50,8 @@ vbs = { workspace = true }
 vec1 = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
+[dev-dependencies]
+test-log = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/hotshot/testing/tests/tests_1/da_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/da_task.rs
@@ -28,9 +28,8 @@ use hotshot_types::{
 };
 use vbs::version::{StaticVersionType, Version};
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_da_task() {
-    hotshot::helpers::initialize_logging();
 
     let (handle, _, _, node_key_map) =
         build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await;
@@ -144,9 +143,8 @@ async fn test_da_task() {
     run_test![inputs, da_script].await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_da_task_storage_failure() {
-    hotshot::helpers::initialize_logging();
 
     let (handle, _, _, node_key_map) =
         build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await;

--- a/crates/hotshot/testing/tests/tests_1/libp2p.rs
+++ b/crates/hotshot/testing/tests/tests_1/libp2p.rs
@@ -18,10 +18,9 @@ use tracing::instrument;
 
 /// libp2p network test
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn libp2p_network() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
@@ -50,10 +49,9 @@ async fn libp2p_network() {
 
 /// libp2p network test with failures
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn libp2p_network_failures_2() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
@@ -96,11 +94,10 @@ async fn libp2p_network_failures_2() {
 
 /// stress test for libp2p
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 #[ignore]
 async fn test_stress_libp2p_network() {
-    hotshot::helpers::initialize_logging();
 
     let metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> =
         TestDescription::default_stress();

--- a/crates/hotshot/testing/tests/tests_1/message.rs
+++ b/crates/hotshot/testing/tests/tests_1/message.rs
@@ -61,7 +61,7 @@ fn version_number_at_start_of_serialization() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_certificate2_validity() {
     use futures::StreamExt;
     use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
@@ -71,8 +71,6 @@ async fn test_certificate2_validity() {
         stake_table::StakeTableEntries,
         vote::Certificate,
     };
-
-    hotshot::helpers::initialize_logging();
 
     let node_id = 1;
 

--- a/crates/hotshot/testing/tests/tests_1/network_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/network_task.rs
@@ -30,15 +30,13 @@ use tokio::time::timeout;
 // Test that the event task sends a message, and the message task receives it
 // and emits the proper event
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[allow(clippy::too_many_lines)]
 async fn test_network_task() {
     use std::collections::BTreeMap;
 
     use futures::StreamExt;
     use hotshot_types::epoch_membership::EpochMembershipCoordinator;
-
-    hotshot::helpers::initialize_logging();
 
     let builder: TestDescription<TestTypes, MemoryImpl, TestVersions> =
         TestDescription::default_multiple_rounds();
@@ -116,13 +114,11 @@ async fn test_network_task() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_network_external_mnessages() {
     use hotshot::types::EventType;
     use hotshot_testing::helpers::build_system_handle_from_launcher;
     use hotshot_types::message::RecipientList;
-
-    hotshot::helpers::initialize_logging();
 
     let builder: TestDescription<TestTypes, MemoryImpl, TestVersions> =
         TestDescription::default_multiple_rounds();
@@ -208,14 +204,12 @@ async fn test_network_external_mnessages() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_network_storage_fail() {
     use std::collections::BTreeMap;
 
     use futures::StreamExt;
     use hotshot_types::epoch_membership::EpochMembershipCoordinator;
-
-    hotshot::helpers::initialize_logging();
 
     let builder: TestDescription<TestTypes, MemoryImpl, TestVersions> =
         TestDescription::default_multiple_rounds();

--- a/crates/hotshot/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -40,7 +40,7 @@ use hotshot_types::{
 };
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_recv_task() {
     use std::time::Duration;
 
@@ -48,8 +48,6 @@ async fn test_quorum_proposal_recv_task() {
         helpers::build_fake_view_with_leaf,
         script::{Expectations, TaskScript},
     };
-
-    hotshot::helpers::initialize_logging();
 
     let (handle, _, _, node_key_map) =
         build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await;
@@ -110,7 +108,7 @@ async fn test_quorum_proposal_recv_task() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_recv_task_liveness_check() {
     use std::time::Duration;
 
@@ -122,8 +120,6 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
         script::{Expectations, TaskScript},
     };
     use hotshot_types::{data::Leaf2, vote::HasViewNumber};
-
-    hotshot::helpers::initialize_logging();
 
     let (handle, _, _, node_key_map) =
         build_system_handle::<TestTypes, MemoryImpl, TestVersions>(4).await;

--- a/crates/hotshot/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/quorum_proposal_task.rs
@@ -37,12 +37,10 @@ use hotshot_testing::predicates::event::view_change;
 const TIMEOUT: Duration = Duration::from_millis(35);
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     use hotshot_testing::script::{Expectations, TaskScript};
     use vbs::version::StaticVersionType;
-
-    hotshot::helpers::initialize_logging();
 
     let node_id = 1;
     let (handle, _, _, node_key_map) =
@@ -142,11 +140,9 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
     use vbs::version::StaticVersionType;
-
-    hotshot::helpers::initialize_logging();
 
     let node_id = 3;
     let (handle, _, _, node_key_map) =
@@ -322,11 +318,9 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_task_qc_timeout() {
     use vbs::version::StaticVersionType;
-
-    hotshot::helpers::initialize_logging();
 
     let node_id = 3;
 
@@ -420,13 +414,11 @@ async fn test_quorum_proposal_task_qc_timeout() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_task_view_sync() {
     use hotshot_example_types::block_types::TestMetadata;
     use hotshot_types::data::null_block;
     use vbs::version::StaticVersionType;
-
-    hotshot::helpers::initialize_logging();
 
     let node_id = 2;
     let (handle, _, _, node_key_map) =
@@ -522,11 +514,9 @@ async fn test_quorum_proposal_task_view_sync() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_task_liveness_check() {
     use vbs::version::StaticVersionType;
-
-    hotshot::helpers::initialize_logging();
 
     let node_id = 3;
     let (handle, _, _, node_key_map) =
@@ -701,9 +691,8 @@ async fn test_quorum_proposal_task_liveness_check() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_task_with_incomplete_events() {
-    hotshot::helpers::initialize_logging();
 
     let (handle, _, _, node_key_map) =
         build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await;

--- a/crates/hotshot/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/quorum_vote_task.rs
@@ -30,7 +30,7 @@ use hotshot_types::{
 const TIMEOUT: Duration = Duration::from_millis(35);
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_vote_task_success() {
     use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState};
     use hotshot_testing::{
@@ -38,8 +38,6 @@ async fn test_quorum_vote_task_success() {
         predicates::event::{exact, quorum_vote_send},
         view_generator::TestViewGenerator,
     };
-
-    hotshot::helpers::initialize_logging();
 
     let (handle, _, _, node_key_map) =
         build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await;
@@ -98,14 +96,12 @@ async fn test_quorum_vote_task_success() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_vote_task_miss_dependency() {
     use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState};
     use hotshot_testing::{
         helpers::build_system_handle, predicates::event::exact, view_generator::TestViewGenerator,
     };
-
-    hotshot::helpers::initialize_logging();
 
     let (handle, _, _, node_key_map) =
         build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await;
@@ -181,14 +177,12 @@ async fn test_quorum_vote_task_miss_dependency() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_vote_task_incorrect_dependency() {
     use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::QuorumVoteTaskState};
     use hotshot_testing::{
         helpers::build_system_handle, predicates::event::exact, view_generator::TestViewGenerator,
     };
-
-    hotshot::helpers::initialize_logging();
 
     let (handle, _, _, node_key_map) =
         build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await;

--- a/crates/hotshot/testing/tests/tests_1/transaction_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/transaction_task.rs
@@ -14,9 +14,8 @@ use hotshot_types::{
 use vbs::version::StaticVersionType;
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_transaction_task_leader_two_views_in_a_row() {
-    hotshot::helpers::initialize_logging();
 
     // Build the API for node 2.
     let node_id = 2;

--- a/crates/hotshot/testing/tests/tests_1/upgrade_task_with_proposal.rs
+++ b/crates/hotshot/testing/tests/tests_1/upgrade_task_with_proposal.rs
@@ -46,14 +46,12 @@ use vec1::vec1;
 
 const TIMEOUT: Duration = Duration::from_millis(35);
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 /// Test that we correctly form and include an `UpgradeCertificate` when receiving votes.
 async fn test_upgrade_task_with_proposal() {
     use std::sync::Arc;
 
     use hotshot_testing::helpers::build_system_handle;
-
-    hotshot::helpers::initialize_logging();
 
     let (handle, _, _, node_key_map) =
         build_system_handle::<TestTypes, MemoryImpl, TestVersions>(3).await;

--- a/crates/hotshot/testing/tests/tests_1/upgrade_task_with_vote.rs
+++ b/crates/hotshot/testing/tests/tests_1/upgrade_task_with_vote.rs
@@ -37,13 +37,11 @@ use hotshot_types::{
 use vbs::version::Version;
 const TIMEOUT: Duration = Duration::from_millis(65);
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 /// Tests that we correctly update our internal quorum vote state when reaching a decided upgrade
 /// certificate.
 async fn test_upgrade_task_with_vote() {
     use hotshot_testing::helpers::build_system_handle;
-
-    hotshot::helpers::initialize_logging();
 
     let (handle, _, _, node_key_map) =
         build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2).await;

--- a/crates/hotshot/testing/tests/tests_1/vid_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/vid_task.rs
@@ -32,11 +32,9 @@ use hotshot_types::{
 use vbs::version::StaticVersionType;
 use vec1::vec1;
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_vid_task() {
     use hotshot_types::message::Proposal;
-
-    hotshot::helpers::initialize_logging();
 
     // Build the API for node 2.
     let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(2)

--- a/crates/hotshot/testing/tests/tests_1/view_sync_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/view_sync_task.rs
@@ -16,9 +16,8 @@ use hotshot_types::{
 };
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_view_sync_task() {
-    hotshot::helpers::initialize_logging();
 
     // Build the API for node 5.
     let handle = build_system_handle::<TestTypes, MemoryImpl, TestVersions>(5)

--- a/crates/hotshot/testing/tests/tests_1/vote_dependency_handle.rs
+++ b/crates/hotshot/testing/tests/tests_1/vote_dependency_handle.rs
@@ -24,11 +24,9 @@ use tokio::time::timeout;
 const TIMEOUT: Duration = Duration::from_millis(35);
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_vote_dependency_handle() {
     use std::sync::Arc;
-
-    hotshot::helpers::initialize_logging();
 
     // We use a node ID of 2 here arbitrarily. We just need it to build the system handle.
     let node_id = 2;

--- a/crates/hotshot/testing/tests/tests_2/catchup.rs
+++ b/crates/hotshot/testing/tests/tests_2/catchup.rs
@@ -19,7 +19,7 @@ use hotshot_testing::{
 };
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_catchup() {
     use std::time::Duration;
 
@@ -31,8 +31,6 @@ async fn test_catchup() {
         spinning_task::{ChangeNode, NodeAction, SpinningTaskDescription},
         test_builder::{TestDescription, TimingData},
     };
-
-    hotshot::helpers::initialize_logging();
 
     let timing_data = TimingData {
         next_view_timeout: 2000,
@@ -77,7 +75,7 @@ async fn test_catchup() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_catchup_cdn() {
     use std::time::Duration;
 
@@ -89,8 +87,6 @@ async fn test_catchup_cdn() {
         spinning_task::{ChangeNode, NodeAction, SpinningTaskDescription},
         test_builder::{TestDescription, TimingData},
     };
-
-    hotshot::helpers::initialize_logging();
 
     let timing_data = TimingData {
         next_view_timeout: 2000,
@@ -129,7 +125,7 @@ async fn test_catchup_cdn() {
 
 /// Test that one node catches up and has successful views after coming back
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_catchup_one_node() {
     use std::time::Duration;
 
@@ -141,7 +137,6 @@ async fn test_catchup_one_node() {
         spinning_task::{ChangeNode, NodeAction, SpinningTaskDescription},
         test_builder::{TestDescription, TimingData},
     };
-    hotshot::helpers::initialize_logging();
 
     let timing_data = TimingData {
         next_view_timeout: 2000,
@@ -182,7 +177,7 @@ async fn test_catchup_one_node() {
 
 /// Same as `test_catchup` except we start the nodes after their leadership so they join during view sync
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_catchup_in_view_sync() {
     use std::time::Duration;
 
@@ -194,7 +189,6 @@ async fn test_catchup_in_view_sync() {
         spinning_task::{ChangeNode, NodeAction, SpinningTaskDescription},
         test_builder::{TestDescription, TimingData},
     };
-    hotshot::helpers::initialize_logging();
 
     let timing_data = TimingData {
         next_view_timeout: 2000,
@@ -242,7 +236,7 @@ async fn test_catchup_in_view_sync() {
 // Almost the same as `test_catchup`, but with catchup nodes reloaded from anchor leaf rather than
 // initialized from genesis.
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_catchup_reload() {
     use std::time::Duration;
 
@@ -254,8 +248,6 @@ async fn test_catchup_reload() {
         spinning_task::{ChangeNode, NodeAction, SpinningTaskDescription},
         test_builder::{TestDescription, TimingData},
     };
-
-    hotshot::helpers::initialize_logging();
 
     let timing_data = TimingData {
         next_view_timeout: 2000,

--- a/crates/hotshot/testing/tests/tests_3/memory_network.rs
+++ b/crates/hotshot/testing/tests/tests_3/memory_network.rs
@@ -120,10 +120,9 @@ fn gen_messages(num_messages: u64, seed: u64, pk: BLSPubKey) -> Vec<Message<Test
 
 // Spawning a single MemoryNetwork should produce no errors
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn memory_network_spawn_single() {
-    hotshot::helpers::initialize_logging();
     let group: Arc<MasterMap<<Test as NodeType>::SignatureKey>> = MasterMap::new();
     trace!(?group);
     let _pub_key = pubkey();
@@ -131,10 +130,9 @@ async fn memory_network_spawn_single() {
 
 // // Spawning a two MemoryNetworks and connecting them should produce no errors
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn memory_network_spawn_double() {
-    hotshot::helpers::initialize_logging();
     let group: Arc<MasterMap<<Test as NodeType>::SignatureKey>> = MasterMap::new();
     trace!(?group);
     let _pub_key_1 = pubkey();
@@ -143,10 +141,9 @@ async fn memory_network_spawn_double() {
 
 // Check to make sure direct queue works
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn memory_network_direct_queue() {
-    hotshot::helpers::initialize_logging();
     // Create some dummy messages
 
     // Make and connect the networking instances
@@ -265,11 +262,10 @@ async fn memory_network_broadcast_queue() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 #[allow(deprecated)]
 async fn memory_network_test_in_flight_message_count() {
-    hotshot::helpers::initialize_logging();
 
     let group: Arc<MasterMap<<Test as NodeType>::SignatureKey>> = MasterMap::new();
     trace!(?group);

--- a/crates/hotshot/testing/tests/tests_5/broken_3_chain.rs
+++ b/crates/hotshot/testing/tests/tests_5/broken_3_chain.rs
@@ -13,10 +13,9 @@ use tracing::instrument;
 
 /// Broken 3-chain test
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn broken_3_chain() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, PushCdnImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {

--- a/crates/hotshot/testing/tests/tests_5/combined_network.rs
+++ b/crates/hotshot/testing/tests/tests_5/combined_network.rs
@@ -19,12 +19,10 @@ use tracing::instrument;
 
 /// A run with both the CDN and libp2p functioning properly
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn test_combined_network() {
     use hotshot_testing::block_builder::SimpleBuilderImplementation;
-
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription {
         timing_data: TimingData {
@@ -54,10 +52,9 @@ async fn test_combined_network() {
 
 // A run where the CDN crashes part-way through
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn test_combined_network_cdn_crash() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription {
         timing_data: TimingData {
@@ -100,10 +97,9 @@ async fn test_combined_network_cdn_crash() {
 // A run where the CDN crashes partway through
 // and then comes back up
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn test_combined_network_reup() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription {
         timing_data: TimingData {
@@ -151,10 +147,9 @@ async fn test_combined_network_reup() {
 
 // A run where half of the nodes disconnect from the CDN
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn test_combined_network_half_dc() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription {
         timing_data: TimingData {
@@ -224,11 +219,10 @@ fn generate_random_node_changes(
 
 // A fuzz test, where random network events take place on all nodes
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 #[ignore]
 async fn test_stress_combined_network_fuzzy() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, CombinedImpl, TestVersions> = TestDescription {
         timing_data: TimingData {

--- a/crates/hotshot/testing/tests/tests_5/push_cdn.rs
+++ b/crates/hotshot/testing/tests/tests_5/push_cdn.rs
@@ -17,10 +17,9 @@ use tracing::instrument;
 
 /// Push CDN network test
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn push_cdn_network() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, PushCdnImpl, TestVersions> = TestDescription {
         timing_data: TimingData {

--- a/crates/hotshot/testing/tests/tests_5/timeout.rs
+++ b/crates/hotshot/testing/tests/tests_5/timeout.rs
@@ -5,7 +5,7 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_timeout() {
     use std::time::Duration;
 
@@ -17,7 +17,6 @@ async fn test_timeout() {
         spinning_task::{ChangeNode, NodeAction, SpinningTaskDescription},
         test_builder::{TestDescription, TimingData},
     };
-    hotshot::helpers::initialize_logging();
 
     let timing_data = TimingData {
         next_view_timeout: 2000,
@@ -61,7 +60,7 @@ async fn test_timeout() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[ignore]
 async fn test_timeout_libp2p() {
     use std::time::Duration;
@@ -74,8 +73,6 @@ async fn test_timeout_libp2p() {
         spinning_task::{ChangeNode, NodeAction, SpinningTaskDescription},
         test_builder::{TestDescription, TimingData},
     };
-
-    hotshot::helpers::initialize_logging();
 
     let timing_data = TimingData {
         next_view_timeout: 2000,

--- a/crates/hotshot/testing/tests/tests_5/unreliable_network.rs
+++ b/crates/hotshot/testing/tests/tests_5/unreliable_network.rs
@@ -18,10 +18,9 @@ use hotshot_types::traits::network::{
 };
 use tracing::instrument;
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn libp2p_network_sync() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
@@ -50,7 +49,7 @@ async fn libp2p_network_sync() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_network_sync() {
     use std::time::Duration;
 
@@ -59,8 +58,6 @@ async fn test_memory_network_sync() {
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
         test_builder::TestDescription,
     };
-
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription {
         // allow more time to pass in CI
@@ -85,11 +82,10 @@ async fn test_memory_network_sync() {
         .await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[ignore]
 #[instrument]
 async fn libp2p_network_async() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
@@ -126,7 +122,7 @@ async fn libp2p_network_async() {
 
 #[cfg(test)]
 #[ignore]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_network_async() {
     use std::time::Duration;
 
@@ -135,8 +131,6 @@ async fn test_memory_network_async() {
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
         test_builder::TestDescription,
     };
-
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
@@ -173,7 +167,7 @@ async fn test_memory_network_async() {
 }
 
 #[cfg(test)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_network_partially_sync() {
     use std::time::Duration;
 
@@ -182,8 +176,6 @@ async fn test_memory_network_partially_sync() {
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
         test_builder::TestDescription,
     };
-
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
@@ -225,10 +217,9 @@ async fn test_memory_network_partially_sync() {
         .await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn libp2p_network_partially_sync() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
@@ -267,7 +258,7 @@ async fn libp2p_network_partially_sync() {
 
 #[cfg(test)]
 #[ignore]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_network_chaos() {
     use std::time::Duration;
 
@@ -276,8 +267,6 @@ async fn test_memory_network_chaos() {
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
         test_builder::TestDescription,
     };
-
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, MemoryImpl, TestVersions> = TestDescription {
         // allow more time to pass in CI
@@ -306,11 +295,10 @@ async fn test_memory_network_chaos() {
         .await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[ignore]
 #[instrument]
 async fn libp2p_network_chaos() {
-    hotshot::helpers::initialize_logging();
 
     let mut metadata: TestDescription<TestTypes, Libp2pImpl, TestVersions> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {

--- a/hotshot-builder-core-refactored/Cargo.toml
+++ b/hotshot-builder-core-refactored/Cargo.toml
@@ -39,6 +39,7 @@ hotshot-task-impls = { workspace = true }
 hotshot-testing = { workspace = true }
 num_cpus = { workspace = true }
 portpicker = { workspace = true }
+test-log = { workspace = true }
 tracing-test = { workspace = true }
 url = { workspace = true }
 

--- a/hotshot-query-service/Cargo.toml
+++ b/hotshot-query-service/Cargo.toml
@@ -139,6 +139,7 @@ portpicker = "0.1"
 rand = "0.8"
 reqwest = "0.12.3"
 tempfile = "3.10"
+test-log = { workspace = true }
 
 [lints]
 workspace = true

--- a/hotshot-query-service/src/availability.rs
+++ b/hotshot-query-service/src/availability.rs
@@ -833,7 +833,6 @@ mod test {
         testing::{
             consensus::{MockDataSource, MockNetwork, MockSqlDataSource},
             mocks::{mock_transaction, MockBase, MockHeader, MockPayload, MockTypes, MockVersions},
-            setup_test,
         },
         types::HeightIndexed,
         ApiState, Error, Header,
@@ -1118,10 +1117,8 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_api() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
         network.start().await;
@@ -1438,10 +1435,8 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_api_epochs() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, EpochsTestVersions>::init().await;
         let epoch_height = network.epoch_height();
@@ -1504,10 +1499,8 @@ mod test {
         network.shut_down().await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_old_api() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
         network.start().await;
@@ -1601,11 +1594,9 @@ mod test {
         network.shut_down().await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_extensions() {
         use hotshot_example_types::node_types::TestVersions;
-
-        setup_test();
 
         let dir = TempDir::with_prefix("test_availability_extensions").unwrap();
         let data_source = ExtensibleDataSource::new(
@@ -1705,10 +1696,8 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_range_limit() {
-        setup_test();
-
         let large_object_range_limit = 2;
         let small_object_range_limit = 3;
 
@@ -1800,10 +1789,8 @@ mod test {
         network.shut_down().await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_header_endpoint() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockSqlDataSource, MockVersions>::init().await;
         network.start().await;
@@ -1842,10 +1829,8 @@ mod test {
         network.shut_down().await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_leaf_only_ds() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockSqlDataSource, MockVersions>::init_with_leaf_ds().await;
         network.start().await;

--- a/hotshot-query-service/src/data_source.rs
+++ b/hotshot-query-service/src/data_source.rs
@@ -139,7 +139,6 @@ pub mod availability_tests {
         testing::{
             consensus::{MockNetwork, TestableDataSource},
             mocks::{mock_transaction, MockTypes, MockVersions},
-            setup_test,
         },
         types::HeightIndexed,
     };
@@ -290,13 +289,11 @@ pub mod availability_tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_update<D: TestableDataSource>()
     where
         for<'a> D::ReadOnly<'a>: NodeStorage<MockTypes>,
     {
-        setup_test();
-
         let mut network = MockNetwork::<D, MockVersions>::init().await;
         let ds = network.data_source();
 
@@ -365,13 +362,11 @@ pub mod availability_tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_range<D: TestableDataSource>()
     where
         for<'a> D::ReadOnly<'a>: NodeStorage<MockTypes>,
     {
-        setup_test();
-
         let mut network = MockNetwork::<D, MockVersions>::init().await;
         let ds = network.data_source();
         network.start().await;
@@ -463,13 +458,11 @@ pub mod availability_tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_range_rev<D: TestableDataSource>()
     where
         for<'a> D::ReadOnly<'a>: NodeStorage<MockTypes>,
     {
-        setup_test();
-
         let mut network = MockNetwork::<D, MockVersions>::init().await;
         let ds = network.data_source();
         network.start().await;
@@ -565,13 +558,12 @@ pub mod persistence_tests {
         testing::{
             consensus::TestableDataSource,
             mocks::{MockPayload, MockTypes},
-            setup_test,
         },
         types::HeightIndexed,
         Leaf2,
     };
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_revert<D: TestableDataSource>()
     where
         for<'a> D::Transaction<'a>: UpdateAvailabilityStorage<MockTypes>
@@ -579,8 +571,6 @@ pub mod persistence_tests {
             + NodeStorage<MockTypes>,
     {
         use hotshot_example_types::node_types::TestVersions;
-
-        setup_test();
 
         let storage = D::create(0).await;
         let ds = D::connect(&storage).await;
@@ -625,14 +615,12 @@ pub mod persistence_tests {
         ds.get_block(1).await.try_resolve().unwrap_err();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_reset<D: TestableDataSource>()
     where
         for<'a> D::Transaction<'a>: UpdateAvailabilityStorage<MockTypes>,
     {
         use hotshot_example_types::node_types::TestVersions;
-
-        setup_test();
 
         let storage = D::create(0).await;
         let ds = D::connect(&storage).await;
@@ -685,7 +673,7 @@ pub mod persistence_tests {
         ds.get_block(1).await.try_resolve().unwrap_err();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_drop_tx<D: TestableDataSource>()
     where
         for<'a> D::Transaction<'a>: UpdateAvailabilityStorage<MockTypes>
@@ -694,8 +682,6 @@ pub mod persistence_tests {
         for<'a> D::ReadOnly<'a>: NodeStorage<MockTypes>,
     {
         use hotshot_example_types::node_types::TestVersions;
-
-        setup_test();
 
         let storage = D::create(0).await;
         let ds = D::connect(&storage).await;
@@ -802,7 +788,7 @@ pub mod node_tests {
         testing::{
             consensus::{MockNetwork, TestableDataSource},
             mocks::{mock_transaction, MockPayload, MockTypes, MockVersions},
-            setup_test, sleep,
+            sleep,
         },
         types::HeightIndexed,
         Header, VidCommon,
@@ -812,14 +798,12 @@ pub mod node_tests {
         <TestBlockHeader as BlockHeader<MockTypes>>::timestamp(header)
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_sync_status<D: TestableDataSource>()
     where
         for<'a> D::Transaction<'a>: UpdateAvailabilityStorage<MockTypes>,
     {
         use hotshot_example_types::node_types::TestVersions;
-
-        setup_test();
 
         let storage = D::create(0).await;
         let ds = D::connect(&storage).await;
@@ -966,11 +950,9 @@ pub mod node_tests {
         assert_eq!(ds.sync_status().await.unwrap(), expected_sync_status);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_counters<D: TestableDataSource>() {
         use hotshot_example_types::node_types::TestVersions;
-
-        setup_test();
 
         let storage = D::create(0).await;
         let ds = D::connect(&storage).await;
@@ -1059,13 +1041,11 @@ pub mod node_tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_vid_shares<D: TestableDataSource>()
     where
         for<'a> D::ReadOnly<'a>: NodeStorage<MockTypes>,
     {
-        setup_test();
-
         let mut network = MockNetwork::<D, MockVersions>::init().await;
         let ds = network.data_source();
 
@@ -1087,15 +1067,13 @@ pub mod node_tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_vid_monotonicity<D: TestableDataSource>()
     where
         for<'a> D::Transaction<'a>: UpdateAvailabilityStorage<MockTypes>,
         for<'a> D::ReadOnly<'a>: NodeStorage<MockTypes>,
     {
         use hotshot_example_types::node_types::TestVersions;
-
-        setup_test();
 
         let storage = D::create(0).await;
         let ds = D::connect(&storage).await;
@@ -1145,13 +1123,11 @@ pub mod node_tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_vid_recovery<D: TestableDataSource>()
     where
         for<'a> D::ReadOnly<'a>: NodeStorage<MockTypes>,
     {
-        setup_test();
-
         let mut network = MockNetwork::<D, MockVersions>::init().await;
         let ds = network.data_source();
 
@@ -1227,10 +1203,8 @@ pub mod node_tests {
         assert_eq!(recovered.transactions, vec![txn]);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_timestamp_window<D: TestableDataSource>() {
-        setup_test();
-
         let mut network = MockNetwork::<D, MockVersions>::init().await;
         let ds = network.data_source();
 
@@ -1427,14 +1401,12 @@ pub mod status_tests {
         testing::{
             consensus::{DataSourceLifeCycle, MockNetwork},
             mocks::{mock_transaction, MockVersions},
-            setup_test, sleep,
+            sleep,
         },
     };
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_metrics<D: DataSourceLifeCycle + StatusDataSource>() {
-        setup_test();
-
         let mut network = MockNetwork::<D, MockVersions>::init().await;
         let ds = network.data_source();
 

--- a/hotshot-query-service/src/data_source/notifier.rs
+++ b/hotshot-query-service/src/data_source/notifier.rs
@@ -296,11 +296,9 @@ mod test {
     use tokio::time::timeout;
 
     use super::*;
-    use crate::testing::setup_test;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_notify_drop() {
-        setup_test();
         let n = Notifier::new();
 
         // Create two subscribers with different predicates.
@@ -324,9 +322,8 @@ mod test {
         assert!(active[0].is_closed());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_notify_active() {
-        setup_test();
         let n = Notifier::new();
 
         // Create two subscribers.
@@ -359,9 +356,8 @@ mod test {
         assert_eq!(s1.await.unwrap(), 1);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_pending_dropped() {
-        setup_test();
         let n = Notifier::new();
 
         // Create and immediately drop a pending subscriber.
@@ -372,10 +368,8 @@ mod test {
         assert_eq!(n.active.lock().await.len(), 0);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_notifier_dropped() {
-        setup_test();
-
         let n = Notifier::new();
 
         // Create an active subscriber.

--- a/hotshot-query-service/src/data_source/sql.rs
+++ b/hotshot-query-service/src/data_source/sql.rs
@@ -397,18 +397,16 @@ mod test {
             Transaction, VersionedDataSource,
         },
         fetching::provider::NoFetching,
-        testing::{consensus::DataSourceLifeCycle, mocks::MockTypes, setup_test},
+        testing::{consensus::DataSourceLifeCycle, mocks::MockTypes},
     };
 
     type D = SqlDataSource<MockTypes, NoFetching>;
 
     // This function should be generic, but the file system data source does not currently support
     // storing VID common and later the corresponding share.
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_vid_monotonicity() {
         use hotshot_example_types::node_types::TestVersions;
-
-        setup_test();
 
         let storage = D::create(0).await;
         let ds = <D as DataSourceLifeCycle>::connect(&storage).await;

--- a/hotshot-query-service/src/data_source/storage/ledger_log.rs
+++ b/hotshot-query-service/src/data_source/storage/ledger_log.rs
@@ -266,12 +266,9 @@ mod test {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::testing::setup_test;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_ledger_log_creation() {
-        setup_test();
-
         let dir = TempDir::with_prefix("test_ledger_log").unwrap();
 
         // Create and populuate a log.
@@ -298,10 +295,8 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_ledger_log_insert() {
-        setup_test();
-
         let dir = TempDir::with_prefix("test_ledger_log").unwrap();
         let mut loader = AtomicStoreLoader::create(dir.path(), "test_ledger_log").unwrap();
         let mut log = LedgerLog::<u64>::create(&mut loader, "ledger", 3).unwrap();
@@ -342,10 +337,8 @@ mod test {
         // See https://github.com/EspressoSystems/hotshot-query-service/issues/16
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_ledger_log_iter() {
-        setup_test();
-
         let dir = TempDir::with_prefix("test_ledger_log").unwrap();
         let mut loader = AtomicStoreLoader::create(dir.path(), "test_ledger_log").unwrap();
         let mut log = LedgerLog::<u64>::create(&mut loader, "ledger", 3).unwrap();

--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -1390,16 +1390,11 @@ mod test {
         availability::LeafQueryData,
         data_source::storage::{pruning::PrunedHeightStorage, UpdateAvailabilityStorage},
         merklized_state::{MerklizedState, UpdateStateData},
-        testing::{
-            mocks::{MockHeader, MockMerkleTree, MockPayload, MockTypes, MockVersions},
-            setup_test,
-        },
+        testing::mocks::{MockHeader, MockMerkleTree, MockPayload, MockTypes, MockVersions},
     };
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_migrations() {
-        setup_test();
-
         let db = TmpDb::init().await;
         let cfg = db.config();
 
@@ -1482,10 +1477,8 @@ mod test {
             .unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_target_period_pruning() {
-        setup_test();
-
         let db = TmpDb::init().await;
         let cfg = db.config();
 
@@ -1573,10 +1566,8 @@ mod test {
         )
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_merklized_state_pruning() {
-        setup_test();
-
         let db = TmpDb::init().await;
         let config = db.config();
 
@@ -1665,10 +1656,8 @@ mod test {
         assert!(count == 0);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_minimum_retention_pruning() {
-        setup_test();
-
         let db = TmpDb::init().await;
 
         let mut storage = SqlStorage::connect(db.config()).await.unwrap();
@@ -1742,10 +1731,8 @@ mod test {
         assert_eq!(header_rows, 0);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_pruned_height_storage() {
-        setup_test();
-
         let db = TmpDb::init().await;
         let cfg = db.config();
 
@@ -1775,10 +1762,8 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_types_migration() {
-        setup_test();
-
         let num_rows = 500;
         let db = TmpDb::init().await;
 

--- a/hotshot-query-service/src/data_source/storage/sql/queries/state.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/state.rs
@@ -505,17 +505,13 @@ mod test {
             VersionedDataSource,
         },
         merklized_state::UpdateStateData,
-        testing::{
-            mocks::{MockMerkleTree, MockTypes},
-            setup_test,
-        },
+        testing::mocks::{MockMerkleTree, MockTypes},
     };
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_merklized_state_storage() {
         // In this test we insert some entries into the tree and update the database
         // Each entry's merkle path is compared with the path from the tree
-        setup_test();
 
         let db = TmpDb::init().await;
         let storage = SqlStorage::connect(db.config()).await.unwrap();
@@ -674,14 +670,13 @@ mod test {
         assert_eq!(path_with_bh_1, proof_bh_1);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_merklized_state_non_membership_proof() {
         // This test updates the Merkle tree with a new entry and inserts the corresponding Merkle nodes into the database with created = 1.
         // A Merkle node is then deleted from the tree.
         // The database is then updated to reflect the deletion of the entry with a created (block height) of 2
         // As the leaf node becomes a non-member, we do a universal lookup to obtain its non-membership proof path.
         // It is expected that the path retrieved from the tree matches the path obtained from the database.
-        setup_test();
 
         let db = TmpDb::init().await;
         let storage = SqlStorage::connect(db.config()).await.unwrap();
@@ -812,10 +807,8 @@ mod test {
         assert_eq!(proof_bh_1, proof_before_remove, "merkle paths dont match");
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_merklized_state_non_membership_proof_unseen_entry() {
-        setup_test();
-
         let db = TmpDb::init().await;
         let storage = SqlStorage::connect(db.config()).await.unwrap();
 
@@ -880,10 +873,9 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_merklized_storage_with_commit() {
         // This test insert a merkle path into the database and queries the path using the merkle commitment
-        setup_test();
 
         let db = TmpDb::init().await;
         let storage = SqlStorage::connect(db.config()).await.unwrap();
@@ -944,7 +936,7 @@ mod test {
 
         assert_eq!(merkle_proof, proof.clone(), "merkle paths mismatch");
     }
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_merklized_state_missing_state() {
         // This test checks that header commitment matches the root hash.
         // For this, the header merkle root commitment field is not updated, which should result in an error
@@ -952,7 +944,6 @@ mod test {
         // An index and its corresponding merkle nodes with created (bh) = 1 are inserted.
         // The entry of the index is updated, and the updated nodes are inserted with created (bh) = 2.
         // A node which is in the traversal path with bh = 2 is deleted, so the get_path should return an error as an older version of one of the nodes is used.
-        setup_test();
 
         let db = TmpDb::init().await;
         let storage = SqlStorage::connect(db.config()).await.unwrap();
@@ -1120,10 +1111,8 @@ mod test {
         assert!(merkle_path.is_err());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_merklized_state_snapshot() {
-        setup_test();
-
         let db = TmpDb::init().await;
         let storage = SqlStorage::connect(db.config()).await.unwrap();
 
@@ -1295,14 +1284,13 @@ mod test {
         validate(&storage, &test_tree, &expected, 1).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_merklized_state_missing_leaf() {
         // Check that if a leaf is missing but its ancestors are present/key is in the tree, we
         // catch it rather than interpreting the entry as an empty node by default. Note that this
         // scenario should be impossible in normal usage, since we never store or delete partial
         // paths. But we should never return an invalid proof even in extreme cases like database
         // corruption.
-        setup_test();
 
         for tree_size in 1..=3 {
             let db = TmpDb::init().await;

--- a/hotshot-query-service/src/explorer.rs
+++ b/hotshot-query-service/src/explorer.rs
@@ -408,7 +408,6 @@ mod test {
         testing::{
             consensus::{MockNetwork, MockSqlDataSource},
             mocks::{mock_transaction, MockBase, MockTypes, MockVersions},
-            setup_test,
         },
         ApiState, Error,
     };
@@ -849,7 +848,7 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_api() {
         test_api_helper().await;
     }
@@ -863,8 +862,6 @@ mod test {
     }
 
     async fn test_api_helper() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockSqlDataSource, MockVersions>::init().await;
         network.start().await;

--- a/hotshot-query-service/src/fetching/provider/any.rs
+++ b/hotshot-query-service/src/fetching/provider/any.rs
@@ -216,7 +216,6 @@ mod test {
         testing::{
             consensus::{MockDataSource, MockNetwork},
             mocks::{MockBase, MockTypes, MockVersions},
-            setup_test,
         },
         types::HeightIndexed,
         ApiState, Error,
@@ -224,10 +223,8 @@ mod test {
 
     type Provider = AnyProvider<MockTypes>;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_first_provider_fails() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -542,7 +542,7 @@ mod test {
         testing::{
             consensus::{MockDataSource, MockNetwork},
             mocks::{mock_transaction, MockBase, MockTypes, MockVersions},
-            setup_test, sleep,
+            sleep,
         },
         types::HeightIndexed,
         ApiState,
@@ -575,10 +575,8 @@ mod test {
         builder(db, provider).await.build().await.unwrap()
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_on_request() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -809,8 +807,6 @@ mod test {
         // specifically focused on epoch version transitions
         tracing::info!("Starting test_fetch_on_request_epoch_version");
 
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, EpochsTestVersions>::init().await;
 
@@ -1038,10 +1034,8 @@ mod test {
         tracing::info!("Test completed successfully!");
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_block_and_leaf_concurrently() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -1101,10 +1095,8 @@ mod test {
         assert_eq!(leaf.header(), block.header());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_different_blocks_same_payload() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -1168,10 +1160,8 @@ mod test {
         assert_eq!(block2.header(), leaves[1].header());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_stream() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -1232,10 +1222,8 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_range_start() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -1293,10 +1281,8 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn fetch_transaction() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -1374,10 +1360,8 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_retry() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -1496,10 +1480,8 @@ mod test {
             .ok();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_from_malicious_server() {
-        setup_test();
-
         let port = pick_unused_port().unwrap();
         let _server = BackgroundTask::spawn("malicious server", malicious_server(port));
 
@@ -1524,10 +1506,8 @@ mod test {
         assert_eq!(res, None);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_archive_recovery() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -1699,8 +1679,6 @@ mod test {
     }
 
     async fn test_fetch_storage_failure_helper(failure: FailureType) {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -1787,24 +1765,22 @@ mod test {
         assert_eq!(leaves[0], fetch.try_resolve().ok().unwrap());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_storage_failure_on_begin() {
         test_fetch_storage_failure_helper(FailureType::Begin).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_storage_failure_on_write() {
         test_fetch_storage_failure_helper(FailureType::Write).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_storage_failure_on_commit() {
         test_fetch_storage_failure_helper(FailureType::Commit).await;
     }
 
     async fn test_fetch_storage_failure_retry_helper(failure: FailureType) {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -1883,25 +1859,23 @@ mod test {
         assert_eq!(leaves[0], tx.get_leaf(1.into()).await.unwrap());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_storage_failure_retry_on_begin() {
         test_fetch_storage_failure_retry_helper(FailureType::Begin).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_storage_failure_retry_on_write() {
         test_fetch_storage_failure_retry_helper(FailureType::Write).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_storage_failure_retry_on_commit() {
         test_fetch_storage_failure_retry_helper(FailureType::Commit).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_on_decide() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -1967,10 +1941,8 @@ mod test {
         assert_eq!(vid.block_hash(), leaf.block_hash());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_begin_failure() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -2030,10 +2002,8 @@ mod test {
         assert_eq!(leaves[0], data_source.get_leaf(1).await.await);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_load_failure_block() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -2111,10 +2081,8 @@ mod test {
         assert_eq!(block.hash(), leaf.block_hash());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_load_failure_tx() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -2214,10 +2182,8 @@ mod test {
         assert_eq!(tx, fetch.await);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_stream_begin_failure() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -2286,10 +2252,8 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_stream_load_failure() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -2365,8 +2329,6 @@ mod test {
     }
 
     async fn test_metadata_stream_begin_failure_helper(stream: MetadataType) {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -2465,12 +2427,12 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_metadata_stream_begin_failure_payload() {
         test_metadata_stream_begin_failure_helper(MetadataType::Payload).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_metadata_stream_begin_failure_vid() {
         test_metadata_stream_begin_failure_helper(MetadataType::Vid).await
     }
@@ -2586,10 +2548,8 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fallback_deserialization_for_fetch_requests_v0() {
-        setup_test();
-
         let port = pick_unused_port().unwrap();
 
         // This run will call v0 availalbilty api for fetch requests.
@@ -2600,9 +2560,8 @@ mod test {
         run_fallback_deserialization_test_helper::<MockVersions>(port, "v0").await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fallback_deserialization_for_fetch_requests_v1() {
-        setup_test();
         let port = pick_unused_port().unwrap();
 
         // Fetch from the v1 availability API using MockVersions.
@@ -2611,19 +2570,16 @@ mod test {
         run_fallback_deserialization_test_helper::<MockVersions>(port, "v1").await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fallback_deserialization_for_fetch_requests_pos() {
-        setup_test();
         let port = pick_unused_port().unwrap();
 
         // Fetch Proof of Stake (PoS) data using the v1 availability API
         // with proof of stake version
         run_fallback_deserialization_test_helper::<EpochsTestVersions>(port, "v1").await;
     }
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fallback_deserialization_for_fetch_requests_v0_pos() {
-        setup_test();
-
         // Run with the PoS version against a v0 provider.
         // Fetch requests are expected to fail because PoS commitments differ from the legacy commitments
         // returned by the v0 provider.

--- a/hotshot-query-service/src/metrics.rs
+++ b/hotshot-query-service/src/metrics.rs
@@ -450,12 +450,9 @@ mod test {
     use tide_disco::metrics::Metrics as _;
 
     use super::*;
-    use crate::testing::setup_test;
 
-    #[test]
+    #[test_log::test]
     fn test_prometheus_metrics() {
-        setup_test();
-
         let metrics = PrometheusMetrics::default();
 
         // Register one metric of each type.
@@ -505,10 +502,8 @@ mod test {
         assert!(lines.contains(&"text 1"));
     }
 
-    #[test]
+    #[test_log::test]
     fn test_namespace() {
-        setup_test();
-
         let metrics = PrometheusMetrics::default();
         let subgroup1 = metrics.subgroup("subgroup1".into());
         let subgroup2 = subgroup1.subgroup("subgroup2".into());
@@ -575,10 +570,8 @@ mod test {
             .contains(&"subgroup1_subgroup2_text 1"));
     }
 
-    #[test]
+    #[test_log::test]
     fn test_labels() {
-        setup_test();
-
         let metrics = PrometheusMetrics::default();
 
         let http_count = metrics.counter_family("http".into(), vec!["method".into()]);

--- a/hotshot-query-service/src/node.rs
+++ b/hotshot-query-service/src/node.rs
@@ -244,15 +244,12 @@ mod test {
         testing::{
             consensus::{MockDataSource, MockNetwork, MockSqlDataSource},
             mocks::{mock_transaction, MockBase, MockTypes, MockVersions},
-            setup_test,
         },
         ApiState, Error, Header,
     };
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_api() {
-        setup_test();
-
         let window_limit = 78;
 
         // Create the consensus network.
@@ -431,10 +428,8 @@ mod test {
         network.shut_down().await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_aggregate_ranges() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockSqlDataSource, MockVersions>::init().await;
         let mut events = network.handle().event_stream();
@@ -595,10 +590,8 @@ mod test {
         network.shut_down().await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_extensions() {
-        setup_test();
-
         let dir = TempDir::with_prefix("test_node_extensions").unwrap();
         let data_source = ExtensibleDataSource::new(
             MockDataSource::create(dir.path(), Default::default())

--- a/hotshot-query-service/src/status.rs
+++ b/hotshot-query-service/src/status.rs
@@ -126,15 +126,13 @@ mod test {
         testing::{
             consensus::{MockDataSource, MockNetwork},
             mocks::{MockBase, MockVersions},
-            setup_test, sleep,
+            sleep,
         },
         ApiState, Error,
     };
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_api() {
-        setup_test();
-
         // Create the consensus network.
         let mut network = MockNetwork::<MockDataSource, MockVersions>::init().await;
 
@@ -207,10 +205,8 @@ mod test {
         network.shut_down().await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_extensions() {
-        setup_test();
-
         let dir = TempDir::with_prefix("test_status_extensions").unwrap();
         let data_source = ExtensibleDataSource::new(
             MockDataSource::create(dir.path(), Default::default())

--- a/hotshot-query-service/src/testing.rs
+++ b/hotshot-query-service/src/testing.rs
@@ -13,23 +13,9 @@
 // see <https://www.gnu.org/licenses/>.
 use std::time::Duration;
 
-use tracing_subscriber::EnvFilter;
-
 pub mod consensus;
 pub mod mocks;
 
 pub async fn sleep(dur: Duration) {
     tokio::time::sleep(dur).await;
-}
-
-pub fn setup_test() {
-    // Initialize logging
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .try_init();
-
-    #[cfg(all(feature = "backtrace-on-stack-overflow", not(windows)))]
-    unsafe {
-        backtrace_on_stack_overflow::enable();
-    }
 }

--- a/hotshot-state-prover/Cargo.toml
+++ b/hotshot-state-prover/Cargo.toml
@@ -45,6 +45,7 @@ vbs = { workspace = true }
 
 [dev-dependencies]
 sequencer-utils = { path = "../utils", features = ["testing"] }
+test-log = { workspace = true }
 
 [features]
 default = ["parallel"]

--- a/hotshot-state-prover/src/v1/service.rs
+++ b/hotshot-state-prover/src/v1/service.rs
@@ -425,7 +425,6 @@ mod test {
     use espresso_contract_deployer::{deploy_light_client_proxy, Contracts};
     use hotshot_contract_adapter::sol_types::LightClientMock;
     use jf_utils::test_rng;
-    use sequencer_utils::test_utils::setup_test;
 
     use super::*;
     use crate::v1::mock_ledger::{MockLedger, MockSystemParam, STAKE_TABLE_CAPACITY_FOR_TEST};
@@ -461,10 +460,8 @@ mod test {
         Ok(lc_proxy_addr)
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_read_contract_state() -> Result<()> {
-        setup_test();
-
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
         let rng = &mut test_rng();
@@ -505,10 +502,8 @@ mod test {
     }
 
     // This test is temporarily ignored. We are unifying the contract deployment in #1071.
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_submit_state_and_proof() -> Result<()> {
-        setup_test();
-
         let pp = MockSystemParam::init();
         let mut ledger = MockLedger::init(pp, NUM_INIT_VALIDATORS);
         let genesis_state: LightClientStateSol = ledger.light_client_state().into();

--- a/hotshot-state-prover/src/v2/service.rs
+++ b/hotshot-state-prover/src/v2/service.rs
@@ -595,7 +595,6 @@ mod test {
     };
     use hotshot_contract_adapter::sol_types::LightClientV2Mock;
     use jf_utils::test_rng;
-    use sequencer_utils::test_utils::setup_test;
 
     use super::*;
     use crate::v2::mock_ledger::{
@@ -644,10 +643,8 @@ mod test {
         Ok(lc_proxy_addr)
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_read_contract_state() -> Result<()> {
-        setup_test();
-
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
         let rng = &mut test_rng();
@@ -694,10 +691,8 @@ mod test {
     }
 
     // This test is temporarily ignored. We are unifying the contract deployment in #1071.
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_submit_state_and_proof() -> Result<()> {
-        setup_test();
-
         let pp = MockSystemParam::init();
         let mut ledger = MockLedger::init(pp, NUM_INIT_VALIDATORS);
         let genesis_state: LightClientStateSol = ledger.light_client_state().into();

--- a/hotshot-state-prover/src/v3/service.rs
+++ b/hotshot-state-prover/src/v3/service.rs
@@ -566,7 +566,6 @@ mod test {
     };
     use hotshot_contract_adapter::sol_types::LightClientV2Mock;
     use jf_utils::test_rng;
-    use sequencer_utils::test_utils::setup_test;
 
     use super::*;
     use crate::v3::mock_ledger::{EPOCH_HEIGHT_FOR_TEST, EPOCH_START_BLOCK_FOR_TEST};
@@ -612,10 +611,8 @@ mod test {
         Ok(lc_proxy_addr)
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_read_contract_state() -> Result<()> {
-        setup_test();
-
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let mut contracts = Contracts::new();
         let rng = &mut test_rng();
@@ -661,11 +658,9 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_submit_state_and_proof() -> Result<()> {
         // TODO(Chengyu): disabled because it's under development
-
-        // setup_test();
 
         // let pp = MockSystemParam::init();
         // let mut ledger = MockLedger::init(pp, NUM_INIT_VALIDATORS);

--- a/node-metrics/Cargo.toml
+++ b/node-metrics/Cargo.toml
@@ -10,6 +10,7 @@ testing = ["espresso-types/testing", "hotshot-query-service/testing"]
 
 [dev-dependencies]
 node-metrics = { path = ".", features = [ "testing" ] }
+test-log = { workspace = true }
 
 [dependencies]
 alloy = { workspace = true }

--- a/node-metrics/src/api/node_validator/v0/create_node_validator_api.rs
+++ b/node-metrics/src/api/node_validator/v0/create_node_validator_api.rs
@@ -256,12 +256,9 @@ mod test {
 
     use crate::run_standalone_service;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     #[ignore]
     async fn test_full_setup_example() {
-        use hotshot::helpers::initialize_logging;
-        initialize_logging();
-
         let base_url: Url = "https://query.main.net.espresso.network/v0/"
             .parse()
             .unwrap();

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -33,6 +33,7 @@ hotshot-testing = { workspace = true }
 pretty_assertions = { workspace = true }
 rand = "0.8.5"
 reqwest = { workspace = true }
+test-log = { workspace = true }
 
 # Enable "testing" feature when running tests
 sequencer = { path = ".", features = ["testing"] }
@@ -67,9 +68,9 @@ csv = "1"
 derivative = "2.2"
 derive_more = { workspace = true }
 dotenvy = { workspace = true }
+either = { workspace = true }
 espresso-contract-deployer = { path = "../contracts/rust/deployer" }
 espresso-types = { path = "../types" }
-either = { workspace = true }
 futures = { workspace = true }
 generic-tests = "0.1.3"
 

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1590,9 +1590,8 @@ pub mod test_helpers {
 }
 
 #[cfg(test)]
-#[espresso_macros::generic_tests]
 mod api_tests {
-    use std::fmt::Debug;
+    use std::{fmt::Debug, marker::PhantomData};
 
     use committable::Committable;
     use data_source::testing::TestableSequencerDataSource;
@@ -1633,26 +1632,42 @@ mod api_tests {
         testing::{wait_for_decide_on_handle, TestConfigBuilder},
     };
 
+    #[rstest_reuse::template]
+    #[rstest::rstest]
+    #[case(PhantomData::<crate::api::sql::DataSource>)]
+    #[case(PhantomData::<crate::api::fs::DataSource>)]
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    pub(crate) async fn submit_test_with_query_module<D: TestableSequencerDataSource>() {
+    pub fn testable_sequencer_data_source<D: TestableSequencerDataSource>(
+        #[case] _d: PhantomData<D>,
+    ) {
+    }
+
+    #[rstest_reuse::apply(testable_sequencer_data_source)]
+    pub(crate) async fn submit_test_with_query_module<D: TestableSequencerDataSource>(
+        _d: PhantomData<D>,
+    ) {
         let storage = D::create_storage().await;
         submit_test_helper(|opt| D::options(&storage, opt)).await
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    pub(crate) async fn status_test_with_query_module<D: TestableSequencerDataSource>() {
+    #[rstest_reuse::apply(testable_sequencer_data_source)]
+    pub(crate) async fn status_test_with_query_module<D: TestableSequencerDataSource>(
+        _d: PhantomData<D>,
+    ) {
         let storage = D::create_storage().await;
         status_test_helper(|opt| D::options(&storage, opt)).await
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    pub(crate) async fn state_signature_test_with_query_module<D: TestableSequencerDataSource>() {
+    #[rstest_reuse::apply(testable_sequencer_data_source)]
+    pub(crate) async fn state_signature_test_with_query_module<D: TestableSequencerDataSource>(
+        _d: PhantomData<D>,
+    ) {
         let storage = D::create_storage().await;
         state_signature_test_helper(|opt| D::options(&storage, opt)).await
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    pub(crate) async fn test_namespace_query<D: TestableSequencerDataSource>() {
+    #[rstest_reuse::apply(testable_sequencer_data_source)]
+    pub(crate) async fn test_namespace_query<D: TestableSequencerDataSource>(_d: PhantomData<D>) {
         // Arbitrary transaction, arbitrary namespace ID
         let ns_id = NamespaceId::from(42_u32);
         let txn = Transaction::new(ns_id, vec![1, 2, 3, 4]);
@@ -1744,14 +1759,16 @@ mod api_tests {
         assert!(found_empty_block);
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    pub(crate) async fn catchup_test_with_query_module<D: TestableSequencerDataSource>() {
+    #[rstest_reuse::apply(testable_sequencer_data_source)]
+    pub(crate) async fn catchup_test_with_query_module<D: TestableSequencerDataSource>(
+        _d: PhantomData<D>,
+    ) {
         let storage = D::create_storage().await;
         catchup_test_helper(|opt| D::options(&storage, opt)).await
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    pub async fn test_non_consecutive_decide_with_failing_event_consumer<D>()
+    #[rstest_reuse::apply(testable_sequencer_data_source)]
+    pub async fn test_non_consecutive_decide_with_failing_event_consumer<D>(_d: PhantomData<D>)
     where
         D: TestableSequencerDataSource + Debug + 'static,
     {
@@ -1967,8 +1984,8 @@ mod api_tests {
             .unwrap();
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    pub async fn test_decide_missing_data<D>()
+    #[rstest_reuse::apply(testable_sequencer_data_source)]
+    pub async fn test_decide_missing_data<D>(_d: PhantomData<D>)
     where
         D: TestableSequencerDataSource + Debug + 'static,
     {
@@ -2053,8 +2070,8 @@ mod api_tests {
     }
 
     #[ignore]
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    pub(crate) async fn test_state_cert_query<D: TestableSequencerDataSource>() {
+    #[rstest_reuse::apply(testable_sequencer_data_source)]
+    pub(crate) async fn test_state_cert_query<D: TestableSequencerDataSource>(_d: PhantomData<D>) {
         const TEST_EPOCH_HEIGHT: u64 = 10;
         const TEST_EPOCHS: u64 = 3;
 

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1633,25 +1633,25 @@ mod api_tests {
         testing::{wait_for_decide_on_handle, TestConfigBuilder},
     };
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub(crate) async fn submit_test_with_query_module<D: TestableSequencerDataSource>() {
         let storage = D::create_storage().await;
         submit_test_helper(|opt| D::options(&storage, opt)).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub(crate) async fn status_test_with_query_module<D: TestableSequencerDataSource>() {
         let storage = D::create_storage().await;
         status_test_helper(|opt| D::options(&storage, opt)).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub(crate) async fn state_signature_test_with_query_module<D: TestableSequencerDataSource>() {
         let storage = D::create_storage().await;
         state_signature_test_helper(|opt| D::options(&storage, opt)).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub(crate) async fn test_namespace_query<D: TestableSequencerDataSource>() {
         // Arbitrary transaction, arbitrary namespace ID
         let ns_id = NamespaceId::from(42_u32);
@@ -1744,13 +1744,13 @@ mod api_tests {
         assert!(found_empty_block);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub(crate) async fn catchup_test_with_query_module<D: TestableSequencerDataSource>() {
         let storage = D::create_storage().await;
         catchup_test_helper(|opt| D::options(&storage, opt)).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_non_consecutive_decide_with_failing_event_consumer<D>()
     where
         D: TestableSequencerDataSource + Debug + 'static,
@@ -1967,7 +1967,7 @@ mod api_tests {
             .unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_decide_missing_data<D>()
     where
         D: TestableSequencerDataSource + Debug + 'static,
@@ -2053,7 +2053,7 @@ mod api_tests {
     }
 
     #[ignore]
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub(crate) async fn test_state_cert_query<D: TestableSequencerDataSource>() {
         const TEST_EPOCH_HEIGHT: u64 = 10;
         const TEST_EPOCHS: u64 = 3;
@@ -2198,7 +2198,7 @@ mod test {
     type PosVersionV3 = SequencerVersions<StaticVersion<0, 3>, StaticVersion<0, 0>>;
     type PosVersionV4 = SequencerVersions<StaticVersion<0, 4>, StaticVersion<0, 0>>;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_healthcheck() {
         let port = pick_unused_port().expect("No ports free");
         let url = format!("http://localhost:{port}").parse().unwrap();
@@ -2216,27 +2216,27 @@ mod test {
         assert_eq!(health.status, HealthStatus::Available);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn status_test_without_query_module() {
         status_test_helper(|opt| opt).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn submit_test_without_query_module() {
         submit_test_helper(|opt| opt).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn state_signature_test_without_query_module() {
         state_signature_test_helper(|opt| opt).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn catchup_test_without_query_module() {
         catchup_test_helper(|opt| opt).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn slow_test_merklized_state_api() {
         let port = pick_unused_port().expect("No ports free");
 
@@ -2312,7 +2312,7 @@ mod test {
         assert_eq!(expected, amount.0);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_leaf_only_data_source() {
         let port = pick_unused_port().expect("No ports free");
 
@@ -2499,22 +2499,22 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_catchup() {
         run_catchup_test("").await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_catchup_v0() {
         run_catchup_test("/v0").await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_catchup_v1() {
         run_catchup_test("/v1").await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_catchup_no_state_peers() {
         // Start a sequencer network, using the query service for catchup.
         let port = pick_unused_port().expect("No ports free");
@@ -2600,7 +2600,7 @@ mod test {
     }
 
     #[ignore]
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_catchup_epochs_no_state_peers() {
         // Start a sequencer network, using the query service for catchup.
         let port = pick_unused_port().expect("No ports free");
@@ -2692,7 +2692,7 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_chain_config_from_instance() {
         // This test uses a ValidatedState which only has the default chain config commitment.
         // The NodeState has the full chain config.
@@ -2744,7 +2744,7 @@ mod test {
         drop(network);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_chain_config_catchup() {
         // This test uses a ValidatedState with a non-default chain config
         // so it will be different from the NodeState chain config used by the TestNetwork.
@@ -2815,7 +2815,7 @@ mod test {
         drop(network);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_pos_upgrade_view_based() {
         type PosUpgrade = SequencerVersions<FeeVersion, EpochVersion>;
         test_upgrade_helper::<PosUpgrade>(PosUpgrade::new()).await;
@@ -2910,7 +2910,7 @@ mod test {
         network.server.shut_down().await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub(crate) async fn test_restart() {
         const NUM_NODES: usize = 5;
         // Initialize nodes.
@@ -3037,7 +3037,7 @@ mod test {
         assert_eq!(chain, new_chain);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetch_config() {
         let port = pick_unused_port().expect("No ports free");
         let url: surf_disco::Url = format!("http://localhost:{port}").parse().unwrap();
@@ -3124,24 +3124,24 @@ mod test {
         assert_eq!(receive_count, total_count + 1);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_hotshot_event_streaming_v0() {
         run_hotshot_event_streaming_test("/v0").await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_hotshot_event_streaming_v1() {
         run_hotshot_event_streaming_test("/v1").await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_hotshot_event_streaming() {
         run_hotshot_event_streaming_test("").await;
     }
 
     // TODO when `EpochVersion` becomes base version we can merge this
     // w/ above test.
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_hotshot_event_streaming_epoch_progression() {
         let epoch_height = 35;
         let wanted_epochs = 4;
@@ -3224,7 +3224,7 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_pos_rewards_basic() -> anyhow::Result<()> {
         // Basic PoS rewards test:
         // - Sets up a single validator and a single delegator (the node itself).
@@ -3322,7 +3322,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_cumulative_pos_rewards() -> anyhow::Result<()> {
         // This test registers 5 validators and multiple delegators for each validator.
         // One of the delegators is also a validator.
@@ -3445,7 +3445,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_stake_table_duplicate_events_from_contract() -> anyhow::Result<()> {
         // TODO(abdul): This test currently uses TestNetwork only for contract deployment and for L1 block number.
         // Once the stake table deployment logic is refactored and isolated, TestNetwork here will be unnecessary
@@ -3553,7 +3553,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_rewards_v3() -> anyhow::Result<()> {
         // The test registers multiple delegators for each validator
         // It verifies that no rewards are distributed in the first two epochs
@@ -3774,7 +3774,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_rewards_v4() -> anyhow::Result<()> {
         // This test verifies PoS reward distribution logic for multiple delegators per validator.
         //
@@ -4046,7 +4046,7 @@ mod test {
     #[rstest]
     #[case(PosVersionV3::new())]
     #[case(PosVersionV4::new())]
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
 
     async fn test_node_stake_table_api<Ver: Versions>(#[case] ver: Ver) {
         let epoch_height = 20;
@@ -4120,7 +4120,7 @@ mod test {
     #[rstest]
     #[case(PosVersionV3::new())]
     #[case(PosVersionV4::new())]
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
 
     async fn test_epoch_stake_table_catchup<Ver: Versions>(#[case] ver: Ver) {
         const EPOCH_HEIGHT: u64 = 10;
@@ -4252,7 +4252,7 @@ mod test {
     #[rstest]
     #[case(PosVersionV3::new())]
     #[case(PosVersionV4::new())]
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
 
     async fn test_epoch_stake_table_catchup_stress<Ver: Versions>(#[case] versions: Ver) {
         const EPOCH_HEIGHT: u64 = 10;
@@ -4397,7 +4397,7 @@ mod test {
     #[rstest]
     #[case(PosVersionV3::new())]
     #[case(PosVersionV4::new())]
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_merklized_state_catchup_on_restart<Ver: Versions>(
         #[case] versions: Ver,
     ) -> anyhow::Result<()> {
@@ -4619,7 +4619,7 @@ mod test {
     #[rstest]
     #[case(PosVersionV3::new())]
     #[case(PosVersionV4::new())]
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_state_reconstruction<Ver: Versions>(
         #[case] pos_version: Ver,
     ) -> anyhow::Result<()> {
@@ -4956,7 +4956,7 @@ mod test {
     #[rstest]
     #[case(PosVersionV3::new())]
     #[case(PosVersionV4::new())]
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_block_reward_api<Ver: Versions>(#[case] versions: Ver) -> anyhow::Result<()> {
         let epoch_height = 10;
 
@@ -5022,7 +5022,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_scanning_token_contract_initialized_event() -> anyhow::Result<()> {
         use espresso_types::v0_3::ChainConfig;
 
@@ -5143,7 +5143,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_tx_metadata() {
         let port = pick_unused_port().expect("No ports free");
 
@@ -5223,7 +5223,7 @@ mod test {
 
     use rand::thread_rng;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_aggregator_namespace_endpoints() {
         let mut rng = thread_rng();
 
@@ -5397,7 +5397,7 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_stream_transactions_endpoint() {
         // This test submits transactions to a sequencer for multiple namespaces,
         // waits for them to be decided, and then verifies that:
@@ -5519,7 +5519,7 @@ mod test {
     #[rstest]
     #[case(PosVersionV3::new())]
     #[case(PosVersionV4::new())]
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_v3_and_v4_reward_tree_updates<Ver: Versions>(
         #[case] versions: Ver,
     ) -> anyhow::Result<()> {

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -942,7 +942,6 @@ pub mod test_helpers {
     use itertools::izip;
     use jf_merkle_tree::{MerkleCommitment, MerkleTreeScheme};
     use portpicker::pick_unused_port;
-    use sequencer_utils::test_utils::setup_test;
     use staking_cli::demo::{setup_stake_table_contract_for_test, DelegationConfig};
     use surf_disco::Client;
     use tempfile::TempDir;
@@ -1324,8 +1323,6 @@ pub mod test_helpers {
     /// to test a different initialization path) but should not remove or modify the existing
     /// functionality (e.g. removing the status module or changing the port).
     pub async fn status_test_helper(opt: impl FnOnce(Options) -> Options) {
-        setup_test();
-
         let port = pick_unused_port().expect("No ports free");
         let url = format!("http://localhost:{port}").parse().unwrap();
         let client: Client<ServerError, StaticVersion<0, 1>> = Client::new(url);
@@ -1371,8 +1368,6 @@ pub mod test_helpers {
     /// to test a different initialization path) but should not remove or modify the existing
     /// functionality (e.g. removing the submit module or changing the port).
     pub async fn submit_test_helper(opt: impl FnOnce(Options) -> Options) {
-        setup_test();
-
         let txn = Transaction::new(NamespaceId::from(1_u32), vec![1, 2, 3, 4]);
 
         let port = pick_unused_port().expect("No ports free");
@@ -1406,8 +1401,6 @@ pub mod test_helpers {
 
     /// Test the state signature API.
     pub async fn state_signature_test_helper(opt: impl FnOnce(Options) -> Options) {
-        setup_test();
-
         let port = pick_unused_port().expect("No ports free");
 
         let url = format!("http://localhost:{port}").parse().unwrap();
@@ -1448,8 +1441,6 @@ pub mod test_helpers {
     /// to test a different initialization path) but should not remove or modify the existing
     /// functionality (e.g. removing the catchup module or changing the port).
     pub async fn catchup_test_helper(opt: impl FnOnce(Options) -> Options) {
-        setup_test();
-
         let port = pick_unused_port().expect("No ports free");
         let url = format!("http://localhost:{port}").parse().unwrap();
         let client: Client<ServerError, StaticVersion<0, 1>> = Client::new(url);
@@ -1627,7 +1618,6 @@ mod api_tests {
         vid::avidm::{init_avidm_param, AvidMScheme},
     };
     use portpicker::pick_unused_port;
-    use sequencer_utils::test_utils::setup_test;
     use surf_disco::Client;
     use test_helpers::{
         catchup_test_helper, state_signature_test_helper, status_test_helper, submit_test_helper,
@@ -1663,8 +1653,6 @@ mod api_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     pub(crate) async fn test_namespace_query<D: TestableSequencerDataSource>() {
-        setup_test();
-
         // Arbitrary transaction, arbitrary namespace ID
         let ns_id = NamespaceId::from(42_u32);
         let txn = Transaction::new(ns_id, vec![1, 2, 3, 4]);
@@ -1777,7 +1765,6 @@ mod api_tests {
             }
         }
 
-        setup_test();
         let (pubkey, privkey) = PubKey::generated_from_seed_indexed([0; 32], 1);
 
         let storage = D::create_storage().await;
@@ -1985,8 +1972,6 @@ mod api_tests {
     where
         D: TestableSequencerDataSource + Debug + 'static,
     {
-        setup_test();
-
         let storage = D::create_storage().await;
         let persistence = D::persistence_options(&storage).create().await.unwrap();
         let data_source: Arc<StorageState<network::Memory, NoStorage, _, MockSequencerVersions>> =
@@ -2070,8 +2055,6 @@ mod api_tests {
     #[ignore]
     #[tokio::test(flavor = "multi_thread")]
     pub(crate) async fn test_state_cert_query<D: TestableSequencerDataSource>() {
-        setup_test();
-
         const TEST_EPOCH_HEIGHT: u64 = 10;
         const TEST_EPOCHS: u64 = 3;
 
@@ -2186,7 +2169,6 @@ mod test {
     use portpicker::pick_unused_port;
     use rand::seq::SliceRandom;
     use rstest::rstest;
-    use sequencer_utils::test_utils::setup_test;
     use staking_cli::demo::DelegationConfig;
     use surf_disco::Client;
     use test_helpers::{
@@ -2218,8 +2200,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_healthcheck() {
-        setup_test();
-
         let port = pick_unused_port().expect("No ports free");
         let url = format!("http://localhost:{port}").parse().unwrap();
         let client: Client<ServerError, StaticVersion<0, 1>> = Client::new(url);
@@ -2258,8 +2238,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn slow_test_merklized_state_api() {
-        setup_test();
-
         let port = pick_unused_port().expect("No ports free");
 
         let storage = SqlDataSource::create_storage().await;
@@ -2336,8 +2314,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_leaf_only_data_source() {
-        setup_test();
-
         let port = pick_unused_port().expect("No ports free");
 
         let storage = SqlDataSource::create_storage().await;
@@ -2424,8 +2400,6 @@ mod test {
     }
 
     async fn run_catchup_test(url_suffix: &str) {
-        setup_test();
-
         // Start a sequencer network, using the query service for catchup.
         let port = pick_unused_port().expect("No ports free");
         const NUM_NODES: usize = 5;
@@ -2542,8 +2516,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_catchup_no_state_peers() {
-        setup_test();
-
         // Start a sequencer network, using the query service for catchup.
         let port = pick_unused_port().expect("No ports free");
         const NUM_NODES: usize = 5;
@@ -2630,8 +2602,6 @@ mod test {
     #[ignore]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_catchup_epochs_no_state_peers() {
-        setup_test();
-
         // Start a sequencer network, using the query service for catchup.
         let port = pick_unused_port().expect("No ports free");
         const EPOCH_HEIGHT: u64 = 5;
@@ -2727,7 +2697,6 @@ mod test {
         // This test uses a ValidatedState which only has the default chain config commitment.
         // The NodeState has the full chain config.
         // Both chain config commitments will match, so the ValidatedState should have the full chain config after a non-genesis block is decided.
-        setup_test();
 
         let port = pick_unused_port().expect("No ports free");
 
@@ -2781,8 +2750,6 @@ mod test {
         // so it will be different from the NodeState chain config used by the TestNetwork.
         // However, for this test to work, at least one node should have a full chain config
         // to allow other nodes to catch up.
-
-        setup_test();
 
         let port = pick_unused_port().expect("No ports free");
 
@@ -2855,7 +2822,6 @@ mod test {
     }
 
     async fn test_upgrade_helper<V: Versions>(version: V) {
-        setup_test();
         // wait this number of views beyond the configured first view
         // before asserting anything.
         let wait_extra_views = 10;
@@ -2946,8 +2912,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     pub(crate) async fn test_restart() {
-        setup_test();
-
         const NUM_NODES: usize = 5;
         // Initialize nodes.
         let storage = join_all((0..NUM_NODES).map(|_| SqlDataSource::create_storage())).await;
@@ -3075,8 +3039,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_fetch_config() {
-        setup_test();
-
         let port = pick_unused_port().expect("No ports free");
         let url: surf_disco::Url = format!("http://localhost:{port}").parse().unwrap();
         let client: Client<ServerError, StaticVersion<0, 1>> = Client::new(url.clone());
@@ -3118,8 +3080,6 @@ mod test {
     }
 
     async fn run_hotshot_event_streaming_test(url_suffix: &str) {
-        setup_test();
-
         let hotshot_event_streaming_port =
             pick_unused_port().expect("No ports free for hotshot event streaming");
         let query_service_port = pick_unused_port().expect("No ports free for query service");
@@ -3183,7 +3143,6 @@ mod test {
     // w/ above test.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_hotshot_event_streaming_epoch_progression() {
-        setup_test();
         let epoch_height = 35;
         let wanted_epochs = 4;
 
@@ -3273,7 +3232,6 @@ mod test {
         // - Rewards begin applying from block 41 (i.e., the start of the 3rd epoch).
         // - Since the validator is also the delegator, it receives the full reward.
         // - Verifies that the reward at block height 60 matches the expected amount.
-        setup_test();
         let epoch_height = 20;
 
         let network_config = TestConfigBuilder::default()
@@ -3371,7 +3329,6 @@ mod test {
         // The test verifies that the cumulative reward at each block height equals the total block reward,
         // which is a constant.
 
-        setup_test();
         let epoch_height = 20;
 
         let network_config = TestConfigBuilder::default()
@@ -3493,7 +3450,6 @@ mod test {
         // TODO(abdul): This test currently uses TestNetwork only for contract deployment and for L1 block number.
         // Once the stake table deployment logic is refactored and isolated, TestNetwork here will be unnecessary
 
-        setup_test();
         let epoch_height = 20;
 
         let network_config = TestConfigBuilder::default()
@@ -3604,7 +3560,6 @@ mod test {
         // and that rewards are correctly allocated starting from the third epoch.
         // also checks that the total stake of delegators matches the stake of the validator
         // and that the calculated rewards match those obtained via the merklized state api
-        setup_test();
         const EPOCH_HEIGHT: u64 = 20;
 
         let network_config = TestConfigBuilder::default()
@@ -3830,7 +3785,6 @@ mod test {
         // - Reward values match those returned by the reward state API.
         // - Commission calculations are within a small acceptable rounding tolerance.
         // - Ensure that the `total_reward_distributed` field in the block header matches the total block reward distributed
-        setup_test();
         const EPOCH_HEIGHT: u64 = 20;
 
         type V4 = SequencerVersions<StaticVersion<0, 4>, StaticVersion<0, 0>>;
@@ -4095,7 +4049,6 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
 
     async fn test_node_stake_table_api<Ver: Versions>(#[case] ver: Ver) {
-        setup_test();
         let epoch_height = 20;
 
         let network_config = TestConfigBuilder::default()
@@ -4170,8 +4123,6 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
 
     async fn test_epoch_stake_table_catchup<Ver: Versions>(#[case] ver: Ver) {
-        setup_test();
-
         const EPOCH_HEIGHT: u64 = 10;
         const NUM_NODES: usize = 6;
 
@@ -4304,8 +4255,6 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
 
     async fn test_epoch_stake_table_catchup_stress<Ver: Versions>(#[case] versions: Ver) {
-        setup_test();
-
         const EPOCH_HEIGHT: u64 = 10;
         const NUM_NODES: usize = 6;
 
@@ -4463,7 +4412,6 @@ mod test {
         // 4. Allow the network to progress 3 more epochs (query node remains offline).
         // 5. Restart the query node.
         //    - The node is expected to reconstruct or catch up on its own
-        setup_test();
         const EPOCH_HEIGHT: u64 = 10;
 
         let network_config = TestConfigBuilder::default()
@@ -4690,7 +4638,6 @@ mod test {
         //    - Both fee and reward accounts
         // 6. Assert that the reconstructed state is correct in all scenarios.
 
-        setup_test();
         const EPOCH_HEIGHT: u64 = 10;
 
         let network_config = TestConfigBuilder::default()
@@ -5011,7 +4958,6 @@ mod test {
     #[case(PosVersionV4::new())]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_block_reward_api<Ver: Versions>(#[case] versions: Ver) -> anyhow::Result<()> {
-        setup_test();
         let epoch_height = 10;
 
         let network_config = TestConfigBuilder::default()
@@ -5079,8 +5025,6 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_scanning_token_contract_initialized_event() -> anyhow::Result<()> {
         use espresso_types::v0_3::ChainConfig;
-
-        setup_test();
 
         let blocks_per_epoch = 10;
 
@@ -5201,8 +5145,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_tx_metadata() {
-        setup_test();
-
         let port = pick_unused_port().expect("No ports free");
 
         let url = format!("http://localhost:{port}").parse().unwrap();
@@ -5283,8 +5225,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_aggregator_namespace_endpoints() {
-        setup_test();
-
         let mut rng = thread_rng();
 
         let port = pick_unused_port().expect("No ports free");
@@ -5463,7 +5403,6 @@ mod test {
         // waits for them to be decided, and then verifies that:
         // 1. All transactions appear in the transaction stream.
         // 2. Each namespace-specific transaction stream only includes the transactions of that namespace.
-        setup_test();
 
         let mut rng = thread_rng();
 
@@ -5593,7 +5532,6 @@ mod test {
         // When the protocol version is v4:
         // - The v4 Merkle tree is updated
         // - The v3 Merkle tree must be empty.
-        setup_test();
         const EPOCH_HEIGHT: u64 = 10;
 
         let network_config = TestConfigBuilder::default()

--- a/sequencer/src/api/fs.rs
+++ b/sequencer/src/api/fs.rs
@@ -52,13 +52,3 @@ mod impl_testable_data_source {
         }
     }
 }
-
-#[cfg(test)]
-mod generic_tests {
-    use super::{super::api_tests, DataSource};
-    // For some reason this is the only way to import the macro defined in another module of this
-    // crate.
-    use crate::*;
-
-    instantiate_api_tests!(DataSource);
-}

--- a/sequencer/src/api/sql.rs
+++ b/sequencer/src/api/sql.rs
@@ -915,13 +915,3 @@ pub(crate) mod impl_testable_data_source {
         }
     }
 }
-
-#[cfg(test)]
-mod generic_tests {
-    use super::{super::api_tests, DataSource};
-    // For some reason this is the only way to import the macro defined in another module of this
-    // crate.
-    use crate::*;
-
-    instantiate_api_tests!(DataSource);
-}

--- a/sequencer/src/bin/espresso-dev-node.rs
+++ b/sequencer/src/bin/espresso-dev-node.rs
@@ -941,7 +941,6 @@ mod tests {
     use portpicker::pick_unused_port;
     use rand::Rng;
     use sequencer::SequencerApiVersion;
-    use sequencer_utils::test_utils::setup_test;
     use surf_disco::Client;
     use tide_disco::error::ServerError;
     use tokio::time::sleep;
@@ -966,10 +965,8 @@ mod tests {
     // and open a PR.
     // - APIs update
     // - Types (like `Header`) update
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn slow_dev_node_test() {
-        setup_test();
-
         let builder_port = pick_unused_port().unwrap();
         let api_port = pick_unused_port().unwrap();
         let dev_node_port = pick_unused_port().unwrap();
@@ -1287,10 +1284,8 @@ mod tests {
         (providers, urls)
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn slow_dev_node_multiple_lc_providers_test() {
-        setup_test();
-
         let builder_port = pick_unused_port().unwrap();
         let api_port = pick_unused_port().unwrap();
         let dev_node_port = pick_unused_port().unwrap();

--- a/sequencer/src/genesis.rs
+++ b/sequencer/src/genesis.rs
@@ -334,7 +334,7 @@ mod test {
     use espresso_types::{
         L1BlockInfo, TimeBasedUpgrade, Timestamp, UpgradeMode, UpgradeType, ViewBasedUpgrade,
     };
-    use sequencer_utils::{ser::FromStringOrInteger, test_utils::setup_test};
+    use sequencer_utils::ser::FromStringOrInteger;
     use toml::toml;
 
     use super::*;
@@ -533,10 +533,8 @@ mod test {
     // deploying of the fee contract behind proxy, and this function is being unit tested there.
     // Here, we primarily focus on testing the config and validation logic, not deployment logic.
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_genesis_fee_contract_is_a_proxy() -> anyhow::Result<()> {
-        setup_test();
-
         let anvil = Arc::new(Anvil::new().spawn());
         let wallet = anvil.wallet().unwrap();
         let admin = wallet.default_signer().address();
@@ -588,10 +586,8 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_genesis_fee_contract_is_a_proxy_with_upgrades() -> anyhow::Result<()> {
-        setup_test();
-
         let anvil = Arc::new(Anvil::new().spawn());
         let wallet = anvil.wallet().unwrap();
         let admin = wallet.default_signer().address();
@@ -658,7 +654,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_genesis_missing_fee_contract_with_upgrades() {
         let toml = toml! {
             base_version = "0.1"
@@ -728,7 +724,7 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_genesis_upgrade_fee_contract_address_is_zero() {
         let toml = toml! {
             base_version = "0.1"
@@ -787,10 +783,8 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_genesis_fee_contract_l1_failover() -> anyhow::Result<()> {
-        setup_test();
-
         let anvil = Arc::new(Anvil::new().spawn());
         let wallet = anvil.wallet().unwrap();
         let admin = wallet.default_signer().address();

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -1370,15 +1370,13 @@ mod test {
         event::LeafInfo,
         traits::block_contents::{BlockHeader, BlockPayload},
     };
-    use sequencer_utils::test_utils::setup_test;
     use testing::{wait_for_decide_on_handle, TestConfigBuilder};
 
     use self::testing::run_test_builder;
     use super::*;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_skeleton_instantiation() {
-        setup_test();
         // Assign `config` so it isn't dropped early.
         let anvil = Anvil::new().spawn();
         let url = anvil.endpoint_url();
@@ -1415,10 +1413,8 @@ mod test {
         wait_for_decide_on_handle(&mut events, &txn).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_header_invariants() {
-        setup_test();
-
         let success_height = 30;
         // Assign `config` so it isn't dropped early.
         let anvil = Anvil::new().spawn();

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -143,7 +143,7 @@ mod tests {
         }
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_voted_view<P: TestablePersistence>(_p: PhantomData<P>) {
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
@@ -184,7 +184,7 @@ mod tests {
         );
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_restart_view<P: TestablePersistence>(_p: PhantomData<P>) {
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
@@ -245,7 +245,7 @@ mod tests {
         );
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_store_drb_input<P: TestablePersistence>(_p: PhantomData<P>) {
         use hotshot_types::drb::DrbInput;
 
@@ -294,7 +294,7 @@ mod tests {
         assert_eq!(storage.load_drb_input(10).await.unwrap(), drb_input_3);
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_epoch_info<P: TestablePersistence>(_p: PhantomData<P>) {
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
@@ -406,7 +406,7 @@ mod tests {
         }
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_append_and_decide<P: TestablePersistence>(_p: PhantomData<P>) {
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
@@ -785,7 +785,7 @@ mod tests {
         );
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_upgrade_certificate<P: TestablePersistence>(_p: PhantomData<P>) {
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
@@ -832,7 +832,7 @@ mod tests {
         assert_eq!(view_number, new_view_number_for_certificate);
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_next_epoch_quorum_certificate<P: TestablePersistence>(_p: PhantomData<P>) {
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
@@ -892,7 +892,7 @@ mod tests {
         assert_eq!(view_number, new_view_number_for_qc);
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_decide_with_failing_event_consumer<P: TestablePersistence>(
         _p: PhantomData<P>,
     ) {
@@ -1111,7 +1111,7 @@ mod tests {
         }
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_pruning<P: TestablePersistence>(_p: PhantomData<P>) {
         let tmp = P::tmp_storage().await;
 
@@ -1290,7 +1290,7 @@ mod tests {
 
     // test for validating stake table event fetching from persistence,
     // ensuring that persisted data matches the on-chain events and that event fetcher work correctly.
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_stake_table_fetching_from_persistence<P: TestablePersistence>(
         #[values(StakeTableContractVersion::V1, StakeTableContractVersion::V2)]
         stake_table_version: StakeTableContractVersion,
@@ -1416,7 +1416,7 @@ mod tests {
         Ok(())
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_stake_table_background_fetching<P: TestablePersistence>(
         #[values(StakeTableContractVersion::V1, StakeTableContractVersion::V2)]
         stake_table_version: StakeTableContractVersion,
@@ -1577,7 +1577,7 @@ mod tests {
         Ok(())
     }
 
-    #[test_log::test(rstest_reuse::apply(persistence_types))]
+    #[rstest_reuse::apply(persistence_types)]
     pub async fn test_membership_persistence<P: TestablePersistence>(
         _p: PhantomData<P>,
     ) -> anyhow::Result<()> {

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -79,7 +79,6 @@ mod tests {
     };
     use indexmap::IndexMap;
     use portpicker::pick_unused_port;
-    use sequencer_utils::test_utils::setup_test;
     use staking_cli::demo::{setup_stake_table_contract_for_test, DelegationConfig};
     use surf_disco::Client;
     use tide_disco::error::ServerError;
@@ -112,7 +111,7 @@ mod tests {
     #[rstest::rstest]
     #[case(PhantomData::<crate::persistence::sql::Persistence>)]
     #[case(PhantomData::<crate::persistence::fs::Persistence>)]
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub fn persistence_types<P: TestablePersistence>(#[case] _p: PhantomData<P>) {}
 
     #[derive(Clone, Debug, Default)]
@@ -144,10 +143,8 @@ mod tests {
         }
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_voted_view<P: TestablePersistence>(_p: PhantomData<P>) {
-        setup_test();
-
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
 
@@ -187,10 +184,8 @@ mod tests {
         );
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_restart_view<P: TestablePersistence>(_p: PhantomData<P>) {
-        setup_test();
-
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
 
@@ -250,10 +245,9 @@ mod tests {
         );
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_store_drb_input<P: TestablePersistence>(_p: PhantomData<P>) {
         use hotshot_types::drb::DrbInput;
-        setup_test();
 
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
@@ -300,9 +294,8 @@ mod tests {
         assert_eq!(storage.load_drb_input(10).await.unwrap(), drb_input_3);
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_epoch_info<P: TestablePersistence>(_p: PhantomData<P>) {
-        setup_test();
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
 
@@ -413,10 +406,8 @@ mod tests {
         }
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_append_and_decide<P: TestablePersistence>(_p: PhantomData<P>) {
-        setup_test();
-
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
 
@@ -794,10 +785,8 @@ mod tests {
         );
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_upgrade_certificate<P: TestablePersistence>(_p: PhantomData<P>) {
-        setup_test();
-
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
 
@@ -843,10 +832,8 @@ mod tests {
         assert_eq!(view_number, new_view_number_for_certificate);
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_next_epoch_quorum_certificate<P: TestablePersistence>(_p: PhantomData<P>) {
-        setup_test();
-
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
 
@@ -905,7 +892,7 @@ mod tests {
         assert_eq!(view_number, new_view_number_for_qc);
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_decide_with_failing_event_consumer<P: TestablePersistence>(
         _p: PhantomData<P>,
     ) {
@@ -918,8 +905,6 @@ mod tests {
                 bail!("mock error injection");
             }
         }
-
-        setup_test();
 
         let tmp = P::tmp_storage().await;
         let storage = P::connect(&tmp).await;
@@ -1126,10 +1111,8 @@ mod tests {
         }
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_pruning<P: TestablePersistence>(_p: PhantomData<P>) {
-        setup_test();
-
         let tmp = P::tmp_storage().await;
 
         let mut options = P::options(&tmp);
@@ -1307,14 +1290,12 @@ mod tests {
 
     // test for validating stake table event fetching from persistence,
     // ensuring that persisted data matches the on-chain events and that event fetcher work correctly.
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_stake_table_fetching_from_persistence<P: TestablePersistence>(
         #[values(StakeTableContractVersion::V1, StakeTableContractVersion::V2)]
         stake_table_version: StakeTableContractVersion,
         _p: PhantomData<P>,
     ) -> anyhow::Result<()> {
-        setup_test();
-
         let epoch_height = 20;
         type PosVersion = SequencerVersions<StaticVersion<0, 3>, StaticVersion<0, 0>>;
 
@@ -1435,7 +1416,7 @@ mod tests {
         Ok(())
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_stake_table_background_fetching<P: TestablePersistence>(
         #[values(StakeTableContractVersion::V1, StakeTableContractVersion::V2)]
         stake_table_version: StakeTableContractVersion,
@@ -1443,8 +1424,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         use espresso_types::v0_3::ChainConfig;
         use hotshot_contract_adapter::stake_table::StakeTableContractVersion;
-
-        setup_test();
 
         let blocks_per_epoch = 10;
 
@@ -1598,12 +1577,10 @@ mod tests {
         Ok(())
     }
 
-    #[rstest_reuse::apply(persistence_types)]
+    #[test_log::test(rstest_reuse::apply(persistence_types))]
     pub async fn test_membership_persistence<P: TestablePersistence>(
         _p: PhantomData<P>,
     ) -> anyhow::Result<()> {
-        setup_test();
-
         let tmp = P::tmp_storage().await;
         let mut opt = P::options(&tmp);
 

--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -1989,7 +1989,6 @@ mod test {
         vid::advz::advz_scheme,
     };
     use jf_vid::VidScheme;
-    use sequencer_utils::test_utils::setup_test;
     use serde_json::json;
     use tempfile::TempDir;
     use vbs::version::StaticVersionType;
@@ -2116,9 +2115,8 @@ mod test {
         assert_eq!(migrate_network_config(before.clone()).unwrap(), before);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     pub async fn test_consensus_migration() {
-        setup_test();
         let rows = 300;
         let tmp = Persistence::tmp_storage().await;
         let mut opt = Persistence::options(&tmp);
@@ -2356,10 +2354,8 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_load_quorum_proposals_invalid_extension() {
-        setup_test();
-
         let tmp = Persistence::tmp_storage().await;
         let storage = Persistence::connect(&tmp).await;
 
@@ -2419,10 +2415,8 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_load_quorum_proposals_malformed_data() {
-        setup_test();
-
         let tmp = Persistence::tmp_storage().await;
         let storage = Persistence::connect(&tmp).await;
 

--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -2657,16 +2657,13 @@ mod test {
         },
     };
     use jf_vid::VidScheme;
-    use sequencer_utils::test_utils::setup_test;
     use vbs::version::StaticVersionType;
 
     use super::*;
     use crate::{persistence::tests::TestablePersistence as _, BLSPubKey, PubKey};
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_quorum_proposals_leaf_hash_migration() {
-        setup_test();
-
         // Create some quorum proposals to test with.
         let leaf: Leaf2 =
             Leaf::genesis::<TestVersions>(&ValidatedState::default(), &NodeState::mock())
@@ -2744,10 +2741,8 @@ mod test {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fetching_providers() {
-        setup_test();
-
         let tmp = Persistence::tmp_storage().await;
         let storage = Persistence::connect(&tmp).await;
 
@@ -2887,8 +2882,6 @@ mod test {
     /// different configurations that can achieve this behavior, such that the data is retained and
     /// then pruned due to different logic and code paths.
     async fn test_pruning_helper(pruning_opt: ConsensusPruningOptions) {
-        setup_test();
-
         let tmp = Persistence::tmp_storage().await;
         let mut opt = Persistence::options(&tmp);
         opt.consensus_pruning = pruning_opt;
@@ -3009,7 +3002,7 @@ mod test {
         storage.load_quorum_proposal(data_view).await.unwrap_err();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_pruning_minimum_retention() {
         test_pruning_helper(ConsensusPruningOptions {
             // Use a very low target usage, to show that we still retain data up to the minimum
@@ -3023,7 +3016,7 @@ mod test {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_pruning_target_retention() {
         test_pruning_helper(ConsensusPruningOptions {
             target_retention: 1,
@@ -3037,10 +3030,8 @@ mod test {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_consensus_migration() {
-        setup_test();
-
         let tmp = Persistence::tmp_storage().await;
         let mut opt = Persistence::options(&tmp);
 
@@ -3304,14 +3295,11 @@ mod postgres_tests {
             EncodeBytes,
         },
     };
-    use sequencer_utils::test_utils::setup_test;
 
     use super::*;
     use crate::persistence::tests::TestablePersistence as _;
 
     async fn test_postgres_read_ns_table(instance_state: NodeState) {
-        setup_test();
-
         instance_state
             .coordinator
             .membership()
@@ -3410,17 +3398,17 @@ mod postgres_tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_postgres_read_ns_table_v0_1() {
         test_postgres_read_ns_table(NodeState::mock()).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_postgres_read_ns_table_v0_2() {
         test_postgres_read_ns_table(NodeState::mock_v2()).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_postgres_read_ns_table_v0_3() {
         test_postgres_read_ns_table(NodeState::mock_v3().with_epoch_height(0)).await;
     }

--- a/sequencer/src/restart_tests.rs
+++ b/sequencer/src/restart_tests.rs
@@ -58,7 +58,6 @@ use itertools::Itertools;
 use options::Modules;
 use portpicker::pick_unused_port;
 use run::init_with_storage;
-use sequencer_utils::test_utils::setup_test;
 use staking_cli::demo::{setup_stake_table_contract_for_test, DelegationConfig};
 use surf_disco::{error::ClientError, Url};
 use tempfile::TempDir;
@@ -82,8 +81,6 @@ use crate::{
 };
 type MockSequencerVersions = SequencerVersions<EpochVersion, V0_0>;
 async fn test_restart_helper(network: (usize, usize), restart: (usize, usize), cdn: bool) {
-    setup_test();
-
     let mut network = TestNetwork::new(network.0, network.1, cdn).await;
 
     // Let the network get going.
@@ -94,113 +91,111 @@ async fn test_restart_helper(network: (usize, usize), restart: (usize, usize), c
     network.shut_down().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_1_da_with_cdn() {
     test_restart_helper((2, 3), (1, 0), true).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_1_regular_with_cdn() {
     test_restart_helper((2, 3), (0, 1), true).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_f_with_cdn() {
     test_restart_helper((4, 6), (1, 2), true).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_f_minus_1_with_cdn() {
     test_restart_helper((4, 6), (1, 1), true).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_f_plus_1_with_cdn() {
     test_restart_helper((4, 6), (1, 3), true).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_2f_with_cdn() {
     test_restart_helper((4, 6), (1, 5), true).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_2f_minus_1_with_cdn() {
     test_restart_helper((4, 6), (1, 4), true).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_2f_plus_1_with_cdn() {
     test_restart_helper((4, 6), (2, 5), true).await;
 }
 
 #[ignore]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_all_with_cdn() {
     test_restart_helper((2, 8), (2, 8), true).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_all_da_with_cdn() {
     test_restart_helper((2, 8), (2, 0), true).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_1_da_without_cdn() {
     test_restart_helper((2, 3), (1, 0), false).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_1_regular_without_cdn() {
     test_restart_helper((2, 3), (0, 1), false).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_f_without_cdn() {
     test_restart_helper((4, 6), (1, 2), false).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_f_minus_1_without_cdn() {
     test_restart_helper((4, 6), (1, 1), false).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_f_plus_1_without_cdn() {
     test_restart_helper((4, 6), (1, 3), false).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_2f_without_cdn() {
     test_restart_helper((4, 6), (1, 5), false).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_2f_minus_1_without_cdn() {
     test_restart_helper((4, 6), (1, 4), false).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_2f_plus_1_without_cdn() {
     test_restart_helper((4, 6), (2, 5), false).await;
 }
 
 #[ignore]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_all_without_cdn() {
     test_restart_helper((2, 8), (2, 8), false).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_all_da_without_cdn() {
     test_restart_helper((2, 8), (2, 0), false).await;
 }
 
 #[ignore]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn slow_test_restart_staggered() {
-    setup_test();
-
     let mut network = TestNetwork::new(4, 6, false).await;
 
     // Check that the builder works at the beginning.

--- a/sequencer/src/run.rs
+++ b/sequencer/src/run.rs
@@ -299,7 +299,6 @@ mod test {
     use espresso_types::{MockSequencerVersions, PubKey};
     use hotshot_types::{light_client::StateKeyPair, traits::signature_key::SignatureKey};
     use portpicker::pick_unused_port;
-    use sequencer_utils::test_utils::setup_test;
     use surf_disco::{error::ClientError, Client, Url};
     use tempfile::TempDir;
     use tokio::spawn;
@@ -313,10 +312,8 @@ mod test {
         SequencerApiVersion,
     };
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_startup_before_orchestrator() {
-        setup_test();
-
         let (pub_key, priv_key) = PubKey::generated_from_seed_indexed([0; 32], 0);
         let state_key = StateKeyPair::generate_from_seed_indexed([0; 32], 0);
 

--- a/staking-cli/Cargo.toml
+++ b/staking-cli/Cargo.toml
@@ -42,6 +42,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+test-log = { workspace = true }
 
 [lints]
 workspace = true

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -330,7 +330,6 @@ mod test {
     use espresso_types::v0_3::Validator;
     use hotshot_types::signature_key::BLSPubKey;
     use rand::rngs::StdRng;
-    use sequencer_utils::test_utils::setup_test;
 
     use super::*;
     use crate::{deploy::TestSystem, info::stake_table_info};
@@ -338,7 +337,6 @@ mod test {
     async fn shared_setup(
         config: DelegationConfig,
     ) -> Result<(Validator<BLSPubKey>, Validator<BLSPubKey>)> {
-        setup_test();
         let system = TestSystem::deploy().await?;
 
         let mut rng = StdRng::from_seed([42u8; 32]);
@@ -370,7 +368,7 @@ mod test {
         Ok((val1, val2))
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_stake_for_demo_equal_amounts() -> Result<()> {
         let (val1, val2) = shared_setup(DelegationConfig::EqualAmounts).await?;
 
@@ -388,7 +386,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_stake_for_demo_variable_amounts() -> Result<()> {
         let (val1, val2) = shared_setup(DelegationConfig::VariableAmounts).await?;
 
@@ -406,7 +404,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_stake_for_demo_multiple_delegators() -> Result<()> {
         let (val1, val2) = shared_setup(DelegationConfig::MultipleDelegators).await?;
 

--- a/staking-cli/tests/cli.rs
+++ b/staking-cli/tests/cli.rs
@@ -10,7 +10,6 @@ use alloy::primitives::{
 use anyhow::Result;
 use hotshot_contract_adapter::stake_table::StakeTableContractVersion;
 use rand::{rngs::StdRng, SeedableRng as _};
-use sequencer_utils::test_utils::setup_test;
 use staking_cli::{demo::DelegationConfig, deploy, deploy::Signer, Config};
 
 use crate::deploy::TestSystem;
@@ -95,16 +94,14 @@ fn base_cmd() -> Command {
     Command::new(path)
 }
 
-#[test]
+#[test_log::test]
 fn test_cli_version() -> Result<()> {
-    setup_test();
     base_cmd().arg("version").output()?.assert_success();
     Ok(())
 }
 
-#[test]
+#[test_log::test]
 fn test_cli_create_and_remove_config_file_mnemonic() -> anyhow::Result<()> {
-    setup_test();
     let tmpdir = tempfile::tempdir()?;
     let config_path = tmpdir.path().join("config.toml");
 
@@ -165,9 +162,8 @@ fn test_cli_create_file_ledger() -> anyhow::Result<()> {
 }
 
 // TODO: ideally we would test that the decoding works for all the commands
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_contract_revert(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     let mut cmd = base_cmd();
     system.args(&mut cmd, Signer::Mnemonic);
@@ -186,13 +182,12 @@ async fn test_cli_contract_revert(#[case] version: StakeTableContractVersion) ->
 }
 
 #[rstest::rstest]
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn test_cli_register_validator(
     #[values(StakeTableContractVersion::V1, StakeTableContractVersion::V2)]
     version: StakeTableContractVersion,
     #[values(Signer::Mnemonic, Signer::BrokeMnemonic)] signer: Signer,
 ) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     let mut cmd = base_cmd();
     system.args(&mut cmd, signer);
@@ -251,9 +246,8 @@ async fn test_cli_update_consensus_keys(#[case] version: StakeTableContractVersi
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_delegate(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     system.register_validator().await?;
 
@@ -269,9 +263,8 @@ async fn test_cli_delegate(#[case] version: StakeTableContractVersion) -> Result
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_deregister_validator(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     system.register_validator().await?;
 
@@ -281,9 +274,8 @@ async fn test_cli_deregister_validator(#[case] version: StakeTableContractVersio
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_undelegate(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     system.register_validator().await?;
     let amount = "123";
@@ -301,9 +293,8 @@ async fn test_cli_undelegate(#[case] version: StakeTableContractVersion) -> Resu
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_claim_withdrawal(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     let amount = U256::from(123);
     system.register_validator().await?;
@@ -321,9 +312,8 @@ async fn test_cli_claim_withdrawal(#[case] version: StakeTableContractVersion) -
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_claim_validator_exit(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     let amount = U256::from(123);
     system.register_validator().await?;
@@ -341,11 +331,10 @@ async fn test_cli_claim_validator_exit(#[case] version: StakeTableContractVersio
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_stake_for_demo_default_num_validators(
     #[case] version: StakeTableContractVersion,
 ) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
 
     let mut cmd = base_cmd();
@@ -354,11 +343,10 @@ async fn test_cli_stake_for_demo_default_num_validators(
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_stake_for_demo_three_validators(
     #[case] version: StakeTableContractVersion,
 ) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
 
     let mut cmd = base_cmd();
@@ -372,7 +360,7 @@ async fn test_cli_stake_for_demo_three_validators(
 }
 
 #[rstest::rstest]
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn stake_for_demo_delegation_config_helper(
     #[values(StakeTableContractVersion::V1, StakeTableContractVersion::V2)]
     version: StakeTableContractVersion,
@@ -383,7 +371,6 @@ async fn stake_for_demo_delegation_config_helper(
     )]
     config: DelegationConfig,
 ) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
 
     let mut cmd = base_cmd();
@@ -396,9 +383,8 @@ async fn stake_for_demo_delegation_config_helper(
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_approve(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     let amount = "123";
 
@@ -415,9 +401,8 @@ async fn test_cli_approve(#[case] version: StakeTableContractVersion) -> Result<
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_balance(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
 
     // Check balance of account owner
@@ -450,9 +435,8 @@ async fn test_cli_balance(#[case] version: StakeTableContractVersion) -> Result<
 }
 
 // This test can be remove when the deprecated argument is removed
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn test_deprecated_token_address_cli_arg() -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy().await?;
 
     let mut cmd = base_cmd();
@@ -463,9 +447,8 @@ async fn test_deprecated_token_address_cli_arg() -> Result<()> {
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_allowance(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
 
     // Check allowance of account owner
@@ -494,9 +477,8 @@ async fn test_cli_allowance(#[case] version: StakeTableContractVersion) -> Resul
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_transfer(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     let addr = "0x1111111111111111111111111111111111111111".parse::<Address>()?;
     let amount = parse_ether("0.123")?;
@@ -515,9 +497,8 @@ async fn test_cli_transfer(#[case] version: StakeTableContractVersion) -> Result
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_stake_table_full(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     system.register_validator().await?;
 
@@ -538,9 +519,8 @@ async fn test_cli_stake_table_full(#[case] version: StakeTableContractVersion) -
     Ok(())
 }
 
-#[rstest_reuse::apply(stake_table_versions)]
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_stake_table_compact(#[case] version: StakeTableContractVersion) -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy_version(version).await?;
     system.register_validator().await?;
 
@@ -593,9 +573,8 @@ async fn address_from_cli(system: &TestSystem) -> Result<Address> {
 /// This test requires a ledger device to be connected and unlocked.
 /// cargo test -p staking-cli -- --ignored --nocapture transfer_ledger
 #[ignore]
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn test_cli_transfer_ledger() -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy().await?;
     let address = address_from_cli(&system).await?;
 
@@ -635,9 +614,8 @@ async fn test_cli_transfer_ledger() -> Result<()> {
 /// This test requires a ledger device to be connected and unlocked.
 /// cargo test -p staking-cli -- --ignored --nocapture delegate_ledger
 #[ignore]
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn test_cli_delegate_ledger() -> Result<()> {
-    setup_test();
     let system = TestSystem::deploy().await?;
     system.register_validator().await?;
     let address = address_from_cli(&system).await?;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -24,10 +24,9 @@ clap = { workspace = true }
 cld = { workspace = true }
 committable = { workspace = true }
 derive_more = { workspace = true }
-ethers-core = "2.0"
 either = { workspace = true }
+ethers-core = "2.0"
 fluent-asserter = "0.1.9"
-sha3 = "0.10"
 futures = { workspace = true }
 hotshot = { workspace = true }
 hotshot-contract-adapter = { workspace = true }
@@ -51,6 +50,7 @@ sequencer-utils = { path = "../utils" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }                                                         # TODO temporary, used only for VID, should be set in hotshot
+sha3 = "0.10"
 static_assertions = { workspace = true }
 surf-disco = { workspace = true }
 tagged-base64 = { workspace = true }
@@ -71,6 +71,7 @@ espresso-types = { path = ".", features = [ "testing" ] }
 portpicker = { workspace = true }
 rstest = { workspace = true }
 rstest_reuse = { workspace = true }
+test-log = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["base64_bytes", "hotshot_testing"]

--- a/types/src/reference_tests.rs
+++ b/types/src/reference_tests.rs
@@ -44,7 +44,7 @@ use jf_merkle_tree::MerkleTreeScheme;
 use jf_vid::VidScheme;
 use pretty_assertions::assert_eq;
 use rand::{Rng, RngCore};
-use sequencer_utils::{commitment_to_u256, test_utils::setup_test};
+use sequencer_utils::commitment_to_u256;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use tagged_base64::TaggedBase64;
@@ -261,8 +261,6 @@ fn reference_test_without_committable<T: Serialize + DeserializeOwned + Eq + Deb
     name: &str,
     reference: &T,
 ) {
-    setup_test();
-
     // Load the expected serialization from the repo.
     let data_dir = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
         .join("../data")
@@ -366,8 +364,6 @@ fn reference_test<T: Committable + Serialize + DeserializeOwned + Eq + Debug>(
     reference: T,
     commitment: &str,
 ) {
-    setup_test();
-
     reference_test_without_committable(version, name, &reference);
 
     // Print information about the commitment that might be useful in generating tests for other
@@ -395,12 +391,12 @@ Actual: {actual}
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_reference_payload() {
     reference_test_without_committable("v1", "payload", &reference_payload().await);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_reference_ns_table() {
     reference_test(
         "v1",
@@ -410,7 +406,7 @@ async fn test_reference_ns_table() {
     );
 }
 
-#[test]
+#[test_log::test]
 fn test_reference_l1_block() {
     reference_test(
         "v1",
@@ -420,7 +416,7 @@ fn test_reference_l1_block() {
     );
 }
 
-#[test]
+#[test_log::test]
 fn test_reference_v1_chain_config() {
     reference_test(
         "v1",
@@ -430,7 +426,7 @@ fn test_reference_v1_chain_config() {
     );
 }
 
-#[test]
+#[test_log::test]
 fn test_reference_v2_chain_config() {
     reference_test(
         "v2",
@@ -440,7 +436,7 @@ fn test_reference_v2_chain_config() {
     );
 }
 
-#[test]
+#[test_log::test]
 fn test_reference_v3_chain_config() {
     reference_test(
         "v3",
@@ -450,7 +446,7 @@ fn test_reference_v3_chain_config() {
     );
 }
 
-#[test]
+#[test_log::test]
 fn test_reference_fee_info() {
     reference_test(
         "v1",
@@ -460,7 +456,7 @@ fn test_reference_fee_info() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_reference_header_v1() {
     reference_test(
         "v1",
@@ -470,7 +466,7 @@ async fn test_reference_header_v1() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_reference_header_v2() {
     reference_test(
         "v2",
@@ -480,7 +476,7 @@ async fn test_reference_header_v2() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_reference_header_v3() {
     reference_test(
         "v3",
@@ -490,7 +486,7 @@ async fn test_reference_header_v3() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_reference_header_v4() {
     reference_test(
         "v4",
@@ -500,7 +496,7 @@ async fn test_reference_header_v4() {
     );
 }
 
-#[test]
+#[test_log::test]
 fn test_reference_transaction() {
     reference_test(
         "v1",
@@ -511,25 +507,25 @@ fn test_reference_transaction() {
 }
 
 // "legacy" refers to the proof type used before it was an enum.
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_reference_ns_proof_legacy() {
     reference_test_without_committable("v1", "ns_proof_legacy", &reference_ns_proof_legacy().await);
 }
 
 // "V0" does not refer to the version scheme used in this crate but to the NSProof::VO variant.
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_reference_ns_proof_enum_advz() {
     reference_test_without_committable("v3", "ns_proof_V0", &reference_ns_proof_enum_advz().await);
 }
 
 // "V1" does not refer to the version scheme used in this crate but to the NSProof::V1 variant.
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_reference_ns_proof_enum_avidm() {
     reference_test_without_committable("v3", "ns_proof_V1", &reference_ns_proof_enum_avidm().await);
 }
 
 // Legacy leaf query data
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_leaf_query_data_legacy_v1() {
     let validated_state = ValidatedState::default();
     let instance_state = NodeState::default();
@@ -539,7 +535,7 @@ async fn test_leaf_query_data_legacy_v1() {
     reference_test_without_committable("v1", "leaf_query_data_legacy", &leaf);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_leaf_query_data_legacy_v2() {
     let validated_state = ValidatedState::default();
     let instance_state = NodeState::default();
@@ -550,7 +546,7 @@ async fn test_leaf_query_data_legacy_v2() {
 }
 
 // new leaf2 query data
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_leaf_query_data_v3() {
     let validated_state = ValidatedState::default();
     let instance_state = NodeState::default();
@@ -559,13 +555,13 @@ async fn test_leaf_query_data_v3() {
     reference_test_without_committable("v3", "leaf_query_data", &leaf);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_block_query_data() {
     let block = reference_block().await;
     reference_test_without_committable("v1", "block_query_data", &block);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_payload_query_data() {
     let block = reference_block().await;
     let payload = PayloadQueryData::from(block);
@@ -573,7 +569,7 @@ async fn test_payload_query_data() {
 }
 
 // v0 is the `VidCommon`` v0 variant
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_vid_common_v0_query_data() {
     let header = reference_header(Version { major: 0, minor: 1 }).await;
     let payload = reference_payload().await;
@@ -587,7 +583,7 @@ async fn test_vid_common_v0_query_data() {
 }
 
 // v1 is the `VidCommon`` v1 variant
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_vid_common_v1_query_data() {
     let header = reference_header(Version { major: 0, minor: 1 }).await;
     let avid_m_param = init_avidm_param(10).unwrap();
@@ -597,7 +593,7 @@ async fn test_vid_common_v1_query_data() {
 }
 
 // Transaction query data
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_transaction_query_data() {
     let block = reference_block().await;
 
@@ -622,7 +618,7 @@ async fn test_transaction_query_data() {
 }
 
 // State certificate
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_state_cert_query_data_v3() {
     let light_client_cert = LightClientStateUpdateCertificate::<SeqTypes>::genesis();
     let state_cert = StateCertQueryData(light_client_cert);

--- a/types/src/v0/impls/block/full_payload/ns_proof/advz.rs
+++ b/types/src/v0/impls/block/full_payload/ns_proof/advz.rs
@@ -166,7 +166,7 @@ impl ADVZNsProof {
 #[cfg(test)]
 mod tests {
     use futures::future;
-    use hotshot::{helpers::initialize_logging, traits::BlockPayload};
+    use hotshot::traits::BlockPayload;
     use hotshot_types::{
         data::VidCommitment,
         traits::EncodeBytes,
@@ -176,7 +176,7 @@ mod tests {
 
     use crate::{v0::impls::block::test::ValidTest, v0_1::ADVZNsProof, Payload};
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn ns_proof() {
         let test_cases = vec![
             vec![
@@ -189,8 +189,6 @@ mod tests {
             vec![vec![1, 2, 3], vec![4, 5, 6]],
             vec![],
         ];
-
-        initialize_logging();
 
         let mut rng = jf_utils::test_rng();
         let mut tests = ValidTest::many_from_tx_lengths(test_cases, &mut rng);

--- a/types/src/v0/impls/block/full_payload/ns_proof/avidm.rs
+++ b/types/src/v0/impls/block/full_payload/ns_proof/avidm.rs
@@ -192,7 +192,7 @@ impl AvidMNsProofV1 {
 #[cfg(test)]
 mod tests {
     use futures::future;
-    use hotshot::{helpers::initialize_logging, traits::BlockPayload};
+    use hotshot::traits::BlockPayload;
     use hotshot_types::{
         data::VidCommitment,
         traits::EncodeBytes,
@@ -201,7 +201,7 @@ mod tests {
 
     use crate::{v0::impls::block::test::ValidTest, v0_3::AvidMNsProof, NsIndex, Payload};
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn ns_proof() {
         let test_cases = vec![
             vec![
@@ -214,8 +214,6 @@ mod tests {
             vec![vec![1, 2, 3], vec![4, 5, 6]],
             vec![],
         ];
-
-        initialize_logging();
 
         let mut rng = jf_utils::test_rng();
         let mut tests = ValidTest::many_from_tx_lengths(test_cases, &mut rng);

--- a/types/src/v0/impls/block/full_payload/ns_table/test.rs
+++ b/types/src/v0/impls/block/full_payload/ns_table/test.rs
@@ -1,6 +1,5 @@
 use hotshot::traits::BlockPayload;
 use rand::{Rng, RngCore};
-use sequencer_utils::test_utils::setup_test;
 
 use crate::{
     v0::impls::block::{
@@ -15,9 +14,8 @@ use crate::{
     NamespaceId, NsTable, Payload,
 };
 
-#[test]
+#[test_log::test]
 fn random_valid() {
-    setup_test();
     let mut rng = jf_utils::test_rng();
 
     for num_entries in 0..20 {
@@ -25,16 +23,15 @@ fn random_valid() {
     }
 }
 
-#[test]
+#[test_log::test]
 fn ns_table_from_bytes() {
     let bytes = Vec::from([0; NUM_NSS_BYTE_LEN]);
     let ns_table = NsTable::from_bytes_unchecked(&bytes);
     expect_valid(&ns_table);
 }
 
-#[test]
+#[test_log::test]
 fn ns_table_byte_len() {
-    setup_test();
     let mut rng = jf_utils::test_rng();
 
     // Extremely small byte lengths should get rejected.
@@ -67,9 +64,8 @@ fn ns_table_byte_len() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn payload_byte_len() {
-    setup_test();
     let test_case = vec![vec![5, 8, 8], vec![7, 9, 11], vec![10, 5, 8]];
     let mut rng = jf_utils::test_rng();
     let test = ValidTest::from_tx_lengths(test_case, &mut rng);
@@ -130,10 +126,8 @@ async fn payload_byte_len() {
     );
 }
 
-#[test]
+#[test_log::test]
 fn monotonic_increase() {
-    setup_test();
-
     // Duplicate namespace ID
     two_entries_ns_table((5, 5), (5, 6), Some(DuplicateNamespaceId));
 
@@ -172,9 +166,8 @@ fn monotonic_increase() {
 
 // TODO this test obsolete after
 // https://github.com/EspressoSystems/espresso-sequencer/issues/1604
-#[test]
+#[test_log::test]
 fn header() {
-    setup_test();
     let mut rng = jf_utils::test_rng();
 
     for num_entries in 0..20 {

--- a/types/src/v0/impls/block/namespace_payload/ns_payload/test.rs
+++ b/types/src/v0/impls/block/namespace_payload/ns_payload/test.rs
@@ -1,13 +1,10 @@
-use hotshot::helpers::initialize_logging;
-
 use crate::{
     v0::impls::block::{usize_max_from_byte_len, usize_to_bytes},
     NamespaceId, NsPayloadBuilder, NsPayloadOwned,
 };
 
-#[test]
+#[test_log::test]
 fn ns_payload_len() {
-    initialize_logging();
     let ns_id = NamespaceId::from(69_u32); // dummy
 
     // ordinary valid ns_payload
@@ -94,10 +91,8 @@ fn ns_payload_len() {
     }
 }
 
-#[test]
+#[test_log::test]
 fn negative_len_txs() {
-    initialize_logging();
-
     let ns_id = NamespaceId::from(69_u32); // dummy
 
     // 1 negative-length tx at the end, no overlapping tx bytes
@@ -162,10 +157,8 @@ fn negative_len_txs() {
     }
 }
 
-#[test]
+#[test_log::test]
 fn negative_len_txs_and_abnormal_payload_len() {
-    initialize_logging();
-
     let ns_id = NamespaceId::from(69_u32); // dummy
 
     // 1 negative-length tx in the middle, overlapping tx bytes
@@ -237,10 +230,8 @@ fn negative_len_txs_and_abnormal_payload_len() {
     }
 }
 
-#[test]
+#[test_log::test]
 fn tx_table_header() {
-    initialize_logging();
-
     let ns_id = NamespaceId::from(69_u32); // dummy
 
     // header declares 1 fewer txs, tx table bytes appear in tx payloads, wasted

--- a/types/src/v0/impls/block/test.rs
+++ b/types/src/v0/impls/block/test.rs
@@ -6,21 +6,18 @@ use hotshot_query_service::availability::QueryablePayload;
 use hotshot_types::{data::VidCommitment, traits::EncodeBytes, vid::advz::advz_scheme};
 use jf_vid::VidScheme;
 use rand::RngCore;
-use sequencer_utils::test_utils::setup_test;
 
 use crate::{
     v0_1::ADVZNsProof, v0_3::ChainConfig, BlockSize, NamespaceId, NodeState, Payload, Transaction,
     TxProof, ValidatedState,
 };
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn basic_correctness() {
     // play with this
     let test_cases = vec![
         vec![vec![5, 8, 8], vec![7, 9, 11], vec![10, 5, 8]], // 3 non-empty namespaces
     ];
-
-    setup_test();
     let mut rng = jf_utils::test_rng();
     let valid_tests = ValidTest::many_from_tx_lengths(test_cases, &mut rng);
 
@@ -105,9 +102,8 @@ async fn basic_correctness() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn enforce_max_block_size() {
-    setup_test();
     let test_case = vec![vec![5, 8, 8], vec![7, 9, 11], vec![10, 5, 8]];
     let payload_byte_len_expected: usize = 119;
     let ns_table_byte_len_expected: usize = 28;

--- a/types/src/v0/impls/header.rs
+++ b/types/src/v0/impls/header.rs
@@ -1163,7 +1163,6 @@ mod test_headers {
     };
     use hotshot_query_service::testing::mocks::MockVersions;
     use hotshot_types::traits::signature_key::BuilderSignatureKey;
-    use sequencer_utils::test_utils::setup_test;
     use v0_1::{BlockMerkleTree, FeeMerkleTree, L1Client};
     use vbs::{bincode_serializer::BincodeSerializer, version::StaticVersion, BinarySerializer};
 
@@ -1201,8 +1200,6 @@ mod test_headers {
 
     impl TestCase {
         async fn run(self) {
-            setup_test();
-
             // Check test case validity.
             assert!(self.expected_timestamp >= self.parent_timestamp);
             assert!(self.expected_timestamp_millis >= self.parent_timestamp_millis);
@@ -1306,13 +1303,13 @@ mod test_headers {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header() {
         // Simplest case: building on genesis, L1 info and timestamp unchanged.
         TestCase::default().run().await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header_advance_timestamp() {
         TestCase {
             timestamp: 1,
@@ -1325,7 +1322,7 @@ mod test_headers {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header_advance_l1_block() {
         TestCase {
             parent_l1_head: 0,
@@ -1343,7 +1340,7 @@ mod test_headers {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header_advance_l1_finalized_from_none() {
         TestCase {
             l1_finalized: Some(l1_block(1)),
@@ -1354,7 +1351,7 @@ mod test_headers {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header_timestamp_behind_finalized_l1_block() {
         let l1_finalized = Some(L1BlockInfo {
             number: 1,
@@ -1378,7 +1375,7 @@ mod test_headers {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header_timestamp_behind() {
         TestCase {
             parent_timestamp: 1,
@@ -1394,7 +1391,7 @@ mod test_headers {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header_l1_head_behind() {
         TestCase {
             parent_l1_head: 1,
@@ -1407,7 +1404,7 @@ mod test_headers {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header_l1_finalized_behind_some() {
         TestCase {
             parent_l1_finalized: Some(l1_block(1)),
@@ -1420,7 +1417,7 @@ mod test_headers {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header_l1_finalized_behind_none() {
         TestCase {
             parent_l1_finalized: Some(l1_block(0)),
@@ -1433,7 +1430,7 @@ mod test_headers {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header_deposits_one() {
         TestCase {
             l1_deposits: vec![FeeInfo::new(Address::default(), 1)],
@@ -1443,7 +1440,7 @@ mod test_headers {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_new_header_deposits_many() {
         TestCase {
             l1_deposits: [
@@ -1487,10 +1484,8 @@ mod test_headers {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_proposal_validation_success() {
-        setup_test();
-
         let anvil = Anvil::new().block_time(1u64).spawn();
         let mut genesis_state = NodeState::mock()
             .with_l1(L1Client::new(vec![anvil.endpoint_url()]).expect("Failed to create L1 client"))
@@ -1591,7 +1586,7 @@ mod test_headers {
         // );
     }
 
-    #[test]
+    #[test_log::test]
     fn verify_builder_signature() {
         // simulate a fixed size hash by padding our message
         let message = ";)";
@@ -1605,10 +1600,8 @@ mod test_headers {
             .validate_builder_signature(&signature, &commitment));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_versioned_header_serialization() {
-        setup_test();
-
         let genesis = GenesisForTest::default().await;
         let header = genesis.header.clone();
         let ns_table = genesis.ns_table;

--- a/types/src/v0/impls/l1.rs
+++ b/types/src/v0/impls/l1.rs
@@ -1119,7 +1119,6 @@ mod test {
     };
     use espresso_contract_deployer::{deploy_fee_contract_proxy, Contracts};
     use portpicker::pick_unused_port;
-    use sequencer_utils::test_utils::setup_test;
     use time::OffsetDateTime;
 
     use super::*;
@@ -1153,9 +1152,8 @@ mod test {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_get_finalized_deposits() -> anyhow::Result<()> {
-        setup_test();
         let num_deposits = 5;
 
         let anvil = Anvil::new().spawn();
@@ -1250,8 +1248,6 @@ mod test {
     }
 
     async fn test_wait_for_finalized_block_helper(ws: bool) {
-        setup_test();
-
         let anvil = Arc::new(Anvil::new().block_time_f64(0.1).spawn());
         let l1_client = new_l1_client(&anvil, ws).await;
         let provider = &l1_client.provider;
@@ -1276,19 +1272,17 @@ mod test {
         assert_eq!(block.hash, true_block.header.hash);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_wait_for_finalized_block_ws() {
         test_wait_for_finalized_block_helper(true).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_wait_for_finalized_block_http() {
         test_wait_for_finalized_block_helper(false).await
     }
 
     async fn test_wait_for_old_finalized_block_helper(ws: bool) {
-        setup_test();
-
         let anvil = Arc::new(Anvil::new().block_time_f64(0.2).spawn());
         let l1_client = new_l1_client_opt(&anvil, |opt| {
             if ws {
@@ -1310,19 +1304,17 @@ mod test {
         assert_eq!(block.hash, true_block.header.hash);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_wait_for_old_finalized_block_ws() {
         test_wait_for_old_finalized_block_helper(true).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_wait_for_old_finalized_block_http() {
         test_wait_for_old_finalized_block_helper(false).await
     }
 
     async fn test_wait_for_finalized_block_by_timestamp_helper(ws: bool) {
-        setup_test();
-
         let anvil = Arc::new(Anvil::new().block_time_f64(0.2).spawn());
         let l1_client = new_l1_client(&anvil, ws).await;
         let provider = &l1_client.provider;
@@ -1363,19 +1355,17 @@ mod test {
         assert_eq!(block.hash, true_block.header.hash);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_wait_for_finalized_block_by_timestamp_ws() {
         test_wait_for_finalized_block_by_timestamp_helper(true).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_wait_for_finalized_block_by_timestamp_http() {
         test_wait_for_finalized_block_by_timestamp_helper(false).await
     }
 
     async fn test_wait_for_old_finalized_block_by_timestamp_helper(ws: bool) {
-        setup_test();
-
         let anvil = Arc::new(Anvil::new().block_time_f64(0.2).spawn());
         let l1_client = new_l1_client(&anvil, ws).await;
 
@@ -1393,19 +1383,17 @@ mod test {
         assert_eq!(block, true_block);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_wait_for_old_finalized_block_by_timestamp_ws() {
         test_wait_for_old_finalized_block_by_timestamp_helper(true).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_wait_for_old_finalized_block_by_timestamp_http() {
         test_wait_for_old_finalized_block_by_timestamp_helper(false).await
     }
 
     async fn test_wait_for_block_helper(ws: bool) {
-        setup_test();
-
         let anvil = Arc::new(Anvil::new().block_time_f64(0.1).spawn());
         let l1_client = new_l1_client(&anvil, ws).await;
         let provider = &l1_client.provider;
@@ -1422,19 +1410,17 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_wait_for_block_ws() {
         test_wait_for_block_helper(true).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_wait_for_block_http() {
         test_wait_for_block_helper(false).await
     }
 
     async fn test_reconnect_update_task_helper(ws: bool) {
-        setup_test();
-
         let port = pick_unused_port().unwrap();
         let anvil = Arc::new(Anvil::new().block_time(1).port(port).spawn());
         let client = new_l1_client(&anvil, ws).await;
@@ -1488,19 +1474,18 @@ mod test {
         tracing::info!(?final_state, "state updated");
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_reconnect_update_task_ws() {
         test_reconnect_update_task_helper(true).await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_reconnect_update_task_http() {
         test_reconnect_update_task_helper(false).await
     }
 
-    // #[tokio::test]
+    // #[test_log::test(tokio::test(flavor = "multi_thread"))]
     // async fn test_fetch_stake_table() -> anyhow::Result<()> {
-    //     setup_test();
 
     //     let anvil = Anvil::new().spawn();
     //     let wallet = anvil.wallet().unwrap();
@@ -1544,8 +1529,6 @@ mod test {
     }
 
     async fn test_failover_update_task_helper(ws: bool) {
-        setup_test();
-
         let anvil = Anvil::new().block_time(1).spawn();
 
         // Create an L1 client with fake providers, and check that the state is still updated after
@@ -1592,20 +1575,18 @@ mod test {
         tracing::info!(?updated_state, "state updated");
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_failover_update_task_ws() {
         test_failover_update_task_helper(true).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_failover_update_task_http() {
         test_failover_update_task_helper(false).await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_failover_consecutive_failures() {
-        setup_test();
-
         let anvil = Anvil::new().block_time(1).spawn();
 
         let l1_options = L1ClientOptions {
@@ -1636,10 +1617,8 @@ mod test {
         provider.get_block_number().await.unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_failover_frequent_failures() {
-        setup_test();
-
         let anvil = Anvil::new().block_time(1).spawn();
         let provider = L1ClientOptions {
             l1_polling_interval: Duration::from_secs(1),
@@ -1670,10 +1649,8 @@ mod test {
         assert!(get_failover_index(&provider) == 1);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_failover_revert() {
-        setup_test();
-
         let anvil = Anvil::new().block_time(1).spawn();
         let provider = L1ClientOptions {
             l1_polling_interval: Duration::from_secs(1),
@@ -1702,9 +1679,8 @@ mod test {
     // Checks that the L1 client initialized the state on startup even
     // if the L1 is not currently mining blocks. It's useful for testing that we
     // don't require an L1 that is continuously mining blocks.
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_update_loop_initializes_l1_state() {
-        setup_test();
         let anvil = Arc::new(Anvil::new().port(9988u16).spawn());
         let l1_client = new_l1_client(&anvil, true).await;
 

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -2421,14 +2421,12 @@ mod tests {
     use hotshot_contract_adapter::stake_table::StakeTableContractVersion;
     use pretty_assertions::assert_matches;
     use rstest::rstest;
-    use sequencer_utils::test_utils::setup_test;
 
     use super::*;
     use crate::{v0::impls::testing::*, L1ClientOptions};
 
-    #[test]
+    #[test_log::test]
     fn test_from_l1_events() -> anyhow::Result<()> {
-        setup_test();
         // Build a stake table with one DA node and one consensus node.
         let val_1 = TestValidator::random();
         let val_1_new_keys = val_1.randomize_keys();
@@ -2905,10 +2903,8 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_decaf_stake_table() {
-        setup_test();
-
         // The following commented-out block demonstrates how the `decaf_stake_table_events.json`
         // and `decaf_stake_table.json` files were originally generated.
 
@@ -2965,11 +2961,9 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     #[should_panic]
     async fn test_large_max_events_range_panic() {
-        setup_test();
-
         // decaf stake table contract address
         let contract_address = "0x40304fbe94d5e7d1492dd90c53a2d63e8506a037";
 
@@ -2995,10 +2989,8 @@ mod tests {
         .await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn sanity_check_block_reward_v3() {
-        setup_test();
-
         // 10b tokens
         let initial_supply = U256::from_str("10000000000000000000000000000").unwrap();
 

--- a/types/src/v0/impls/state.rs
+++ b/types/src/v0/impls/state.rs
@@ -1266,7 +1266,7 @@ impl MerklizedState<SeqTypes, { Self::ARITY }> for RewardMerkleTreeV1 {
 
 #[cfg(test)]
 mod test {
-    use hotshot::{helpers::initialize_logging, traits::BlockPayload};
+    use hotshot::traits::BlockPayload;
     use hotshot_query_service::{testing::mocks::MockVersions, Resolvable};
     use hotshot_types::traits::signature_key::BuilderSignatureKey;
     use sequencer_utils::ser::FromStringOrInteger;
@@ -1401,10 +1401,8 @@ mod test {
         }
     }
 
-    #[test]
+    #[test_log::test]
     fn test_fee_proofs() {
-        initialize_logging();
-
         let mut tree = ValidatedState::default().fee_merkle_tree;
         let account1 = Address::random();
         let account2 = Address::default();
@@ -1439,10 +1437,8 @@ mod test {
         FeeAccountProof::prove(&tree, account2).unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_l1_head() {
-        initialize_logging();
-
         // Setup.
         let tx = Transaction::of_size(10);
         let (header, block_size) = tx.into_mock_header().await;
@@ -1461,10 +1457,8 @@ mod test {
         assert_eq!(ProposalValidationError::DecrementingL1Head, err);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_builder_fee() {
-        initialize_logging();
-
         // Setup.
         let instance = NodeState::mock();
         let tx = Transaction::of_size(20);
@@ -1492,10 +1486,8 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_chain_config() {
-        initialize_logging();
-
         // Setup.
         let instance = NodeState::mock();
         let tx = Transaction::of_size(20);
@@ -1528,9 +1520,8 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_max_block_size() {
-        initialize_logging();
         const MAX_BLOCK_SIZE: usize = 10;
 
         // Setup.
@@ -1565,9 +1556,8 @@ mod test {
             .unwrap()
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_base_fee() {
-        initialize_logging();
         // Setup
         let tx = Transaction::of_size(20);
         let (header, block_size) = tx.into_mock_header().await;
@@ -1594,9 +1584,8 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_height() {
-        initialize_logging();
         // Setup
         let instance = NodeState::mock_v2();
         let tx = Transaction::of_size(10);
@@ -1627,9 +1616,8 @@ mod test {
             .unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_timestamp_non_dec() {
-        initialize_logging();
         let tx = Transaction::of_size(10);
         let (parent, block_size) = tx.into_mock_header().await;
 
@@ -1653,9 +1641,8 @@ mod test {
         proposal.validate_timestamp_non_dec(0).unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_timestamp_drift() {
-        initialize_logging();
         // Setup
         let instance = NodeState::mock_v2();
         let (parent, block_size) = Transaction::of_size(10).into_mock_header().await;
@@ -1715,9 +1702,8 @@ mod test {
         proposal.validate_timestamp_drift(timestamp).unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_fee_root() {
-        initialize_logging();
         // Setup
         let instance = NodeState::mock_v2();
         let (header, block_size) = Transaction::of_size(10).into_mock_header().await;
@@ -1750,9 +1736,8 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_block_root() {
-        initialize_logging();
         // Setup.
         let instance = NodeState::mock_v2();
         let (header, block_size) = Transaction::of_size(10).into_mock_header().await;
@@ -1785,11 +1770,9 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_ns_table() {
         use NsTableValidationError::InvalidFinalOffset;
-
-        initialize_logging();
         // Setup.
         let tx = Transaction::of_size(10);
         let (header, block_size) = tx.into_mock_header().await;
@@ -1814,9 +1797,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn test_charge_fee() {
-        initialize_logging();
         let src = FeeAccount::generated_from_seed_indexed([0; 32], 0).0;
         let dst = FeeAccount::generated_from_seed_indexed([0; 32], 1).0;
         let amt = FeeAmount::from(1);
@@ -1917,9 +1899,8 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validate_builder_fee() {
-        initialize_logging();
         let max_block_size = 10;
 
         let validated_state = ValidatedState::default();

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -27,5 +27,8 @@ toml = { workspace = true }
 tracing = "0.1.37"
 url = "2.3.1"
 
+[dev-dependencies]
+test-log = { workspace = true }
+
 [lints]
 workspace = true

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -126,7 +126,6 @@ mod test {
     use alloy::{primitives::I256, sol};
     use anyhow::Result;
     use committable::RawCommitmentBuilder;
-    use test_utils::setup_test;
 
     use super::*;
 
@@ -186,9 +185,8 @@ mod test {
         );
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_contract_send() -> Result<()> {
-        setup_test();
         let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let contract = CounterWithError::deploy(provider.clone()).await?;
 

--- a/utils/src/test_utils.rs
+++ b/utils/src/test_utils.rs
@@ -1,3 +1,1 @@
-pub fn setup_test() {
-    super::logging::Config::from_env().init();
-}
+


### PR DESCRIPTION
Currently when running tests with `cargo` (not nextest) all the tracing logs spam the test output.

Use test-log crate that solves this problem

- hotshot tests: initialize_logging -> test_log
- sequencer: setup_test -> test_log

With this change capturing works again and you won't get any logs output on a normal run unless tests fail. To see logs use `--nocapture`.


```
$  cargo test -p espresso-types -- v0::impls::block::test::enforce_max_block_size --nocapture
    Finished `test` profile [optimized + debuginfo] target(s) in 1.00s
     Running unittests src/lib.rs (target/nix/debug/deps/espresso_types-4b5902f288820fe9)

running 1 test
2025-08-04T11:03:24.301193Z  WARN espresso_types::v0::impls::block::full_payload::payload: transactions truncated to fit in maximum block byte length 118
test v0::impls::block::test::enforce_max_block_size ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 147 filtered out; finished in 0.00s
```

Without `--nocapture` we don't get the WARN log

```
$  cargo test -p espresso-types -- v0::impls::block::test::enforce_max_block_size
    Finished `test` profile [optimized + debuginfo] target(s) in 0.44s
     Running unittests src/lib.rs (target/nix/debug/deps/espresso_types-4b5902f288820fe9)

running 1 test
test v0::impls::block::test::enforce_max_block_size ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 147 filtered out; finished in 0.00s
```

To check that we don't lose any tests the diff of `cargo nextest list` w.r.t. `main`

```
diff test_list_main.txt test_list_head.txt
452,465c452,465
<     api::fs::generic_tests::catchup_test_with_query_module
<     api::fs::generic_tests::state_signature_test_with_query_module
<     api::fs::generic_tests::status_test_with_query_module
<     api::fs::generic_tests::submit_test_with_query_module
<     api::fs::generic_tests::test_decide_missing_data
<     api::fs::generic_tests::test_namespace_query
<     api::fs::generic_tests::test_non_consecutive_decide_with_failing_event_consumer
<     api::sql::generic_tests::catchup_test_with_query_module
<     api::sql::generic_tests::state_signature_test_with_query_module
<     api::sql::generic_tests::status_test_with_query_module
<     api::sql::generic_tests::submit_test_with_query_module
<     api::sql::generic_tests::test_decide_missing_data
<     api::sql::generic_tests::test_namespace_query
<     api::sql::generic_tests::test_non_consecutive_decide_with_failing_event_consumer
---
>     api::api_tests::catchup_test_with_query_module::case_1
>     api::api_tests::catchup_test_with_query_module::case_2
>     api::api_tests::state_signature_test_with_query_module::case_1
>     api::api_tests::state_signature_test_with_query_module::case_2
>     api::api_tests::status_test_with_query_module::case_1
>     api::api_tests::status_test_with_query_module::case_2
>     api::api_tests::submit_test_with_query_module::case_1
>     api::api_tests::submit_test_with_query_module::case_2
>     api::api_tests::test_decide_missing_data::case_1
>     api::api_tests::test_decide_missing_data::case_2
>     api::api_tests::test_namespace_query::case_1
>     api::api_tests::test_namespace_query::case_2
>     api::api_tests::test_non_consecutive_decide_with_failing_event_consumer::case_1
>     api::api_tests::test_non_consecutive_decide_with_failing_event_consumer::case_2
```