### PR TITLE
feat: staking-cli export signed node signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,6 +1349,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2185,17 @@ checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2 0.10.9",
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.9",
+ "serde",
 ]
 
 [[package]]
@@ -3750,6 +3777,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4682,6 +4715,15 @@ checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -8289,6 +8331,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07626f57b1cb0ee81e5193d331209751d2e18ffa3ceaa0fd6fab63db31fafd9"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9083,6 +9131,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -11384,6 +11462,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "ark-serialize 0.4.2",
+ "assert_cmd",
  "clap 4.5.39",
  "clap-serde",
  "clap-serde-derive",
@@ -11399,6 +11478,7 @@ dependencies = [
  "hotshot-types",
  "jf-signature 0.2.0",
  "portpicker",
+ "predicates",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rstest",
@@ -11406,6 +11486,7 @@ dependencies = [
  "rust_decimal",
  "sequencer-utils",
  "serde",
+ "serde_json",
  "sysinfo",
  "tagged-base64",
  "tempfile",
@@ -11872,6 +11953,12 @@ dependencies = [
  "rustversion",
  "winapi",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-log"

--- a/contracts/rust/adapter/src/stake_table.rs
+++ b/contracts/rust/adapter/src/stake_table.rs
@@ -7,11 +7,12 @@ use ark_ec::{AffineRepr, CurveGroup as _};
 use ark_ed_on_bn254::EdwardsConfig;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use hotshot_types::{
-    light_client::{hash_bytes_to_field, StateKeyPair, StateVerKey},
+    light_client::{hash_bytes_to_field, StateKeyPair, StateSignature, StateVerKey},
     signature_key::{BLSKeyPair, BLSPubKey, BLSSignature},
     traits::signature_key::SignatureKey,
 };
 use jf_signature::{
+    bls_over_bn254,
     constants::{CS_ID_BLS_BN254, CS_ID_SCHNORR},
     schnorr,
 };
@@ -20,6 +21,10 @@ use crate::sol_types::{
     StakeTableV2::{getVersionReturn, ConsensusKeysUpdatedV2, ValidatorRegisteredV2},
     *,
 };
+
+// Allows us to implement From on existing Bytes type
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateSignatureSol(pub Bytes);
 
 #[derive(Debug, Clone, Copy, Default)]
 pub enum StakeTableContractVersion {
@@ -52,6 +57,12 @@ impl From<G2PointSol> for BLSPubKey {
     }
 }
 
+impl From<BLSPubKey> for G2PointSol {
+    fn from(value: BLSPubKey) -> Self {
+        value.to_affine().into()
+    }
+}
+
 impl From<EdOnBN254PointSol> for StateVerKey {
     fn from(value: EdOnBN254PointSol) -> Self {
         let point: ark_ed_on_bn254::EdwardsAffine = value.into();
@@ -59,50 +70,60 @@ impl From<EdOnBN254PointSol> for StateVerKey {
     }
 }
 
-pub fn sign_address_bls(bls_key_pair: &BLSKeyPair, address: Address) -> G1PointSol {
-    bls_key_pair
-        .sign(&address.abi_encode(), CS_ID_BLS_BN254)
-        .sigma
-        .into_affine()
-        .into()
+impl From<bls_over_bn254::Signature> for G1PointSol {
+    fn from(sig: bls_over_bn254::Signature) -> Self {
+        sig.sigma.into_affine().into()
+    }
 }
 
-pub fn sign_address_schnorr(schnorr_key_pair: &StateKeyPair, address: Address) -> Bytes {
+impl From<StateVerKey> for EdOnBN254PointSol {
+    fn from(ver_key: StateVerKey) -> Self {
+        ver_key.to_affine().into()
+    }
+}
+
+impl From<StateSignature> for StateSignatureSol {
+    fn from(sig: StateSignature) -> Self {
+        let mut buf = vec![];
+        sig.serialize_compressed(&mut buf).expect("serialize works");
+        Self(buf.into())
+    }
+}
+
+impl From<StateSignatureSol> for Bytes {
+    fn from(sig_sol: StateSignatureSol) -> Self {
+        sig_sol.0
+    }
+}
+
+pub fn sign_address_bls(bls_key_pair: &BLSKeyPair, address: Address) -> bls_over_bn254::Signature {
+    bls_key_pair.sign(&address.abi_encode(), CS_ID_BLS_BN254)
+}
+
+pub fn sign_address_schnorr(schnorr_key_pair: &StateKeyPair, address: Address) -> StateSignature {
     let msg = [hash_bytes_to_field(&address.abi_encode()).expect("hash to field works")];
-    let mut buf = vec![];
-    schnorr_key_pair
-        .sign(&msg, CS_ID_SCHNORR)
-        .serialize_compressed(&mut buf)
-        .expect("serialize works");
-    buf.into()
+    schnorr_key_pair.sign(&msg, CS_ID_SCHNORR)
 }
 
-// Helper function useful for unit tests.
-fn authenticate_schnorr_sig(
+/// Authenticate a Schnorr signature over an Ethereum address
+pub fn authenticate_schnorr_sig(
     schnorr_vk: &StateVerKey,
     address: Address,
-    schnorr_sig: &[u8],
+    schnorr_sig: &StateSignature,
 ) -> Result<(), StakeTableSolError> {
     let msg = [hash_bytes_to_field(&address.abi_encode()).expect("hash to field works")];
-    let sig = schnorr::Signature::<EdwardsConfig>::deserialize_compressed(schnorr_sig)?;
-    schnorr_vk.verify(&msg, &sig, CS_ID_SCHNORR)?;
+    schnorr_vk.verify(&msg, schnorr_sig, CS_ID_SCHNORR)?;
     Ok(())
 }
 
-// Helper function useful for unit tests.
-fn authenticate_bls_sig(
+/// Authenticate a BLS signature over an Ethereum address
+pub fn authenticate_bls_sig(
     bls_vk: &BLSPubKey,
     address: Address,
-    bls_sig: &G1PointSol,
+    bls_sig: &BLSSignature,
 ) -> Result<(), StakeTableSolError> {
     let msg = address.abi_encode();
-    let sig = {
-        let sigma_affine: ark_bn254::G1Affine = (*bls_sig).into();
-        BLSSignature {
-            sigma: sigma_affine.into_group(),
-        }
-    };
-    if !bls_vk.validate(&sig, &msg) {
+    if !bls_vk.validate(bls_sig, &msg) {
         return Err(StakeTableSolError::InvalidBlsSignature);
     }
     Ok(())
@@ -125,10 +146,18 @@ fn authenticate_stake_table_validator_event(
         bls_vk_inner.serialize_uncompressed(&mut ser_bytes).unwrap();
         BLSPubKey::deserialize_uncompressed(&ser_bytes[..]).unwrap()
     };
-    authenticate_bls_sig(&bls_vk, account, &bls_sig)?;
+    let bls_sig_jellyfish = {
+        let sigma_affine: ark_bn254::G1Affine = bls_sig.into();
+        BLSSignature {
+            sigma: sigma_affine.into_group(),
+        }
+    };
+    authenticate_bls_sig(&bls_vk, account, &bls_sig_jellyfish)?;
 
     let schnorr_vk: StateVerKey = schnorr_vk.into();
-    authenticate_schnorr_sig(&schnorr_vk, account, schnorr_sig)?;
+    let schnorr_sig_jellyfish =
+        schnorr::Signature::<EdwardsConfig>::deserialize_compressed(schnorr_sig)?;
+    authenticate_schnorr_sig(&schnorr_vk, account, &schnorr_sig_jellyfish)?;
     Ok(())
 }
 
@@ -173,20 +202,21 @@ impl ConsensusKeysUpdatedV2 {
 
 #[cfg(test)]
 mod test {
-    use alloy::primitives::{Address, U256};
+    use alloy::primitives::Address;
     use hotshot_types::{
         light_client::StateKeyPair,
         signature_key::{BLSKeyPair, BLSPrivKey, BLSPubKey},
     };
 
-    use super::{
-        authenticate_bls_sig, authenticate_schnorr_sig, sign_address_bls, sign_address_schnorr,
+    use super::{sign_address_bls, sign_address_schnorr, StateSignatureSol};
+    use crate::sol_types::{
+        G1PointSol, G2PointSol,
+        StakeTableV2::{ConsensusKeysUpdatedV2, ValidatorRegisteredV2},
     };
-    use crate::sol_types::G2PointSol;
 
     fn check_round_trip(pk: BLSPubKey) {
-        let g2: G2PointSol = pk.to_affine().into();
-        let pk2: BLSPubKey = g2.into();
+        let g2 = G2PointSol::from(pk);
+        let pk2 = BLSPubKey::from(g2);
         assert_eq!(pk2, pk, "Failed to roundtrip G2PointSol to BLSPubKey: {pk}");
     }
 
@@ -208,42 +238,67 @@ mod test {
     }
 
     #[test]
-    fn test_schnorr_sigs() {
+    fn test_validator_registered_event_authentication() {
         for _ in 0..10 {
-            let key_pair = StateKeyPair::generate();
+            let bls_key_pair = BLSKeyPair::generate(&mut rand::thread_rng());
+            let schnorr_key_pair = StateKeyPair::generate();
             let address = Address::random();
-            let sig = sign_address_schnorr(&key_pair, address);
-            authenticate_schnorr_sig(key_pair.ver_key_ref(), address, &sig).unwrap();
 
-            // signed with wrong key
-            let sig = sign_address_schnorr(&StateKeyPair::generate(), address);
-            assert!(authenticate_schnorr_sig(key_pair.ver_key_ref(), address, &sig).is_err());
+            let bls_sig = sign_address_bls(&bls_key_pair, address);
+            let schnorr_sig = sign_address_schnorr(&schnorr_key_pair, address);
 
-            // manipulate one byte
-            let mut bad_sig: Vec<u8> = sig.to_vec();
-            bad_sig[0] = bad_sig[0].wrapping_add(1);
-            assert!(authenticate_schnorr_sig(key_pair.ver_key_ref(), address, &bad_sig).is_err());
+            let valid_event = ValidatorRegisteredV2 {
+                account: address,
+                blsVK: bls_key_pair.ver_key().into(),
+                schnorrVK: schnorr_key_pair.ver_key().into(),
+                commission: 1000, // 10%
+                blsSig: G1PointSol::from(bls_sig.clone()).into(),
+                schnorrSig: StateSignatureSol::from(schnorr_sig.clone()).into(),
+            };
+            assert!(valid_event.authenticate().is_ok());
+
+            let wrong_bls_sig =
+                sign_address_bls(&BLSKeyPair::generate(&mut rand::thread_rng()), address);
+            let mut bad_bls_event = valid_event.clone();
+            bad_bls_event.blsSig = G1PointSol::from(wrong_bls_sig).into();
+            assert!(bad_bls_event.authenticate().is_err());
+
+            let wrong_schnorr_sig = sign_address_schnorr(&StateKeyPair::generate(), address);
+            let mut bad_schnorr_event = valid_event.clone();
+            bad_schnorr_event.schnorrSig = StateSignatureSol::from(wrong_schnorr_sig).into();
+            assert!(bad_schnorr_event.authenticate().is_err());
         }
     }
 
     #[test]
-    fn test_bls_sigs() {
-        let key_pair = BLSKeyPair::generate(&mut rand::thread_rng());
-        let address = Address::random();
-        let sig = sign_address_bls(&key_pair, address);
-        authenticate_bls_sig(key_pair.ver_key_ref(), address, &sig).unwrap();
+    fn test_consensus_keys_updated_event_authentication() {
+        for _ in 0..10 {
+            let bls_key_pair = BLSKeyPair::generate(&mut rand::thread_rng());
+            let schnorr_key_pair = StateKeyPair::generate();
+            let address = Address::random();
 
-        // signed with wrong key
-        assert!(authenticate_bls_sig(
-            key_pair.ver_key_ref(),
-            address,
-            &sign_address_bls(&BLSKeyPair::generate(&mut rand::thread_rng()), address)
-        )
-        .is_err());
+            let bls_sig = sign_address_bls(&bls_key_pair, address);
+            let schnorr_sig = sign_address_schnorr(&schnorr_key_pair, address);
 
-        // tamper with the signature
-        let mut sig = sig;
-        sig.x = sig.x.wrapping_add(U256::from(1));
-        assert!(authenticate_bls_sig(key_pair.ver_key_ref(), address, &sig).is_err());
+            let valid_event = ConsensusKeysUpdatedV2 {
+                account: address,
+                blsVK: bls_key_pair.ver_key().into(),
+                schnorrVK: schnorr_key_pair.ver_key().into(),
+                blsSig: G1PointSol::from(bls_sig.clone()).into(),
+                schnorrSig: StateSignatureSol::from(schnorr_sig.clone()).into(),
+            };
+            assert!(valid_event.authenticate().is_ok());
+
+            let wrong_bls_sig =
+                sign_address_bls(&BLSKeyPair::generate(&mut rand::thread_rng()), address);
+            let mut bad_bls_event = valid_event.clone();
+            bad_bls_event.blsSig = G1PointSol::from(wrong_bls_sig).into();
+            assert!(bad_bls_event.authenticate().is_err());
+
+            let wrong_schnorr_sig = sign_address_schnorr(&StateKeyPair::generate(), address);
+            let mut bad_schnorr_event = valid_event.clone();
+            bad_schnorr_event.schnorrSig = StateSignatureSol::from(wrong_schnorr_sig).into();
+            assert!(bad_schnorr_event.authenticate().is_err());
+        }
     }
 }

--- a/staking-cli/Cargo.toml
+++ b/staking-cli/Cargo.toml
@@ -31,6 +31,7 @@ rstest_reuse = { workspace = true }
 rust_decimal = "1.36.0"
 sequencer-utils = { version = "0.1.0", path = "../utils" }
 serde = { workspace = true }
+serde_json.workspace = true
 sysinfo = "0.33.1"
 tagged-base64 = { workspace = true }
 thiserror = { workspace = true }
@@ -41,6 +42,8 @@ tracing-subscriber = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+assert_cmd = "2.0.17"
+predicates = "3.1.3"
 tempfile = { workspace = true }
 test-log = { workspace = true }
 

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -27,6 +27,7 @@ use crate::{
     info::fetch_token_address,
     parse::{parse_bls_priv_key, parse_state_priv_key, Commission},
     registration::register_validator,
+    signature::NodeSignatures,
     Config,
 };
 
@@ -138,13 +139,12 @@ pub async fn setup_stake_table_contract_for_test(
         assert!(receipt.status());
 
         tracing::info!("deploy validator {val_index} with commission {commission}");
+        let payload = NodeSignatures::create(validator_address, &bls_key_pair, &state_key_pair);
         let receipt = register_validator(
             &validator_provider,
             stake_table_address,
             commission,
-            validator_address,
-            bls_key_pair,
-            state_key_pair,
+            payload,
         )
         .await?;
         assert!(receipt.status());

--- a/staking-cli/src/deploy.rs
+++ b/staking-cli/src/deploy.rs
@@ -1,4 +1,4 @@
-use std::{process::Command, time::Duration};
+use std::time::Duration;
 
 use alloy::{
     network::{Ethereum, EthereumWallet, TransactionBuilder as _},
@@ -30,7 +30,10 @@ use hotshot_types::light_client::StateKeyPair;
 use rand::{rngs::StdRng, CryptoRng, Rng as _, RngCore, SeedableRng as _};
 use url::Url;
 
-use crate::{parse::Commission, registration::register_validator, BLSKeyPair, DEV_MNEMONIC};
+use crate::{
+    parse::Commission, registration::register_validator, signature::NodeSignatures, BLSKeyPair,
+    DEV_MNEMONIC,
+};
 
 type TestProvider = FillProvider<
     JoinFill<JoinedRecommendedFillers, WalletFiller<EthereumWallet>>,
@@ -166,15 +169,13 @@ impl TestSystem {
     }
 
     pub async fn register_validator(&self) -> Result<()> {
-        let receipt = register_validator(
-            &self.provider,
-            self.stake_table,
-            self.commission,
+        let payload = NodeSignatures::create(
             self.deployer_address,
-            self.bls_key_pair.clone(),
-            self.state_key_pair.clone(),
-        )
-        .await?;
+            &self.bls_key_pair.clone(),
+            &self.state_key_pair.clone(),
+        );
+        let receipt =
+            register_validator(&self.provider, self.stake_table, self.commission, payload).await?;
         assert!(receipt.status());
         Ok(())
     }
@@ -266,31 +267,6 @@ impl TestSystem {
         assert!(self.allowance(self.deployer_address).await? == amount);
         Ok(())
     }
-
-    /// Inject test system config into CLI command via arguments
-    pub fn args(&self, cmd: &mut Command, signer: Signer) {
-        cmd.arg("--rpc-url")
-            .arg(self.rpc_url.to_string())
-            .arg("--stake-table-address")
-            .arg(self.stake_table.to_string())
-            .arg("--account-index")
-            .arg("0");
-
-        match signer {
-            Signer::Ledger => cmd.arg("--ledger"),
-            Signer::Mnemonic => cmd.arg("--mnemonic").arg(DEV_MNEMONIC),
-            Signer::BrokeMnemonic => cmd
-                .arg("--mnemonic")
-                .arg("roast term reopen pave choose high rally trouble upon govern hollow stand"),
-        };
-    }
-}
-
-#[derive(Clone, Copy)]
-pub enum Signer {
-    Ledger,
-    Mnemonic,
-    BrokeMnemonic,
 }
 
 #[cfg(test)]

--- a/staking-cli/src/lib.rs
+++ b/staking-cli/src/lib.rs
@@ -23,6 +23,7 @@ pub mod info;
 pub mod l1;
 pub mod parse;
 pub mod registration;
+pub mod signature;
 
 pub mod deploy;
 
@@ -204,15 +205,8 @@ pub enum Commands {
     Account,
     /// Register to become a validator.
     RegisterValidator {
-        /// The consensus signing key. Used to sign a message to prove ownership of the key.
-        #[clap(long, value_parser = parse::parse_bls_priv_key, env = "CONSENSUS_PRIVATE_KEY")]
-        consensus_private_key: BLSPrivKey,
-
-        /// The state signing key.
-        ///
-        /// TODO: Used to sign a message to prove ownership of the key.
-        #[clap(long, value_parser = parse::parse_state_priv_key, env = "STATE_PRIVATE_KEY")]
-        state_private_key: StateSignKey,
+        #[clap(flatten)]
+        signature_args: signature::NodeSignatureArgs,
 
         /// The commission to charge delegators
         #[clap(long, value_parser = parse::parse_commission, env = "COMMISSION")]
@@ -220,15 +214,8 @@ pub enum Commands {
     },
     /// Update a validators Espresso consensus signing keys.
     UpdateConsensusKeys {
-        /// The consensus signing key. Used to sign a message to prove ownership of the key.
-        #[clap(long, value_parser = parse::parse_bls_priv_key, env = "CONSENSUS_PRIVATE_KEY")]
-        consensus_private_key: BLSPrivKey,
-
-        /// The state signing key.
-        ///
-        /// TODO: Used to sign a message to prove ownership of the key.
-        #[clap(long, value_parser = parse::parse_state_priv_key, env = "STATE_PRIVATE_KEY")]
-        state_private_key: StateSignKey,
+        #[clap(flatten)]
+        signature_args: signature::NodeSignatureArgs,
     },
     /// Deregister a validator.
     DeregisterValidator {},
@@ -295,5 +282,22 @@ pub enum Commands {
 
         #[arg(long, value_enum, default_value_t = DelegationConfig::default())]
         delegation_config: DelegationConfig,
+    },
+    /// Export validator node signatures for address validation.
+    ExportNodeSignatures {
+        /// The Ethereum address to sign.
+        #[clap(long)]
+        address: Address,
+
+        /// The BLS private key for signing.
+        #[clap(long, value_parser = parse::parse_bls_priv_key, env = "BLS_PRIVATE_KEY")]
+        consensus_private_key: BLSPrivKey,
+
+        /// The Schnorr private key for signing.
+        #[clap(long, value_parser = parse::parse_state_priv_key, env = "SCHNORR_PRIVATE_KEY")]
+        state_private_key: StateSignKey,
+
+        #[clap(flatten)]
+        output_args: signature::OutputArgs,
     },
 }

--- a/staking-cli/src/main.rs
+++ b/staking-cli/src/main.rs
@@ -21,6 +21,7 @@ use staking_cli::{
     demo::stake_for_demo,
     info::{display_stake_table, fetch_token_address, stake_table_info},
     registration::{deregister_validator, register_validator, update_consensus_keys},
+    signature::{NodeSignatureDestination, NodeSignatureInput, NodeSignatures},
     Commands, Config, ValidSignerConfig,
 };
 use sysinfo::System;
@@ -191,6 +192,23 @@ pub async fn main() -> Result<()> {
             println!("Arch: {}", System::cpu_arch());
             return Ok(());
         },
+        Commands::ExportNodeSignatures {
+            address,
+            consensus_private_key,
+            state_private_key,
+            output_args,
+        } => {
+            let destination = NodeSignatureDestination::try_from(output_args)?;
+
+            let payload = NodeSignatures::create(
+                address,
+                &consensus_private_key.into(),
+                &StateKeyPair::from_sign_key(state_private_key),
+            );
+
+            payload.handle_output(destination)?;
+            return Ok(());
+        },
         _ => {}, // Other commands handled after shared setup.
     }
 
@@ -235,7 +253,7 @@ pub async fn main() -> Result<()> {
     };
 
     let provider = ProviderBuilder::new()
-        .wallet(wallet)
+        .wallet(wallet.clone())
         .on_http(config.rpc_url.clone());
     let stake_table_addr = config.stake_table_address;
     let token_addr = fetch_token_address(config.rpc_url.clone(), stake_table_addr).await?;
@@ -277,34 +295,19 @@ pub async fn main() -> Result<()> {
     // Commands that require a signer
     let result = match config.commands {
         Commands::RegisterValidator {
-            consensus_private_key,
-            state_private_key,
+            signature_args,
             commission,
         } => {
             tracing::info!("Registering validator {account} with commission {commission}");
-            register_validator(
-                &provider,
-                stake_table_addr,
-                commission,
-                account,
-                (consensus_private_key).into(),
-                StateKeyPair::from_sign_key(state_private_key),
-            )
-            .await
+            let input = NodeSignatureInput::try_from((signature_args, &wallet))?;
+            let payload = NodeSignatures::try_from((input, &wallet))?;
+            register_validator(&provider, stake_table_addr, commission, payload).await
         },
-        Commands::UpdateConsensusKeys {
-            consensus_private_key,
-            state_private_key,
-        } => {
+        Commands::UpdateConsensusKeys { signature_args } => {
             tracing::info!("Updating validator {account} with new keys");
-            update_consensus_keys(
-                &provider,
-                stake_table_addr,
-                account,
-                (consensus_private_key).into(),
-                StateKeyPair::from_sign_key(state_private_key),
-            )
-            .await
+            let input = NodeSignatureInput::try_from((signature_args, &wallet))?;
+            let payload = NodeSignatures::try_from((input, &wallet))?;
+            update_consensus_keys(&provider, stake_table_addr, payload).await
         },
         Commands::DeregisterValidator {} => {
             tracing::info!("Deregistering validator {account}");

--- a/staking-cli/src/signature.rs
+++ b/staking-cli/src/signature.rs
@@ -1,0 +1,666 @@
+use std::{
+    io::Read as _,
+    path::{Path, PathBuf},
+};
+
+use alloy::{
+    network::{Ethereum, EthereumWallet, NetworkWallet},
+    primitives::Address,
+};
+use anyhow::bail;
+use clap::Args;
+use hotshot_contract_adapter::{
+    sol_types::{EdOnBN254PointSol, G1PointSol, G2PointSol},
+    stake_table::{self, StateSignatureSol},
+};
+use hotshot_types::{
+    light_client::{StateKeyPair, StateSignature, StateVerKey},
+    signature_key::BLSPubKey,
+};
+use jf_signature::bls_over_bn254;
+use serde::{Deserialize, Serialize};
+
+use crate::{parse, BLSKeyPair, BLSPrivKey, StateSignKey};
+
+/// Node signatures containing pre-signed address signatures for validator operations
+///
+/// This is the native rust type.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NodeSignatures {
+    /// The Ethereum address that was signed
+    pub address: Address,
+    /// BLS verification key
+    pub bls_vk: BLSPubKey,
+    /// BLS signature over the address
+    pub bls_signature: bls_over_bn254::Signature,
+    /// Schnorr verification key
+    pub schnorr_vk: StateVerKey,
+    /// Schnorr signature over the address
+    pub schnorr_signature: StateSignature,
+}
+
+/// Only used for serialization to Solidity.
+#[derive(Clone, Debug)]
+pub struct NodeSignaturesSol {
+    /// The Ethereum address that was signed
+    pub address: Address,
+    /// BLS verification key
+    pub bls_vk: G2PointSol,
+    /// BLS signature over the address
+    pub bls_signature: G1PointSol,
+    /// Schnorr verification key
+    pub schnorr_vk: EdOnBN254PointSol,
+    /// Schnorr signature over the address
+    pub schnorr_signature: StateSignatureSol,
+}
+
+/// Represents either keys for signing or a pre-prepared node signature source
+#[allow(clippy::large_enum_variant)]
+pub enum NodeSignatureInput {
+    /// Sign using private keys
+    Keys {
+        address: Address,
+        bls_key_pair: BLSKeyPair,
+        schnorr_key_pair: StateKeyPair,
+    },
+    /// Load from prepared node signature source
+    PreparedPayload(NodeSignatureSource),
+}
+
+/// Serialization formats supported by the CLI
+#[derive(Clone, Debug, Copy, Default, clap::ValueEnum, PartialEq, Eq)]
+pub enum SerializationFormat {
+    #[default]
+    #[value(name = "json")]
+    Json,
+    #[value(name = "toml")]
+    Toml,
+}
+
+/// Source for pre-prepared NodeSignatures
+#[derive(Debug)]
+pub enum NodeSignatureSource {
+    /// Read from stdin with specified format
+    Stdin(SerializationFormat),
+    /// Read from file path with optional format override
+    File {
+        path: PathBuf,
+        format: Option<SerializationFormat>,
+    },
+}
+
+/// Destination for node signature output
+#[derive(Debug)]
+pub enum NodeSignatureDestination {
+    /// Write to stdout with specified format
+    Stdout(SerializationFormat),
+    /// Write to file with specified format
+    File {
+        path: PathBuf,
+        format: SerializationFormat,
+    },
+}
+
+/// Clap arguments for node signature operations
+#[derive(Args, Clone, Debug)]
+pub struct NodeSignatureArgs {
+    /// The consensus signing key. Used to sign a message to prove ownership of the key.
+    #[clap(long, value_parser = parse::parse_bls_priv_key, env = "CONSENSUS_PRIVATE_KEY", required_unless_present = "node_signatures")]
+    pub consensus_private_key: Option<BLSPrivKey>,
+
+    /// The state signing key.
+    #[clap(long, value_parser = parse::parse_state_priv_key, env = "STATE_PRIVATE_KEY", required_unless_present = "node_signatures")]
+    pub state_private_key: Option<StateSignKey>,
+
+    /// Path to file or "-" for stdin (format auto-detected)
+    #[clap(long, required_unless_present_all = ["consensus_private_key", "state_private_key"])]
+    pub node_signatures: Option<PathBuf>,
+
+    /// Input format for stdin (auto-detected for files)
+    #[clap(long, value_enum)]
+    pub format: Option<SerializationFormat>,
+}
+
+/// Clap arguments for output operations
+#[derive(Args, Clone, Debug)]
+pub struct OutputArgs {
+    /// Output file path. If not specified, outputs to stdout
+    #[clap(long)]
+    pub output: Option<PathBuf>,
+
+    /// Output format
+    #[clap(long, value_enum)]
+    pub format: Option<SerializationFormat>,
+}
+
+impl TryFrom<&Path> for SerializationFormat {
+    type Error = anyhow::Error;
+
+    fn try_from(path: &Path) -> anyhow::Result<Self> {
+        let extension = path.extension().and_then(|ext| ext.to_str());
+        match extension {
+            Some("json") => Ok(SerializationFormat::Json),
+            Some("toml") => Ok(SerializationFormat::Toml),
+            _ => anyhow::bail!(
+                "Unsupported extension in path '{}'. Expected .json or .toml",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl From<NodeSignatures> for NodeSignaturesSol {
+    fn from(payload: NodeSignatures) -> Self {
+        Self {
+            address: payload.address,
+            bls_vk: payload.bls_vk.to_affine().into(),
+            bls_signature: payload.bls_signature.into(),
+            schnorr_vk: payload.schnorr_vk.into(),
+            schnorr_signature: StateSignatureSol::from(payload.schnorr_signature).into(),
+        }
+    }
+}
+
+impl NodeSignatures {
+    /// Create NodeSignatures by signing an Ethereum address with BLS and Schnorr keys
+    pub fn create(
+        address: Address,
+        bls_key_pair: &BLSKeyPair,
+        schnorr_key_pair: &StateKeyPair,
+    ) -> Self {
+        let bls_signature = stake_table::sign_address_bls(bls_key_pair, address);
+        let schnorr_signature = stake_table::sign_address_schnorr(schnorr_key_pair, address);
+
+        Self {
+            address,
+            bls_vk: bls_key_pair.ver_key(),
+            bls_signature,
+            schnorr_vk: schnorr_key_pair.ver_key(),
+            schnorr_signature,
+        }
+    }
+
+    /// Verify that the BLS and Schnorr signatures are valid for the given address
+    pub fn verify_signatures(&self, address: Address) -> anyhow::Result<()> {
+        stake_table::authenticate_bls_sig(&self.bls_vk, address, &self.bls_signature)?;
+        stake_table::authenticate_schnorr_sig(&self.schnorr_vk, address, &self.schnorr_signature)?;
+        Ok(())
+    }
+
+    /// Handle output of the payload to the specified destination
+    pub fn handle_output(&self, destination: NodeSignatureDestination) -> anyhow::Result<()> {
+        match destination {
+            NodeSignatureDestination::Stdout(format) => {
+                let output = match format {
+                    SerializationFormat::Json => serde_json::to_string_pretty(self)?,
+                    SerializationFormat::Toml => toml::to_string_pretty(self)?,
+                };
+                println!("{output}");
+            },
+            NodeSignatureDestination::File { path, format } => {
+                let output = match format {
+                    SerializationFormat::Json => serde_json::to_string_pretty(self)?,
+                    SerializationFormat::Toml => toml::to_string_pretty(self)?,
+                };
+                std::fs::write(&path, output)?;
+                tracing::info!("{:?} signatures written to {}", format, path.display());
+            },
+        }
+        Ok(())
+    }
+}
+
+impl NodeSignatureSource {
+    /// Parse NodeSignatureSource from a PathBuf and optional format, where "-" means stdin
+    pub(crate) fn parse(
+        path: PathBuf,
+        format: Option<SerializationFormat>,
+    ) -> anyhow::Result<Self> {
+        if path.to_string_lossy() == "-" {
+            Ok(Self::Stdin(format.unwrap_or_default()))
+        } else {
+            // Infer format from extension if not explicitly provided
+            let format = if let Some(format) = format {
+                Some(format)
+            } else {
+                Some(SerializationFormat::try_from(path.as_path())?)
+            };
+            Ok(Self::File { path, format })
+        }
+    }
+}
+
+impl TryFrom<OutputArgs> for NodeSignatureDestination {
+    type Error = anyhow::Error;
+
+    fn try_from(args: OutputArgs) -> anyhow::Result<Self> {
+        match args.output {
+            None => {
+                let format = args.format.unwrap_or_default();
+                Ok(Self::Stdout(format))
+            },
+            Some(path) => {
+                // Format selection logic:
+                // 1. If format is explicitly specified, use it (allows overrides)
+                // 2. If no format specified, infer from extension
+                let final_format = match args.format {
+                    Some(explicit_format) => explicit_format,
+                    None => SerializationFormat::try_from(path.as_path())?,
+                };
+                Ok(Self::File {
+                    path,
+                    format: final_format,
+                })
+            },
+        }
+    }
+}
+
+impl TryFrom<NodeSignatureSource> for NodeSignatures {
+    type Error = anyhow::Error;
+
+    fn try_from(source: NodeSignatureSource) -> anyhow::Result<Self> {
+        match source {
+            NodeSignatureSource::Stdin(format) => {
+                let mut buffer = String::new();
+                std::io::stdin().read_to_string(&mut buffer)?;
+
+                match format {
+                    SerializationFormat::Json => serde_json::from_str::<Self>(&buffer)
+                        .or_else(|e| bail!("Failed to parse JSON from stdin: {e}")),
+                    SerializationFormat::Toml => toml::from_str::<Self>(&buffer)
+                        .or_else(|e| bail!("Failed to parse TOML from stdin: {e}")),
+                }
+            },
+            NodeSignatureSource::File { path, format } => {
+                let content = std::fs::read_to_string(&path)?;
+
+                let format = match format {
+                    Some(f) => f,
+                    None => SerializationFormat::try_from(path.as_path())?,
+                };
+
+                match format {
+                    SerializationFormat::Json => serde_json::from_str::<Self>(&content)
+                        .or_else(|e| bail!("Failed to parse JSON file {}: {e}", path.display())),
+                    SerializationFormat::Toml => toml::from_str::<Self>(&content)
+                        .or_else(|e| bail!("Failed to parse TOML file {}: {e}", path.display())),
+                }
+            },
+        }
+    }
+}
+
+impl TryFrom<NodeSignatureInput> for NodeSignatures {
+    type Error = anyhow::Error;
+
+    fn try_from(input: NodeSignatureInput) -> anyhow::Result<Self> {
+        match input {
+            NodeSignatureInput::Keys {
+                address,
+                bls_key_pair,
+                schnorr_key_pair,
+            } => Ok(Self::create(address, &bls_key_pair, &schnorr_key_pair)),
+            NodeSignatureInput::PreparedPayload(source) => Self::try_from(source),
+        }
+    }
+}
+
+impl TryFrom<(NodeSignatureArgs, &EthereumWallet)> for NodeSignatureInput {
+    type Error = anyhow::Error;
+
+    fn try_from((args, wallet): (NodeSignatureArgs, &EthereumWallet)) -> anyhow::Result<Self> {
+        let wallet_address =
+            <EthereumWallet as NetworkWallet<Ethereum>>::default_signer_address(wallet);
+
+        if let Some(sig_path) = args.node_signatures {
+            let source = NodeSignatureSource::parse(sig_path, args.format)?;
+            Ok(Self::PreparedPayload(source))
+        } else {
+            let Some(bls_key) = args.consensus_private_key else {
+                bail!("consensus_private_key is required when not using node_signatures")
+            };
+            let Some(state_key) = args.state_private_key else {
+                bail!("state_private_key is required when not using node_signatures")
+            };
+
+            Ok(Self::Keys {
+                address: wallet_address,
+                bls_key_pair: bls_key.into(),
+                schnorr_key_pair: StateKeyPair::from_sign_key(state_key),
+            })
+        }
+    }
+}
+
+/// Verifies the signatures sign the Ethereum wallet address
+impl TryFrom<(NodeSignatureInput, &EthereumWallet)> for NodeSignatures {
+    type Error = anyhow::Error;
+
+    fn try_from((input, wallet): (NodeSignatureInput, &EthereumWallet)) -> anyhow::Result<Self> {
+        match input {
+            NodeSignatureInput::Keys {
+                address,
+                bls_key_pair,
+                schnorr_key_pair,
+            } => Ok(Self::create(address, &bls_key_pair, &schnorr_key_pair)),
+            NodeSignatureInput::PreparedPayload(source) => {
+                let payload = Self::try_from(source)?;
+                let wallet_address =
+                    <EthereumWallet as NetworkWallet<Ethereum>>::default_signer_address(wallet);
+
+                // Verify the signatures match the expected keys using the wallet address
+                payload.verify_signatures(wallet_address)?;
+
+                // Should never fail unless serialized payload was tampered with
+                if payload.address != wallet_address {
+                    bail!(
+                        "Address mismatch: payload contains {}, but wallet address is {}",
+                        payload.address,
+                        wallet_address
+                    );
+                }
+
+                Ok(payload)
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use alloy::primitives::Address;
+    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rstest::*;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+    use crate::BLSKeyPair;
+
+    #[fixture]
+    fn sample_address() -> Address {
+        "0x1234567890123456789012345678901234567890"
+            .parse()
+            .unwrap()
+    }
+
+    #[fixture]
+    fn sample_node_signatures(sample_address: Address) -> NodeSignatures {
+        let mut rng = StdRng::from_seed([42u8; 32]);
+        let bls_key = BLSKeyPair::generate(&mut rng);
+        let state_key = StateKeyPair::generate_from_seed(rng.gen());
+
+        NodeSignatures::create(sample_address, &bls_key, &state_key)
+    }
+
+    #[fixture]
+    fn json_content(sample_node_signatures: NodeSignatures) -> String {
+        serde_json::to_string_pretty(&sample_node_signatures).unwrap()
+    }
+
+    #[fixture]
+    fn toml_content(sample_node_signatures: NodeSignatures) -> String {
+        toml::to_string_pretty(&sample_node_signatures).unwrap()
+    }
+
+    #[rstest]
+    fn test_signature_source_parse_stdin() {
+        let result = NodeSignatureSource::parse(PathBuf::from("-"), None).unwrap();
+        matches!(
+            result,
+            NodeSignatureSource::Stdin(SerializationFormat::Json)
+        );
+    }
+
+    #[rstest]
+    fn test_signature_source_parse_stdin_with_format() {
+        let result =
+            NodeSignatureSource::parse(PathBuf::from("-"), Some(SerializationFormat::Toml))
+                .unwrap();
+        matches!(
+            result,
+            NodeSignatureSource::Stdin(SerializationFormat::Toml)
+        );
+    }
+
+    #[rstest]
+    #[case("test.json", true)]
+    #[case("test.toml", true)]
+    #[case("test.txt", false)]
+    #[case("test", false)]
+    #[case("test.yaml", false)]
+    fn test_signature_source_parse_file(#[case] filename: &str, #[case] should_succeed: bool) {
+        let path = PathBuf::from(filename);
+        let result = NodeSignatureSource::parse(path.clone(), None);
+
+        if should_succeed {
+            let source = result.unwrap();
+            matches!(source, NodeSignatureSource::File { path: p, .. } if p == path);
+        } else {
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("Unsupported extension"));
+        }
+    }
+
+    #[rstest]
+    fn test_signature_destination_stdout() {
+        let args = OutputArgs {
+            output: None,
+            format: Some(SerializationFormat::Json),
+        };
+        let result = NodeSignatureDestination::try_from(args).unwrap();
+        matches!(
+            result,
+            NodeSignatureDestination::Stdout(SerializationFormat::Json)
+        );
+    }
+
+    #[rstest]
+    #[case("test.json", SerializationFormat::Json)]
+    #[case("test.toml", SerializationFormat::Toml)]
+    fn test_signature_destination_file_valid(
+        #[case] filename: &str,
+        #[case] expected_format: SerializationFormat,
+    ) {
+        let path = PathBuf::from(filename);
+        let args = OutputArgs {
+            output: Some(path.clone()),
+            format: None, // Let it infer from extension
+        };
+        let result = NodeSignatureDestination::try_from(args).unwrap();
+
+        match result {
+            NodeSignatureDestination::File { path: p, format } => {
+                assert_eq!(p, path);
+                assert_eq!(format, expected_format);
+            },
+            _ => panic!("Expected File variant"),
+        }
+    }
+
+    #[rstest]
+    fn test_parse_json_file(
+        json_content: String,
+        sample_node_signatures: NodeSignatures,
+    ) -> anyhow::Result<()> {
+        let temp_file = NamedTempFile::with_suffix(".json")?;
+        std::fs::write(temp_file.path(), &json_content)?;
+
+        let source = NodeSignatureSource::File {
+            path: temp_file.path().to_path_buf(),
+            format: Some(SerializationFormat::Json),
+        };
+        let parsed = NodeSignatures::try_from(source)?;
+
+        assert_eq!(parsed.address, sample_node_signatures.address);
+        assert_eq!(parsed.bls_vk, sample_node_signatures.bls_vk);
+        assert_eq!(parsed.schnorr_vk, sample_node_signatures.schnorr_vk);
+        Ok(())
+    }
+
+    #[rstest]
+    fn test_parse_toml_file(
+        toml_content: String,
+        sample_node_signatures: NodeSignatures,
+    ) -> anyhow::Result<()> {
+        let temp_file = NamedTempFile::with_suffix(".toml")?;
+        std::fs::write(temp_file.path(), &toml_content)?;
+
+        let source = NodeSignatureSource::File {
+            path: temp_file.path().to_path_buf(),
+            format: Some(SerializationFormat::Toml),
+        };
+        let parsed = NodeSignatures::try_from(source)?;
+
+        assert_eq!(parsed.address, sample_node_signatures.address);
+        assert_eq!(parsed.bls_vk, sample_node_signatures.bls_vk);
+        assert_eq!(parsed.schnorr_vk, sample_node_signatures.schnorr_vk);
+        Ok(())
+    }
+
+    #[rstest]
+    fn test_parse_invalid_json_file() -> anyhow::Result<()> {
+        let temp_file = NamedTempFile::with_suffix(".json")?;
+        std::fs::write(temp_file.path(), "invalid json")?;
+
+        let source = NodeSignatureSource::File {
+            path: temp_file.path().to_path_buf(),
+            format: Some(SerializationFormat::Json),
+        };
+        let result = NodeSignatures::try_from(source);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to parse JSON file"));
+        Ok(())
+    }
+
+    #[rstest]
+    fn test_parse_invalid_toml_file() -> anyhow::Result<()> {
+        let temp_file = NamedTempFile::with_suffix(".toml")?;
+        std::fs::write(temp_file.path(), "invalid = toml = syntax")?;
+
+        let source = NodeSignatureSource::File {
+            path: temp_file.path().to_path_buf(),
+            format: Some(SerializationFormat::Toml),
+        };
+        let result = NodeSignatures::try_from(source);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to parse TOML file"));
+        Ok(())
+    }
+
+    #[rstest]
+    #[case(SerializationFormat::Json, ".json")]
+    #[case(SerializationFormat::Toml, ".toml")]
+    #[case(SerializationFormat::Toml, ".not-toml")]
+    fn test_handle_output_to_file(
+        sample_node_signatures: NodeSignatures,
+        #[case] format: SerializationFormat,
+        #[case] suffix: &str,
+    ) -> anyhow::Result<()> {
+        let temp_file = NamedTempFile::with_suffix(suffix)?;
+        let destination = NodeSignatureDestination::File {
+            path: temp_file.path().to_path_buf(),
+            format,
+        };
+
+        sample_node_signatures.handle_output(destination)?;
+
+        let content = std::fs::read_to_string(temp_file.path())?;
+        let parsed: NodeSignatures = match format {
+            SerializationFormat::Json => serde_json::from_str(&content)?,
+            SerializationFormat::Toml => toml::from_str(&content)?,
+        };
+        assert_eq!(parsed.address, sample_node_signatures.address);
+        Ok(())
+    }
+
+    #[rstest]
+    fn test_create_and_verify_signatures(sample_address: Address) {
+        let bls_key = BLSKeyPair::generate(&mut rand::thread_rng());
+        let state_key = hotshot_types::light_client::StateKeyPair::generate();
+
+        let signatures = NodeSignatures::create(sample_address, &bls_key, &state_key);
+
+        assert!(signatures.verify_signatures(sample_address).is_ok());
+
+        let wrong_address: Address = "0x0000000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        assert!(signatures.verify_signatures(wrong_address).is_err());
+    }
+
+    #[rstest]
+    #[case("test.txt")]
+    #[case("test")]
+    #[case("test.yaml")]
+    fn test_signature_destination_file_invalid(#[case] filename: &str) {
+        let path = PathBuf::from(filename);
+        let args = OutputArgs {
+            output: Some(path),
+            format: None,
+        };
+        let result = NodeSignatureDestination::try_from(args);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported extension"));
+    }
+
+    #[rstest]
+    fn test_parse_unsupported_extension() -> anyhow::Result<()> {
+        let temp_file = NamedTempFile::with_suffix(".yaml")?;
+        std::fs::write(temp_file.path(), "test: content")?;
+
+        let result = NodeSignatureSource::parse(temp_file.path().to_path_buf(), None);
+
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err().to_string();
+        assert!(
+            error_msg.contains("Unsupported extension"),
+            "Got error: {}",
+            error_msg
+        );
+        Ok(())
+    }
+
+    #[rstest]
+    #[case("test.json", SerializationFormat::Json)]
+    #[case("test.toml", SerializationFormat::Toml)]
+    fn test_serialization_format_from_path_valid(
+        #[case] filename: &str,
+        #[case] expected_format: SerializationFormat,
+    ) {
+        let path = PathBuf::from(filename);
+        let result = SerializationFormat::try_from(path.as_path()).unwrap();
+        assert_eq!(result, expected_format);
+    }
+
+    #[rstest]
+    #[case("test.txt")]
+    #[case("test")]
+    #[case("test.yaml")]
+    fn test_serialization_format_from_path_invalid(#[case] filename: &str) {
+        let path = PathBuf::from(filename);
+        let result = SerializationFormat::try_from(path.as_path());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported extension"));
+    }
+}

--- a/staking-cli/tests/common/mod.rs
+++ b/staking-cli/tests/common/mod.rs
@@ -1,0 +1,86 @@
+use anyhow::Result;
+use assert_cmd::Command;
+use staking_cli::{deploy::TestSystem, DEV_MNEMONIC};
+
+// rstest macro usage isn't detected
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+pub enum Signer {
+    Ledger,
+    Mnemonic,
+    BrokeMnemonic,
+}
+
+pub trait TestSystemExt {
+    /// Create a base staking-cli command configured for this test system
+    fn cmd(&self, signer: Signer) -> Command;
+
+    // method is used, but somehow flagged as unused
+    #[allow(dead_code)]
+    /// Create an export-node-signatures command with system keys and address
+    fn export_node_signatures_cmd(&self) -> Result<Command>;
+
+    fn bls_private_key_str(&self) -> Result<String>;
+
+    fn state_private_key_str(&self) -> Result<String>;
+}
+
+impl TestSystemExt for TestSystem {
+    fn cmd(&self, signer: Signer) -> Command {
+        let mut cmd = base_cmd();
+        cmd.arg("--rpc-url")
+            .arg(self.rpc_url.to_string())
+            .arg("--stake-table-address")
+            .arg(self.stake_table.to_string())
+            .arg("--account-index")
+            .arg("0");
+
+        match signer {
+            Signer::Ledger => {
+                cmd.arg("--ledger");
+            },
+            Signer::Mnemonic => {
+                cmd.arg("--mnemonic").arg(DEV_MNEMONIC);
+            },
+            Signer::BrokeMnemonic => {
+                cmd.arg("--mnemonic").arg(
+                    "roast term reopen pave choose high rally trouble upon govern hollow stand",
+                );
+            },
+        };
+        cmd
+    }
+
+    fn export_node_signatures_cmd(&self) -> Result<Command> {
+        let mut cmd = base_cmd();
+        cmd.arg("export-node-signatures")
+            .arg("--address")
+            .arg(self.deployer_address.to_string())
+            .arg("--consensus-private-key")
+            .arg(self.bls_private_key_str()?)
+            .arg("--state-private-key")
+            .arg(self.state_private_key_str()?);
+        Ok(cmd)
+    }
+
+    fn bls_private_key_str(&self) -> Result<String> {
+        Ok(self
+            .bls_key_pair
+            .sign_key_ref()
+            .to_tagged_base64()?
+            .to_string())
+    }
+
+    fn state_private_key_str(&self) -> Result<String> {
+        Ok(self
+            .state_key_pair
+            .sign_key()
+            .to_tagged_base64()?
+            .to_string())
+    }
+}
+
+/// Creates a new command to run the staking-cli binary.
+pub fn base_cmd() -> Command {
+    Command::cargo_bin("staking-cli").unwrap()
+}

--- a/staking-cli/tests/node_signatures.rs
+++ b/staking-cli/tests/node_signatures.rs
@@ -1,0 +1,394 @@
+mod common;
+
+use anyhow::Result;
+use assert_cmd::assert::OutputAssertExt;
+use common::{base_cmd, Signer, TestSystemExt};
+use hotshot_contract_adapter::{stake_table, stake_table::StakeTableContractVersion};
+use predicates::str;
+use rand::SeedableRng;
+use staking_cli::{deploy::TestSystem, signature::NodeSignatures};
+
+#[rstest_reuse::template]
+#[rstest::rstest]
+#[case(Extension::Json, Output::Stdout)]
+#[case(Extension::Json, Output::File)]
+#[case(Extension::Toml, Output::Stdout)]
+#[case(Extension::Toml, Output::File)]
+pub fn format_combinations(#[case] format: Extension, #[case] output: Output) {}
+
+#[derive(Debug, Clone, Copy)]
+enum Extension {
+    Json,
+    Toml,
+}
+
+impl std::fmt::Display for Extension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json => write!(f, "json"),
+            Self::Toml => write!(f, "toml"),
+        }
+    }
+}
+
+impl Extension {
+    fn parse_node_signatures(&self, content: &str) -> Result<NodeSignatures> {
+        match self {
+            Self::Json => Ok(serde_json::from_str(content)?),
+            Self::Toml => Ok(toml::from_str(content)?),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Output {
+    Stdout,
+    File,
+}
+
+#[test_log::test(rstest_reuse::apply(format_combinations))]
+#[tokio::test]
+async fn test_export_format_combinations(
+    #[case] format: Extension,
+    #[case] output: Output,
+) -> Result<()> {
+    let system = TestSystem::deploy().await?;
+
+    let mut cmd = system.export_node_signatures_cmd()?;
+
+    let content = match output {
+        Output::Stdout => {
+            cmd.arg("--format").arg(format.to_string());
+            let output = cmd.assert().success().get_output().to_owned();
+            String::from_utf8(output.stdout)?
+        },
+        Output::File => {
+            let tmpdir = tempfile::tempdir()?;
+            let output_file = tmpdir.path().join(format!("payload.{format}"));
+            cmd.arg("--output").arg(&output_file);
+            cmd.assert().success();
+            std::fs::read_to_string(&output_file)?
+        },
+    };
+
+    let parsed = format.parse_node_signatures(&content)?;
+    assert_eq!(parsed.address, system.deployer_address);
+
+    Ok(())
+}
+
+#[test_log::test(rstest::rstest)]
+#[case(Extension::Json, Extension::Json)]
+#[case(Extension::Json, Extension::Toml)]
+#[case(Extension::Toml, Extension::Json)]
+#[case(Extension::Toml, Extension::Toml)]
+#[tokio::test]
+async fn test_explicit_format_override(
+    #[case] extension: Extension,
+    #[case] format: Extension,
+) -> Result<()> {
+    let system = TestSystem::deploy().await?;
+
+    let tmpdir = tempfile::tempdir()?;
+    let output_file = tmpdir.path().join(format!("payload.{extension}"));
+
+    let mut cmd = system.export_node_signatures_cmd()?;
+    cmd.arg("--output")
+        .arg(&output_file)
+        .arg("--format")
+        .arg(format.to_string());
+
+    cmd.assert().success();
+
+    let content = std::fs::read_to_string(&output_file)?;
+    let parsed = format.parse_node_signatures(&content)?;
+    assert_eq!(parsed.address, system.deployer_address);
+
+    Ok(())
+}
+
+#[test_log::test(rstest::rstest)]
+#[tokio::test]
+async fn test_file_extension_inference(
+    #[values(Extension::Json, Extension::Toml)] extension: Extension,
+) -> Result<()> {
+    let system = TestSystem::deploy().await?;
+
+    let tmpdir = tempfile::tempdir()?;
+    let payload_file = tmpdir.path().join(format!("payload.{extension}"));
+
+    let mut cmd = system.export_node_signatures_cmd()?;
+    cmd.arg("--output").arg(&payload_file);
+
+    cmd.assert().success();
+
+    let content = std::fs::read_to_string(&payload_file)?;
+    let parsed = extension.parse_node_signatures(&content)?;
+    assert_eq!(parsed.address, system.deployer_address);
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BadExtension {
+    Yaml,
+    None,
+}
+
+impl BadExtension {
+    fn as_filename(&self) -> &'static str {
+        match self {
+            Self::Yaml => "payload.yaml",
+            Self::None => "payload",
+        }
+    }
+}
+
+#[test_log::test(rstest::rstest)]
+#[tokio::test]
+async fn test_unsupported_file_extensions(
+    #[values(BadExtension::Yaml, BadExtension::None)] extension: BadExtension,
+) -> Result<()> {
+    let system = TestSystem::deploy().await?;
+
+    let tmpdir = tempfile::tempdir()?;
+    let payload_file = tmpdir.path().join(extension.as_filename());
+
+    let mut cmd = system.export_node_signatures_cmd()?;
+    cmd.arg("--output").arg(&payload_file);
+
+    cmd.assert()
+        .failure()
+        .stderr(str::contains("Unsupported extension"));
+
+    Ok(())
+}
+
+#[test_log::test(rstest_reuse::apply(format_combinations))]
+#[tokio::test]
+async fn test_export_node_signatures_command(
+    #[case] format: Extension,
+    #[case] output: Output,
+) -> Result<()> {
+    let system = TestSystem::deploy().await?;
+
+    let mut cmd = system.export_node_signatures_cmd()?;
+
+    match output {
+        Output::Stdout => {
+            cmd.arg("--format").arg(format.to_string());
+            let output = cmd.output()?;
+
+            assert!(output.status.success(), "Command failed");
+            let result = String::from_utf8(output.stdout)?;
+
+            let parsed = format.parse_node_signatures(&result)?;
+            assert_eq!(parsed.address, system.deployer_address);
+        },
+        Output::File => {
+            let tmpdir = tempfile::tempdir()?;
+            let output_file = tmpdir.path().join(format!("payload.{format}"));
+            cmd.arg("--output").arg(&output_file);
+            cmd.assert().success();
+
+            assert!(output_file.exists());
+            let content = std::fs::read_to_string(&output_file)?;
+
+            let parsed = format.parse_node_signatures(&content)?;
+            assert_eq!(parsed.address, system.deployer_address);
+        },
+    }
+
+    Ok(())
+}
+
+#[test_log::test(rstest::rstest)]
+#[tokio::test]
+async fn test_register_validator_with_pre_signed_payload(
+    #[values(StakeTableContractVersion::V1, StakeTableContractVersion::V2)]
+    version: StakeTableContractVersion,
+    #[values(Extension::Json, Extension::Toml)] format: Extension,
+) -> Result<()> {
+    let system = TestSystem::deploy_version(version).await?;
+
+    let tmpdir = tempfile::tempdir()?;
+    let payload_path = tmpdir.path().join(format!("payload.{format}"));
+
+    let mut sign_cmd = system.export_node_signatures_cmd()?;
+    sign_cmd.arg("--output").arg(&payload_path);
+
+    sign_cmd.assert().success();
+
+    let mut reg_cmd = system.cmd(Signer::Mnemonic);
+    reg_cmd
+        .arg("register-validator")
+        .arg("--commission")
+        .arg("12.34")
+        .arg("--node-signatures")
+        .arg(&payload_path);
+
+    if let Extension::Toml = format {
+        reg_cmd.arg("--format").arg("toml");
+    }
+
+    let output = reg_cmd.output()?;
+    output.assert().success();
+
+    Ok(())
+}
+
+#[test_log::test(rstest::rstest)]
+#[tokio::test]
+async fn test_update_consensus_keys_with_pre_signed_payload(
+    #[values(StakeTableContractVersion::V1, StakeTableContractVersion::V2)]
+    version: StakeTableContractVersion,
+    #[values(Extension::Json, Extension::Toml)] format: Extension,
+) -> Result<()> {
+    let system = TestSystem::deploy_version(version).await?;
+
+    system.register_validator().await?;
+
+    let mut rng = rand::rngs::StdRng::from_seed([43u8; 32]);
+    let (_, new_bls, new_state) = TestSystem::gen_keys(&mut rng);
+
+    let tmpdir = tempfile::tempdir()?;
+    let payload_path = tmpdir.path().join(format!("payload.{format}"));
+
+    let mut sign_cmd = base_cmd();
+    sign_cmd
+        .arg("export-node-signatures")
+        .arg("--address")
+        .arg(system.deployer_address.to_string())
+        .arg("--consensus-private-key")
+        .arg(new_bls.sign_key_ref().to_tagged_base64()?.to_string())
+        .arg("--state-private-key")
+        .arg(new_state.sign_key().to_tagged_base64()?.to_string());
+
+    sign_cmd.arg("--output").arg(&payload_path);
+
+    sign_cmd.assert().success();
+
+    let mut cmd = system.cmd(Signer::Mnemonic);
+    cmd.arg("update-consensus-keys")
+        .arg("--node-signatures")
+        .arg(&payload_path);
+
+    if let Extension::Toml = format {
+        cmd.arg("--format").arg("toml");
+    }
+
+    let output = cmd.output()?;
+    output.assert().success();
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_address_validation_mismatch_error() -> Result<()> {
+    let system = TestSystem::deploy().await?;
+
+    let tmpdir = tempfile::tempdir()?;
+    let payload_file = tmpdir.path().join("payload.json");
+
+    let mut sign_cmd = system.export_node_signatures_cmd()?;
+    sign_cmd.arg("--output").arg(&payload_file);
+
+    sign_cmd.assert().success();
+
+    let payload_content = std::fs::read_to_string(&payload_file)?;
+    let mut payload: serde_json::Value = serde_json::from_str(&payload_content)?;
+
+    let different_address = "0x1111111111111111111111111111111111111111";
+    payload["address"] = serde_json::Value::String(different_address.to_string());
+
+    std::fs::write(&payload_file, serde_json::to_string_pretty(&payload)?)?;
+
+    let mut cmd = system.cmd(Signer::Mnemonic);
+
+    cmd.arg("register-validator")
+        .arg("--commission")
+        .arg("12.34")
+        .arg("--node-signatures")
+        .arg(&payload_file)
+        .assert()
+        .failure()
+        .stderr(str::contains("Address mismatch"));
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BadPayloadScenario {
+    Address,
+    Bls,
+    Schnorr,
+}
+
+#[test_log::test(rstest::rstest)]
+#[tokio::test]
+async fn test_signature_verification_failure(
+    #[values(
+        BadPayloadScenario::Address,
+        BadPayloadScenario::Bls,
+        BadPayloadScenario::Schnorr
+    )]
+    scenario: BadPayloadScenario,
+) -> Result<()> {
+    let system = TestSystem::deploy().await?;
+
+    let mut rng = rand::rngs::StdRng::from_seed([99u8; 32]);
+    let (_, bad_bls, bad_schnorr) = TestSystem::gen_keys(&mut rng);
+
+    let tmpdir = tempfile::tempdir()?;
+    let payload_file = tmpdir.path().join("payload.json");
+
+    let mut sign_cmd = system.export_node_signatures_cmd()?;
+    sign_cmd.arg("--output").arg(&payload_file);
+
+    let result = sign_cmd.output()?;
+    result.assert().success();
+
+    let mut payload: NodeSignatures = {
+        let content = std::fs::read_to_string(&payload_file)?;
+        serde_json::from_str(&content)?
+    };
+
+    match scenario {
+        BadPayloadScenario::Address => {
+            payload.address = "0x1111111111111111111111111111111111111111".parse()?;
+        },
+        BadPayloadScenario::Bls => {
+            payload.bls_signature = stake_table::sign_address_bls(&bad_bls, payload.address);
+        },
+        BadPayloadScenario::Schnorr => {
+            payload.schnorr_signature =
+                stake_table::sign_address_schnorr(&bad_schnorr, payload.address);
+        },
+    };
+
+    let tampered_content = serde_json::to_string_pretty(&payload)?;
+    std::fs::write(&payload_file, tampered_content)?;
+
+    let mut cmd = system.cmd(Signer::Mnemonic);
+
+    let cmd_result = cmd
+        .arg("register-validator")
+        .arg("--commission")
+        .arg("12.34")
+        .arg("--node-signatures")
+        .arg(&payload_file);
+
+    let out = cmd_result.assert().failure();
+    match scenario {
+        BadPayloadScenario::Address => {
+            out.stderr(str::contains("Address mismatch"));
+        },
+        BadPayloadScenario::Bls => {
+            out.stderr(str::contains("BLS"));
+        },
+        BadPayloadScenario::Schnorr => {
+            out.stderr(str::contains("Schnorr"));
+        },
+    }
+
+    Ok(())
+}

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -2282,7 +2282,7 @@ pub mod testing {
     use alloy::primitives::Bytes;
     use hotshot_contract_adapter::{
         sol_types::{EdOnBN254PointSol, G1PointSol, G2PointSol},
-        stake_table::{sign_address_bls, sign_address_schnorr},
+        stake_table::{sign_address_bls, sign_address_schnorr, StateSignatureSol},
     };
     use hotshot_types::{light_client::StateKeyPair, signature_key::BLSKeyPair};
     use rand::{Rng as _, RngCore as _};
@@ -2325,8 +2325,8 @@ pub mod testing {
                 bls_vk: bls_key_pair.ver_key().to_affine().into(),
                 schnorr_vk: schnorr_key_pair.ver_key().to_affine().into(),
                 commission,
-                bls_sig,
-                schnorr_sig,
+                bls_sig: bls_sig.into(),
+                schnorr_sig: StateSignatureSol::from(schnorr_sig).into(),
             }
         }
     }


### PR DESCRIPTION
Allows de-coupling of Espresso and Ethereum keys.

- export node signatures
- load node signatures for validator registration and consensus keys rotation
- support json/toml files and stdin/out
- verify signatures on import to avoid errors

Closes #3476 