### PR TITLE
fix: improve database transaction error handling

### DIFF
--- a/hotshot-query-service/src/data_source/storage/sql/transaction.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/transaction.rs
@@ -246,7 +246,9 @@ impl<Mode: TransactionMode> update::Transaction for Transaction<Mode> {
     }
     fn revert(mut self) -> impl Future + Send {
         async move {
-            self.inner.rollback().await.unwrap();
+            if let Err(err) = self.inner.rollback().await {
+                tracing::error!("Failed to rollback transaction: {err:#}");
+            }
             self.metrics.set_closed(CloseType::Revert);
         }
     }


### PR DESCRIPTION
Replace unwrap() with proper error logging in SQL transaction rollback operations.
Prevents crashes during database transaction failures and provides better debugging information.

- hotshot-query-service/src/data_source/storage/sql/transaction.rs: Safe rollback handling