### PR TITLE
fix: go tests: dev node startup times out

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,6 +290,10 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Build espresso-dev-node
+        run: |
+          nix develop --accept-flake-config -c cargo build --bin espresso-dev-node --features testing,embedded-db
+
       - name: Build verification module
         run: |
           nix develop --accept-flake-config -c just build-go-crypto-helper


### PR DESCRIPTION
Build the espresso-dev-node binary before running the tests.

I have a suspicion that compilation just takes longer now since we added more code.

cc @lukaszrzasik 