### PR TITLE
Rust 1.89

### DIFF
--- a/crates/hotshot/types/src/qc.rs
+++ b/crates/hotshot/types/src/qc.rs
@@ -263,7 +263,7 @@ mod tests {
             assert!(BitVectorQc::<$aggsig>::assemble(
                 &qc_pp,
                 signers.as_bitslice(),
-                &[sig2.clone()]
+                std::slice::from_ref(&sig2)
             )
             .is_err());
             // total weight under threshold

--- a/flake.lock
+++ b/flake.lock
@@ -331,11 +331,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1750991972,
-        "narHash": "sha256-jzadGZL1MtqmHb5AZcjZhHpNulOdMZPxf8Wifg8e5VA=",
+        "lastModified": 1754575663,
+        "narHash": "sha256-afOx8AG0KYtw7mlt6s6ahBBy7eEHZwws3iCRoiuRQS4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b6509555d8ffaa0727f998af6ace901c5b78dc26",
+        "rev": "6db0fb0e9cec2e9729dc52bf4898e6c135bb8a0f",
         "type": "github"
       },
       "original": {

--- a/hotshot-query-service/src/data_source/storage/ledger_log.rs
+++ b/hotshot-query-service/src/data_source/storage/ledger_log.rs
@@ -101,7 +101,7 @@ impl<T: Serialize + DeserializeOwned + Clone> LedgerLog<T> {
         })
     }
 
-    pub(crate) fn iter(&self) -> Iter<T> {
+    pub(crate) fn iter(&self) -> Iter<'_, T> {
         Iter {
             index: 0,
             cache_start: self.cache_start,

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -77,28 +77,6 @@ pub type BlocksFrontier = <BlockMerkleTree as MerkleTreeScheme>::MembershipProof
 type BoxLazy<T> = Pin<Arc<Lazy<T, BoxFuture<'static, T>>>>;
 
 #[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
-struct ConsensusState {
-    state_signer: Arc<RwLock<StateSigner<SequencerApiVersion>>>,
-    event_streamer: Arc<RwLock<EventsStreamer<SeqTypes>>>,
-    node_state: NodeState,
-    network_config: NetworkConfig<SeqTypes>,
-}
-
-impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, V: Versions>
-    From<&SequencerContext<N, P, V>> for ConsensusState
-{
-    fn from(ctx: &SequencerContext<N, P, V>) -> Self {
-        Self {
-            state_signer: ctx.state_signer(),
-            event_streamer: ctx.event_streamer(),
-            node_state: ctx.node_state(),
-            network_config: ctx.network_config(),
-        }
-    }
-}
-
-#[derive(Derivative)]
 #[derivative(Clone(bound = ""), Debug(bound = ""))]
 struct ApiState<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, V: Versions> {
     // The consensus state is initialized lazily so we can start the API (and healthcheck endpoints)

--- a/sequencer/src/restart_tests.rs
+++ b/sequencer/src/restart_tests.rs
@@ -342,7 +342,7 @@ impl<S: TestableSequencerDataSource> TestNode<S> {
         }
     }
 
-    fn stop(&mut self) -> BoxFuture<()> {
+    fn stop(&mut self) -> BoxFuture<'_, ()> {
         async {
             if let Some(mut context) = self.context.take() {
                 tracing::info!(node_id = context.node_id(), "stopping node");
@@ -352,7 +352,7 @@ impl<S: TestableSequencerDataSource> TestNode<S> {
         .boxed()
     }
 
-    fn start(&mut self) -> BoxFuture<()>
+    fn start(&mut self) -> BoxFuture<'_, ()>
     where
         S::Storage: Send,
     {
@@ -397,7 +397,7 @@ impl<S: TestableSequencerDataSource> TestNode<S> {
         .boxed()
     }
 
-    async fn event_stream(&self) -> Option<BoxStream<Event<SeqTypes>>> {
+    async fn event_stream(&self) -> Option<BoxStream<'_, Event<SeqTypes>>> {
         if let Some(ctx) = &self.context {
             Some(ctx.event_stream().await.boxed())
         } else {
@@ -412,7 +412,7 @@ impl<S: TestableSequencerDataSource> TestNode<S> {
         Some(context.node_id())
     }
 
-    fn check_progress_with_timeout(&self) -> BoxFuture<anyhow::Result<()>> {
+    fn check_progress_with_timeout(&self) -> BoxFuture<'_, anyhow::Result<()>> {
         async {
             let Some(context) = &self.context else {
                 tracing::info!("skipping progress check on stopped node");


### PR DESCRIPTION
- nix: update rust
- fix clippy

I also get

```
warning: the following packages contain code that will be rejected by a future version of Rust: cdn-proto v0.4.0 (https://github.com/EspressoSystems/Push-CDN?tag=0.5.1-upgrade#849e7edb), cdn-proto v0.4.0 (https://github.com/EspressoSystems/Push-CDN?tag=0.5.7#fd00e12f)
```

but this doesn't seem to cause clippy to fail even with `-D warnings`, so I guess it's not from clippy.