### PR TITLE
fix: argument duplication by shifting positional parameters

### DIFF
--- a/scripts/multisig-upgrade-entrypoint
+++ b/scripts/multisig-upgrade-entrypoint
@@ -10,6 +10,7 @@ set -e
 # Default script path
 DEFAULT_SCRIPT="upgradeProxy.ts"
 SCRIPT_NAME=${1:-$DEFAULT_SCRIPT}
+shift || true
 
 docker_path=/app/contracts/script/multisigTransactionProposals/safeSDK/$SCRIPT_NAME
 


### PR DESCRIPTION
I've added a `shift || true` right after setting `SCRIPT_NAME=${1:-$DEFAULT_SCRIPT}` to remove the first argument from the positional parameters.
this prevents passing the script name twice to `ts-node` when using `npx ts-node "$path" "$@"`.
without this, the first argument ends up duplicated, causing unexpected behavior.
now, only the remaining arguments after the script name are forwarded, fixing the issue.
