### PR TITLE
chore: fix typos across core, contracts, and types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,7 +272,7 @@ vergen = { version = "8.3", features = ["git", "gitcl"] }
 zeroize = "1.7"
 
 [workspace.lints.clippy]
-# may prevent accidental deadlocks from holding guards over match statments
+# may prevent accidental deadlocks from holding guards over match statements
 significant_drop_in_scrutinee = "warn"
 
 # NOTE: when making changes here also update sequencer-sqlite/Cargo.toml.

--- a/contracts/rust/deployer/README.md
+++ b/contracts/rust/deployer/README.md
@@ -580,7 +580,7 @@ RUST_LOG=info cargo run --bin deploy -- \
   --upgrade-esp-token-v2 \
   --rpc-url=$RPC_URL \
   --use-multisig
-  # to similuate, add --dry-run
+  # to simulate, add --dry-run
 ```
 
 ### Upgrading with Docker Compose
@@ -593,7 +593,7 @@ docker compose run --rm \
   -v $(pwd)/.env.mydemo:/app/.env.mydemo \
   deploy-sequencer-contracts \
   deploy --deploy-esp-token --upgrade-esp-token-v2 --rpc-url=$RPC_URL --use-multisig
-  # to similuate, add --dry-run
+  # to simulate, add --dry-run
 ```
 
 You should see the output which says something like:
@@ -965,7 +965,7 @@ docker compose run --rm \
   \
   deploy-sequencer-contracts \
   deploy --upgrade-light-client-v2 --rpc-url=$RPC_URL --use-multisig --out $OUTPUT_FILE
-  # to similuate, add --dry-run
+  # to simulate, add --dry-run
 ```
 
 **Note**: The upgrade process will:
@@ -1052,7 +1052,7 @@ docker compose run --rm \
   --timelock-address $ESPRESSO_SEQUENCER_OPS_TIMELOCK_ADDRESS \
   --rpc-url=$RPC_URL \
   --out $OUTPUT_FILE
-  # to similuate, add --dry-run
+  # to simulate, add --dry-run
 ```
 
 **Note**: The admin transfer process will:
@@ -1117,7 +1117,7 @@ docker compose run --rm \
   \
   deploy-sequencer-contracts \
   deploy --deploy-esp-token --use-timelock-owner --rpc-url=$RPC_URL --out $OUTPUT_FILE
-  # to similuate, add --dry-run
+  # to simulate, add --dry-run
 ```
 
 **Note**: The EspToken deployment process will:
@@ -1226,7 +1226,7 @@ docker compose run --rm \
   \
   deploy-sequencer-contracts \
   deploy --deploy-stake-table --upgrade-stake-table-v2 --use-timelock-owner --rpc-url=$RPC_URL --out $OUTPUT_FILE
-  # to similuate, add --dry-run
+  # to simulate, add --dry-run
 ```
 
 **Note**: The StakeTable deployment and upgrade process will:
@@ -1427,7 +1427,7 @@ docker compose run --rm \
   --timelock-address $ESPRESSO_SEQUENCER_SAFE_EXIT_TIMELOCK_ADDRESS \
   --rpc-url=$RPC_URL \
   --out $OUTPUT_FILE
-  # to similuate, add --dry-run
+  # to simulate, add --dry-run
 ```
 
 **Note**: The admin transfer process will:
@@ -1501,7 +1501,7 @@ docker compose run --rm \
   --timelock-address $ESPRESSO_SEQUENCER_OPS_TIMELOCK_ADDRESS \
   --rpc-url=$RPC_URL \
   --out $OUTPUT_FILE
-  # to similuate, add --dry-run
+  # to simulate, add --dry-run
 ```
 
 Then create a multisig proposal to transfer ownership of the StakeTableProxy to the OpsTimelock.
@@ -1580,7 +1580,7 @@ docker compose run --rm \
   --transfer-ownership-new-owner $ESPRESSO_TRANSFER_OWNERSHIP_NEW_OWNER \
   --rpc-url=$RPC_URL \
   --out $OUTPUT_FILE
-  # to similuate, add --dry-run
+  # to simulate, add --dry-run
 ```
 
 **Note**: The admin transfer process will:
@@ -1749,5 +1749,5 @@ docker compose run --rm \
   --transfer-ownership-new-owner $ESPRESSO_TRANSFER_OWNERSHIP_NEW_OWNER \
   --rpc-url=$RPC_URL \
   --out $OUTPUT_FILE
-  # to similuate, add --dry-run
+  # to simulate, add --dry-run
 ```

--- a/contracts/src/interfaces/IPlonkVerifier.sol
+++ b/contracts/src/interfaces/IPlonkVerifier.sol
@@ -84,7 +84,7 @@ interface IPlonkVerifier {
         BN254.G1Point qEcc; // 0x260
         // serialized G2 point in SRS (compressed, little-endian, 64 bytes)
         // we store the 64 bytes as 2 * bytes32 (first 32 bytes as `g2LSB`)
-        // (G1 points in SRS are implicited committed via poly commitments)
+        // (G1 points in SRS are implicitly committed via poly commitments)
         bytes32 g2LSB; // 0x280
         bytes32 g2MSB; // 0x2A0
     }

--- a/contracts/test/LightClientV3.t.sol
+++ b/contracts/test/LightClientV3.t.sol
@@ -406,7 +406,7 @@ contract LightClient_newFinalizedState_BeforeEpochActivation_Test is LightClient
         }
     }
 
-    /// @dev Test unhappy path when a valid but oudated finalized state is submitted
+    /// @dev Test unhappy path when a valid but outdated finalized state is submitted
     function test_RevertWhen_OutdatedStateSubmitted() external {
         uint64 numBlockSkipped = 1;
         LC.LightClientState memory state = genesis;

--- a/crates/hotshot-builder/legacy/src/builder_state.rs
+++ b/crates/hotshot-builder/legacy/src/builder_state.rs
@@ -529,7 +529,7 @@ impl<Types: NodeType, V: Versions> BuilderState<Types, V> {
             return;
         };
 
-        // first check whether vid_commitment exists in the quorum_proposal_payload_commit_to_quorum_proposal hashmap, if yer, ignore it, otherwise validate it and later insert in
+        // first check whether vid_commitment exists in the quorum_proposal_payload_commit_to_quorum_proposal hashmap, if yes, ignore it, otherwise validate it and later insert in
         // if we have matching da and quorum proposals, we can skip storing the one, and remove the other from storage, and call build_block with both, to save a little space.
         let Entry::Occupied(da_proposal) = self
             .da_proposal_payload_commit_to_da_proposal
@@ -544,7 +544,7 @@ impl<Types: NodeType, V: Versions> BuilderState<Types, V> {
         self.da_proposal_payload_commit_to_da_proposal
             .remove(&(payload_builder_commitment.clone(), view_number));
 
-        // also make sure we clone for the same view number( check incase payload commitments are same)
+        // also make sure we clone for the same view number (check in case payload commitments are same)
         if da_proposal_info.view_number != view_number {
             tracing::debug!(
                 "Not spawning a clone despite matching DA and quorum payload commitments, as they \

--- a/crates/hotshot-builder/shared/src/utils/event_service_wrapper.rs
+++ b/crates/hotshot-builder/shared/src/utils/event_service_wrapper.rs
@@ -31,7 +31,7 @@ pub struct EventServiceStream<Types: NodeType, V: StaticVersionType> {
 
 impl<Types: NodeType, ApiVer: StaticVersionType + 'static> EventServiceStream<Types, ApiVer> {
     /// Maximum period between events, once it elapsed we assume
-    /// udnerlying connection silently went down and attempt to reconnect
+    /// underlying connection silently went down and attempt to reconnect
     const MAX_WAIT_PERIOD: Duration = Duration::from_secs(10);
     const RETRY_PERIOD: Duration = Duration::from_secs(1);
     const CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);

--- a/crates/hotshot/hotshot/src/lib.rs
+++ b/crates/hotshot/hotshot/src/lib.rs
@@ -112,7 +112,7 @@ pub struct SystemContext<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versi
     /// Memberships used by consensus
     pub membership_coordinator: EpochMembershipCoordinator<TYPES>,
 
-    /// the metrics that the implementor is using.
+    /// the metrics that the implementer is using.
     metrics: Arc<ConsensusMetricsValue>,
 
     /// The hotstuff implementation

--- a/crates/hotshot/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/hotshot/src/traits/networking/libp2p_network.rs
@@ -582,7 +582,7 @@ impl<T: NodeType> Libp2pNetwork<T> {
         Ok(result)
     }
 
-    /// Spawns task for looking up nodes pre-emptively
+    /// Spawns task for looking up nodes preemptively
     #[allow(clippy::cast_sign_loss, clippy::cast_precision_loss)]
     fn spawn_node_lookup(
         &self,

--- a/crates/hotshot/libp2p-networking/src/network/node.rs
+++ b/crates/hotshot/libp2p-networking/src/network/node.rs
@@ -269,7 +269,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                 .set_publication_interval(Some(kademlia_record_republication_interval))
                 .set_record_ttl(Some(kademlia_ttl));
 
-            // allowing panic here because something is very wrong if this fales
+            // allowing panic here because something is very wrong if this fails
             #[allow(clippy::panic)]
             if let Some(factor) = config.replication_factor {
                 kconfig.set_replication_factor(factor);

--- a/crates/hotshot/libp2p-networking/src/network/node/handle.rs
+++ b/crates/hotshot/libp2p-networking/src/network/node/handle.rs
@@ -395,7 +395,7 @@ impl<T: NodeType> NetworkNodeHandle<T> {
     /// Forcefully disconnect from a peer
     /// # Errors
     /// If the channel is closed somehow
-    /// Shouldnt' happen.
+    /// Shouldn't happen.
     /// # Panics
     /// If channel errors out
     /// shouldn't happen.
@@ -446,7 +446,7 @@ impl<T: NodeType> NetworkNodeHandle<T> {
     /// Returns number of peers this node is connected to
     /// # Errors
     /// If the channel is closed somehow
-    /// Shouldnt' happen.
+    /// Shouldn't happen.
     /// # Panics
     /// If channel errors out
     /// shouldn't happen.
@@ -460,7 +460,7 @@ impl<T: NodeType> NetworkNodeHandle<T> {
     /// return hashset of PIDs this node is connected to
     /// # Errors
     /// If the channel is closed somehow
-    /// Shouldnt' happen.
+    /// Shouldn't happen.
     /// # Panics
     /// If channel errors out
     /// shouldn't happen.

--- a/crates/hotshot/task-impls/src/quorum_proposal/handlers.rs
+++ b/crates/hotshot/task-impls/src/quorum_proposal/handlers.rs
@@ -586,7 +586,7 @@ impl<TYPES: NodeType, V: Versions> ProposalDependencyHandle<TYPES, V> {
                 maybe_next_epoch_qc
                     .as_ref()
                     .is_some_and(|neqc| neqc.data.leaf_commit == parent_qc.data.leaf_commit),
-                "Jusify QC on our proposal is for an epoch transition block but we don't have the \
+                "Justify QC on our proposal is for an epoch transition block but we don't have the \
                  corresponding next epoch QC. Do not propose."
             );
             maybe_next_epoch_qc

--- a/crates/hotshot/testing/src/byzantine/byzantine_behaviour.rs
+++ b/crates/hotshot/testing/src/byzantine/byzantine_behaviour.rs
@@ -423,7 +423,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + std::fmt::Debug, V: Version
                 let dishonest_proposals = self.dishonest_proposal_view_numbers.read().await;
                 if dishonest_proposals.contains(&proposal.data.view_number()) {
                     // Create a vote using data from most recent vote and the current event number
-                    // We wont update internal consensus state for this Byzantine replica but we are at least
+                    // We won't update internal consensus state for this Byzantine replica but we are at least
                     // Going to send a vote to the next honest leader
                     let vote = QuorumVote2::<TYPES>::create_signed_vote(
                         self.votes_sent.last().unwrap().data.clone(),

--- a/crates/hotshot/types/src/epoch_membership.rs
+++ b/crates/hotshot/types/src/epoch_membership.rs
@@ -39,13 +39,13 @@ type EpochSender<TYPES> = (
 
 /// Struct to Coordinate membership catchup
 pub struct EpochMembershipCoordinator<TYPES: NodeType> {
-    /// The underlying membhersip
+    /// The underlying membership
     membership: Arc<RwLock<TYPES::Membership>>,
 
     /// Any in progress attempts at catching up are stored in this map
-    /// Any new callers wantin an `EpochMembership` will await on the signal
-    /// alerting them the membership is ready.  The first caller for an epoch will
-    /// wait for the actual catchup and allert future callers when it's done
+    /// Any new callers wanting an `EpochMembership` will await on the signal
+    /// alerting them the membership is ready. The first caller for an epoch will
+    /// wait for the actual catchup and alert future callers when it's done
     catchup_map: Arc<Mutex<EpochMap<TYPES>>>,
 
     drb_calculation_map: Arc<Mutex<DrbMap<TYPES>>>,

--- a/hotshot-query-service/src/availability.rs
+++ b/hotshot-query-service/src/availability.rs
@@ -891,7 +891,7 @@ mod test {
         // Check the consistency of every block/leaf pair.
         for i in 0..height {
             // Limit the number of blocks we validate in order to
-            // speeed up the tests.
+            // speed up the tests.
             if ![0, 1, height / 2, height - 1].contains(&i) {
                 continue;
             }
@@ -1229,7 +1229,7 @@ mod test {
         // Check the consistency of every block/leaf pair.
         for i in 0..height {
             // Limit the number of blocks we validate in order to
-            // speeed up the tests.
+            // speed up the tests.
             if ![0, 1, height / 2, height - 1].contains(&i) {
                 continue;
             }

--- a/hotshot-query-service/src/data_source.rs
+++ b/hotshot-query-service/src/data_source.rs
@@ -1455,7 +1455,7 @@ pub mod status_tests {
 
         {
             // Shutting down the consensus to halt block production
-            // Introducing a delay of 3 seconds to ensure that elapsed time since last block is atleast 3seconds
+            // Introducing a delay of 3 seconds to ensure that elapsed time since last block is at least 3 seconds
             network.shut_down().await;
             sleep(Duration::from_secs(3)).await;
             // Asserting that the elapsed time since the last block is at least 3 seconds

--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -508,7 +508,7 @@ impl SqlStorage {
         let pool = config.pool_opt.clone();
         let pruner_cfg = config.pruner_cfg;
 
-        // re-use the same pool if present and return early
+        // reuse the same pool if present and return early
         if let Some(pool) = config.pool {
             return Ok(Self {
                 metrics,

--- a/hotshot-query-service/src/data_source/storage/sql/transaction.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/transaction.rs
@@ -724,7 +724,7 @@ impl<Types: NodeType, State: MerklizedState<Types, ARITY>, const ARITY: usize>
                     hashset.insert([0_u8; 32].to_vec());
                 },
                 MerkleNode::ForgettenSubtree { .. } => {
-                    bail!("Node in the Merkle path contains a forgetten subtree");
+                    bail!("Node in the Merkle path contains a forgotten subtree");
                 },
                 MerkleNode::Leaf { value, pos, elem } => {
                     let mut leaf_commit = Vec::new();

--- a/sdks/go/types/header_test.go
+++ b/sdks/go/types/header_test.go
@@ -125,7 +125,7 @@ func getHeaderFromTestFile(path string, t *testing.T) HeaderInterface {
 }
 
 func TestUnmarshalSignature(t *testing.T) {
-	// `r` ans `s` are hex string of odd length.
+	// `r` and `s` are hex string of odd length.
 	// It should be unmarshalled successfully
 	data := `
 {

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2327,7 +2327,7 @@ mod test {
                 .unwrap();
         }
 
-        // This would fail even though we have processed atleast 10 leaves
+        // This would fail even though we have processed at least 10 leaves
         // this is because light weight nodes only support leaves, headers and VID
         client
             .get::<BlockQueryData<SeqTypes>>("availability/block/1")
@@ -3213,7 +3213,7 @@ mod test {
         // first two epochs will be 1 and 2
         // rewards are distributed starting third epoch
         // third epoch starts from block 40 as epoch height is 20
-        // wait for atleast 65 blocks
+        // wait for at least 65 blocks
         let _blocks = client
             .socket("availability/stream/blocks/0")
             .subscribe::<BlockQueryData<SeqTypes>>()
@@ -3313,7 +3313,7 @@ mod test {
         let client: Client<ServerError, SequencerApiVersion> =
             Client::new(format!("http://localhost:{api_port}").parse().unwrap());
 
-        // wait for atleast 75 blocks
+        // wait for at least 75 blocks
         let _blocks = client
             .socket("availability/stream/blocks/0")
             .subscribe::<BlockQueryData<SeqTypes>>()
@@ -4028,7 +4028,7 @@ mod test {
         let client: Client<ServerError, SequencerApiVersion> =
             Client::new(format!("http://localhost:{api_port}").parse().unwrap());
 
-        // wait for atleast 2 epochs
+        // wait for at least 2 epochs
         let _blocks = client
             .socket("availability/stream/blocks/0")
             .subscribe::<BlockQueryData<SeqTypes>>()
@@ -4515,7 +4515,7 @@ mod test {
         }
 
         retries = 0;
-        // check that the node has stored atleast 6 epochs merklized state in persistence
+        // check that the node has stored at least 6 epochs merklized state in persistence
         loop {
             sleep(Duration::from_secs(3)).await;
 

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -1494,7 +1494,7 @@ mod tests {
 
         // spawn a separate task
         // this is going to keep registering validators and multiple delegators
-        // the interval mining is set to 1s so each transaction finalization would take atleast 1s
+        // the interval mining is set to 1s so each transaction finalization would take at least 1s
         spawn({
             let l1_url = l1_url.clone();
             async move {

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -2637,13 +2637,13 @@ mod tests {
         }
         .into();
 
-        // first ensure that wan build a valid stake table
+        // first ensure that we can build a valid stake table
         assert!(active_validator_set_from_l1_events(
             vec![register.clone(), delegate.clone()].into_iter()
         )
         .is_ok());
 
-        // add the invalid key update (re-using the same consensus keys)
+        // add the invalid key update (reusing the same consensus keys)
         let key_update = ConsensusKeysUpdated::from(&val).into();
         let err =
             active_validator_set_from_l1_events(vec![register, delegate, key_update].into_iter())


### PR DESCRIPTION
This PR fixes minor spelling and wording issues across multiple crates and modules, including contracts, hotshot core, query-service, sequencer, sdks, and types.  

Examples of corrections:  
- **Docs/Comments**: `statments` → `statements`, `similuate` → `simulate`, `implicited` → `implicitly`, `oudated` → `outdated`.  
- **Rust code**: `yer` → `yes`, `incase` → `in case`, `udnerlying` → `underlying`, `implementor` → `implementer`.  
- **Networking**: `fales` → `fails`, `Shouldnt'` → `Shouldn't`.  
- **Hotshot/Consensus**: `Jusify` → `Justify`, `Wont` → `Won't`, `membhersip` → `membership`.  
- **Query-service/Sequencer**: `speeed` → `speed`, `atleast` → `at least`, `forgetten` → `forgotten`, `re-use` → `reuse`.  
- **Solidity**: `implicited` → `implicitly`, `oudated` → `outdated`.  
- **Go tests**: `ans` → `and`.  
- **Types**: `wan` → `can`, `re-using` → `reusing`.  

No functional or logic changes were made — this PR only improves spelling consistency and readability across the codebase.
