### PR TITLE
Garbage collect view sync tasks on decide

### DIFF
--- a/crates/hotshot/hotshot/src/tasks/task_state.rs
+++ b/crates/hotshot/hotshot/src/tasks/task_state.rs
@@ -184,6 +184,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             upgrade_lock: handle.hotshot.upgrade_lock.clone(),
             first_epoch: None,
             highest_finalized_epoch_view: (None, TYPES::View::new(0)),
+            epoch_height: handle.epoch_height,
         }
     }
 }

--- a/crates/hotshot/task-impls/src/events.rs
+++ b/crates/hotshot/task-impls/src/events.rs
@@ -295,8 +295,8 @@ pub enum HotShotEvent<TYPES: NodeType> {
     ),
     /// A replica receives an epoch root QC
     EpochRootQcRecv(EpochRootQuorumCertificate<TYPES>, TYPES::SignatureKey),
-    /// A leaf was decided
-    LeafDecided(Leaf2<TYPES>),
+    /// We decided the given leaves
+    LeavesDecided(Vec<Leaf2<TYPES>>),
 }
 
 impl<TYPES: NodeType> HotShotEvent<TYPES> {
@@ -392,7 +392,7 @@ impl<TYPES: NodeType> HotShotEvent<TYPES> {
                 Some(cert.view_number())
             },
             HotShotEvent::SetFirstEpoch(..) => None,
-            HotShotEvent::LeafDecided(..) => None,
+            HotShotEvent::LeavesDecided(..) => None,
         }
     }
 }
@@ -710,8 +710,8 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
             HotShotEvent::SetFirstEpoch(view, epoch) => {
                 write!(f, "SetFirstEpoch(view_number={view:?}, epoch={epoch:?})")
             },
-            HotShotEvent::LeafDecided(leaf) => {
-                write!(f, "LeafDecided(leaf={leaf:?})")
+            HotShotEvent::LeavesDecided(leaf) => {
+                write!(f, "LeavesDecided(leaf={leaf:?})")
             },
         }
     }

--- a/crates/hotshot/task-impls/src/events.rs
+++ b/crates/hotshot/task-impls/src/events.rs
@@ -295,6 +295,8 @@ pub enum HotShotEvent<TYPES: NodeType> {
     ),
     /// A replica receives an epoch root QC
     EpochRootQcRecv(EpochRootQuorumCertificate<TYPES>, TYPES::SignatureKey),
+    /// A leaf was decided
+    LeafDecided(Leaf2<TYPES>),
 }
 
 impl<TYPES: NodeType> HotShotEvent<TYPES> {
@@ -390,6 +392,7 @@ impl<TYPES: NodeType> HotShotEvent<TYPES> {
                 Some(cert.view_number())
             },
             HotShotEvent::SetFirstEpoch(..) => None,
+            HotShotEvent::LeafDecided(..) => None,
         }
     }
 }
@@ -706,6 +709,9 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
             },
             HotShotEvent::SetFirstEpoch(view, epoch) => {
                 write!(f, "SetFirstEpoch(view_number={view:?}, epoch={epoch:?})")
+            },
+            HotShotEvent::LeafDecided(leaf) => {
+                write!(f, "LeafDecided(leaf={leaf:?})")
             },
         }
     }

--- a/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
@@ -219,13 +219,18 @@ pub(crate) async fn handle_quorum_proposal_validated<
                 leaf_info.leaf.view_number(),
                 leaf_info.leaf.block_header().block_number(),
             );
-
-            broadcast_event(
-                Arc::new(HotShotEvent::LeafDecided(leaf_info.leaf.clone())),
-                event_sender,
-            )
-            .await;
         }
+
+        broadcast_event(
+            Arc::new(HotShotEvent::LeavesDecided(
+                leaf_views
+                    .iter()
+                    .map(|leaf_info| leaf_info.leaf.clone())
+                    .collect(),
+            )),
+            event_sender,
+        )
+        .await;
 
         // Send an update to everyone saying that we've reached a decide
         broadcast_event(

--- a/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
@@ -219,6 +219,12 @@ pub(crate) async fn handle_quorum_proposal_validated<
                 leaf_info.leaf.view_number(),
                 leaf_info.leaf.block_header().block_number(),
             );
+
+            broadcast_event(
+                Arc::new(HotShotEvent::LeafDecided(leaf_info.leaf.clone())),
+                &event_sender,
+            )
+            .await;
         }
 
         // Send an update to everyone saying that we've reached a decide

--- a/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
@@ -222,7 +222,7 @@ pub(crate) async fn handle_quorum_proposal_validated<
 
             broadcast_event(
                 Arc::new(HotShotEvent::LeafDecided(leaf_info.leaf.clone())),
-                &event_sender,
+                event_sender,
             )
             .await;
         }

--- a/crates/hotshot/task-impls/src/view_sync.rs
+++ b/crates/hotshot/task-impls/src/view_sync.rs
@@ -518,12 +518,21 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
 
                 self.garbage_collect_tasks().await;
             },
-            HotShotEvent::LeafDecided(leaf) => {
-                let finalized_epoch = self
-                    .highest_finalized_epoch_view
-                    .0
-                    .max(leaf.epoch(self.epoch_height));
-                let finalized_view = self.highest_finalized_epoch_view.1.max(leaf.view_number());
+            HotShotEvent::LeavesDecided(leaves) => {
+                let finalized_epoch = self.highest_finalized_epoch_view.0.max(
+                    leaves
+                        .iter()
+                        .map(|leaf| leaf.epoch(self.epoch_height))
+                        .max()
+                        .unwrap_or(None),
+                );
+                let finalized_view = self.highest_finalized_epoch_view.1.max(
+                    leaves
+                        .iter()
+                        .map(|leaf| leaf.view_number())
+                        .max()
+                        .unwrap_or(TYPES::View::new(0)),
+                );
 
                 self.highest_finalized_epoch_view = (finalized_epoch, finalized_view);
 

--- a/crates/hotshot/testing/src/predicates/event.rs
+++ b/crates/hotshot/testing/src/predicates/event.rs
@@ -149,6 +149,17 @@ where
     Box::new(EventPredicate { check, info })
 }
 
+pub fn leaf_decided<TYPES>() -> Box<EventPredicate<TYPES>>
+where
+    TYPES: NodeType,
+{
+    let info = "LeafDecided".to_string();
+    let check: EventCallback<TYPES> =
+        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), LeafDecided(_)));
+
+    Box::new(EventPredicate { check, info })
+}
+
 pub fn view_change<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,

--- a/crates/hotshot/testing/src/predicates/event.rs
+++ b/crates/hotshot/testing/src/predicates/event.rs
@@ -149,13 +149,13 @@ where
     Box::new(EventPredicate { check, info })
 }
 
-pub fn leaf_decided<TYPES>() -> Box<EventPredicate<TYPES>>
+pub fn leaves_decided<TYPES>() -> Box<EventPredicate<TYPES>>
 where
     TYPES: NodeType,
 {
-    let info = "LeafDecided".to_string();
+    let info = "LeavesDecided".to_string();
     let check: EventCallback<TYPES> =
-        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), LeafDecided(_)));
+        Arc::new(move |e: Arc<HotShotEvent<TYPES>>| matches!(e.as_ref(), LeavesDecided(_)));
 
     Box::new(EventPredicate { check, info })
 }

--- a/crates/hotshot/testing/tests/tests_1/upgrade_task_with_vote.rs
+++ b/crates/hotshot/testing/tests/tests_1/upgrade_task_with_vote.rs
@@ -143,6 +143,7 @@ async fn test_upgrade_task_with_vote() {
         ),
         Expectations::from_outputs_and_task_states(
             all_predicates![
+                leaf_decided(),
                 exact(DaCertificateValidated(dacs[3].clone())),
                 exact(VidShareValidated(vids[3].0[0].clone())),
                 exact(ViewChange(ViewNumber::new(5), None)),
@@ -152,6 +153,7 @@ async fn test_upgrade_task_with_vote() {
         ),
         Expectations::from_outputs_and_task_states(
             all_predicates![
+                leaf_decided(),
                 exact(DaCertificateValidated(dacs[4].clone())),
                 exact(VidShareValidated(vids[4].0[0].clone())),
                 exact(ViewChange(ViewNumber::new(6), None)),
@@ -159,7 +161,10 @@ async fn test_upgrade_task_with_vote() {
             ],
             vec![no_decided_upgrade_certificate()],
         ),
-        Expectations::from_outputs_and_task_states(vec![], vec![decided_upgrade_certificate()]),
+        Expectations::from_outputs_and_task_states(
+            vec![leaf_decided()],
+            vec![decided_upgrade_certificate()],
+        ),
     ];
 
     let vote_state =

--- a/crates/hotshot/testing/tests/tests_1/upgrade_task_with_vote.rs
+++ b/crates/hotshot/testing/tests/tests_1/upgrade_task_with_vote.rs
@@ -143,7 +143,7 @@ async fn test_upgrade_task_with_vote() {
         ),
         Expectations::from_outputs_and_task_states(
             all_predicates![
-                leaf_decided(),
+                leaves_decided(),
                 exact(DaCertificateValidated(dacs[3].clone())),
                 exact(VidShareValidated(vids[3].0[0].clone())),
                 exact(ViewChange(ViewNumber::new(5), None)),
@@ -153,7 +153,7 @@ async fn test_upgrade_task_with_vote() {
         ),
         Expectations::from_outputs_and_task_states(
             all_predicates![
-                leaf_decided(),
+                leaves_decided(),
                 exact(DaCertificateValidated(dacs[4].clone())),
                 exact(VidShareValidated(vids[4].0[0].clone())),
                 exact(ViewChange(ViewNumber::new(6), None)),
@@ -162,7 +162,7 @@ async fn test_upgrade_task_with_vote() {
             vec![no_decided_upgrade_certificate()],
         ),
         Expectations::from_outputs_and_task_states(
-            vec![leaf_decided()],
+            vec![leaves_decided()],
             vec![decided_upgrade_certificate()],
         ),
     ];


### PR DESCRIPTION
Broadcasts an internal event when HotShot reaches a decide, and garbage collects view sync tasks based on that event
