### PR TITLE
Add retries when installing node packages in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,7 +222,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install node deps
-        run: yarn
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 1
+          max_attempts: 5
+          retry_on: error
+          command: yarn
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -256,7 +261,12 @@ jobs:
           submodules: recursive
 
       - name: Install node deps
-        run: yarn
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 1
+          max_attempts: 5
+          retry_on: error
+          command: yarn
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,8 +224,9 @@ jobs:
       - name: Install node deps
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 1
-          max_attempts: 5
+          timeout_minutes: 3
+          max_attempts: 10
+          retry_wait_seconds: 60
           retry_on: error
           command: yarn
 
@@ -263,8 +264,9 @@ jobs:
       - name: Install node deps
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 1
-          max_attempts: 5
+          timeout_minutes: 3
+          max_attempts: 10
+          retry_wait_seconds: 60
           retry_on: error
           command: yarn
 


### PR DESCRIPTION
Getting 429 and 403 on `Install node deps `CI job. This PR adds retries for installing node packages.
https://github.com/EspressoSystems/espresso-network/actions/runs/17239027138/job/48912151251?pr=3541