### PR TITLE
Change `try_fetch_leaf` to `fetch_leaf` in `get_epoch_drb`

### DIFF
--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -2294,7 +2294,7 @@ impl Membership<SeqTypes> for EpochCommittees {
             block_height
         );
         let drb_leaf = peers
-            .try_fetch_leaf(1, block_height, stake_table, success_threshold)
+            .fetch_leaf(block_height, stake_table, success_threshold)
             .await?;
 
         let Some(drb) = drb_leaf.next_drb_result else {


### PR DESCRIPTION
This automatically retries fetching the leaf containing the DRB result if the request timesout
