### PR TITLE
chore(persistence): make vid_share2 migration idempotent with ON CONFLICT

### DIFF
--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -1723,6 +1723,10 @@ impl SequencerPersistence for Persistence {
                 b.push_bind(view).push_bind(payload_hash).push_bind(data);
             });
 
+            // Offset tracking prevents duplicate inserts
+            // Added as a safeguard.
+            query_builder.push(" ON CONFLICT DO NOTHING");
+
             let query = query_builder.build();
 
             let mut tx = self.db.write().await?;


### PR DESCRIPTION
Add missing ON CONFLICT DO NOTHING to INSERT into vid_share2 in migrate_vid_shares. This aligns the function with other batch migrations (anchor_leaf, da_proposal, quorum_proposals, quorum_certificate), ensuring idempotency on batch boundaries and safe restarts. Without this, re-running a partially completed batch or resuming from an offset would attempt to re-insert rows with the same PRIMARY KEY(view), causing unique constraint violations and breaking the migration.