### PR TITLE
fix: guard leader selection against empty sets across election impls

### DIFF
--- a/crates/hotshot/hotshot/src/traits/election/randomized_committee_members.rs
+++ b/crates/hotshot/hotshot/src/traits/election/randomized_committee_members.rs
@@ -21,6 +21,7 @@ use hotshot_types::{
     PeerConfig,
 };
 use hotshot_utils::anytrace::Result;
+use hotshot_utils::anytrace::{Error as AnyError, Level as AnyLevel};
 use rand::{rngs::StdRng, Rng};
 use tracing::error;
 
@@ -386,6 +387,13 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig, DaConfig: QuorumFilterConfig> 
                 .map(|(idx, v)| (idx, v.clone()))
                 .collect();
 
+            if leader_vec.is_empty() {
+                return Err(AnyError {
+                    level: AnyLevel::Unspecified,
+                    message: format!("No eligible leaders after quorum filter for epoch {epoch}"),
+                });
+            }
+
             let mut rng: StdRng = rand::SeedableRng::seed_from_u64(*view_number);
 
             let randomized_view_number: u64 = rng.gen_range(0..=u64::MAX);
@@ -406,6 +414,12 @@ impl<TYPES: NodeType, CONFIG: QuorumFilterConfig, DaConfig: QuorumFilterConfig> 
 
             let randomized_view_number: u64 = rng.gen_range(0..=u64::MAX);
             #[allow(clippy::cast_possible_truncation)]
+            if self.eligible_leaders.is_empty() {
+                return Err(AnyError {
+                    level: AnyLevel::Unspecified,
+                    message: "No eligible leaders configured".to_string(),
+                });
+            }
             let index = randomized_view_number as usize % self.eligible_leaders.len();
 
             let res = self.eligible_leaders[index].clone();

--- a/crates/hotshot/hotshot/src/traits/election/static_committee.rs
+++ b/crates/hotshot/hotshot/src/traits/election/static_committee.rs
@@ -217,6 +217,12 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommittee<TYPES> {
         epoch: Option<<TYPES as NodeType>::Epoch>,
     ) -> Result<TYPES::SignatureKey> {
         self.check_first_epoch(epoch);
+        if self.eligible_leaders.is_empty() {
+            return Err(Error {
+                level: Level::Unspecified,
+                message: "No eligible leaders configured".to_string(),
+            });
+        }
         #[allow(clippy::cast_possible_truncation)]
         let index = *view_number as usize % self.eligible_leaders.len();
         let res = self.eligible_leaders[index].clone();

--- a/crates/hotshot/hotshot/src/traits/election/static_committee_leader_two_views.rs
+++ b/crates/hotshot/hotshot/src/traits/election/static_committee_leader_two_views.rs
@@ -187,6 +187,12 @@ impl<TYPES: NodeType> Membership<TYPES> for StaticCommitteeLeaderForTwoViews<TYP
         view_number: <TYPES as NodeType>::View,
         _epoch: Option<<TYPES as NodeType>::Epoch>,
     ) -> Result<TYPES::SignatureKey> {
+        if self.eligible_leaders.is_empty() {
+            return Err(hotshot_utils::anytrace::Error {
+                level: hotshot_utils::anytrace::Level::Unspecified,
+                message: "No eligible leaders configured".to_string(),
+            });
+        }
         let index =
             usize::try_from((*view_number / 2) % self.eligible_leaders.len() as u64).unwrap();
         let res = self.eligible_leaders[index].clone();

--- a/crates/hotshot/hotshot/src/traits/election/two_static_committees.rs
+++ b/crates/hotshot/hotshot/src/traits/election/two_static_committees.rs
@@ -337,11 +337,23 @@ impl<TYPES: NodeType> Membership<TYPES> for TwoStaticCommittees<TYPES> {
     ) -> Result<TYPES::SignatureKey> {
         let epoch = epoch.expect("epochs cannot be disabled with TwoStaticCommittees");
         if *epoch != 0 && *epoch % 2 == 0 {
+            if self.eligible_leaders.0.is_empty() {
+                return Err(hotshot_utils::anytrace::Error {
+                    level: hotshot_utils::anytrace::Level::Unspecified,
+                    message: "No eligible leaders configured for committee 0".to_string(),
+                });
+            }
             #[allow(clippy::cast_possible_truncation)]
             let index = *view_number as usize % self.eligible_leaders.0.len();
             let res = self.eligible_leaders.0[index].clone();
             Ok(TYPES::SignatureKey::public_key(&res.stake_table_entry))
         } else {
+            if self.eligible_leaders.1.is_empty() {
+                return Err(hotshot_utils::anytrace::Error {
+                    level: hotshot_utils::anytrace::Level::Unspecified,
+                    message: "No eligible leaders configured for committee 1".to_string(),
+                });
+            }
             #[allow(clippy::cast_possible_truncation)]
             let index = *view_number as usize % self.eligible_leaders.1.len();
             let res = self.eligible_leaders.1[index].clone();

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -2218,7 +2218,9 @@ impl Membership<SeqTypes> for EpochCommittees {
             },
             (_, None) => {
                 let leaders = &self.non_epoch_committee.eligible_leaders;
-
+                if leaders.is_empty() {
+                    return Err(LeaderLookupError);
+                }
                 let index = *view_number as usize % leaders.len();
                 let res = leaders[index].clone();
                 Ok(PubKey::public_key(&res.stake_table_entry))


### PR DESCRIPTION
Prevent panics during leader selection by returning errors when no eligible leaders are available. Previously, modulo operations used the length of leader lists without emptiness checks, risking division-by-zero if quorum filters produced zero leaders or configs resulted in empty leader sets. This aligns with the Membership trait’s error-based contract and ensures robust behavior under edge conditions.