### PR TITLE
Add Summary stats per epoch

### DIFF
--- a/crates/hotshot/task-impls/src/stats.rs
+++ b/crates/hotshot/task-impls/src/stats.rs
@@ -7,7 +7,11 @@ use hotshot_task::task::TaskState;
 use hotshot_types::{
     consensus::OuterConsensus,
     epoch_membership::EpochMembershipCoordinator,
-    traits::node_implementation::{ConsensusTime, NodeType},
+    traits::{
+        block_contents::BlockHeader,
+        node_implementation::{ConsensusTime, NodeType},
+        BlockPayload,
+    },
     vote::HasViewNumber,
 };
 use hotshot_utils::{
@@ -38,6 +42,7 @@ pub struct LeaderViewStats<TYPES: NodeType> {
 pub struct ReplicaViewStats<TYPES: NodeType> {
     pub view: TYPES::View,
     pub view_change: Option<i128>,
+    pub proposal_timestamp: Option<i128>,
     pub proposal_recv: Option<i128>,
     pub vote_send: Option<i128>,
     pub timeout_vote_send: Option<i128>,
@@ -74,6 +79,7 @@ impl<TYPES: NodeType> ReplicaViewStats<TYPES> {
         Self {
             view,
             view_change: None,
+            proposal_timestamp: None,
             proposal_recv: None,
             vote_send: None,
             timeout_vote_send: None,
@@ -97,6 +103,9 @@ pub struct StatsTaskState<TYPES: NodeType> {
     membership_coordinator: EpochMembershipCoordinator<TYPES>,
     leader_stats: BTreeMap<TYPES::View, LeaderViewStats<TYPES>>,
     replica_stats: BTreeMap<TYPES::View, ReplicaViewStats<TYPES>>,
+    latencies_by_view: BTreeMap<TYPES::View, i128>,
+    sizes_by_view: BTreeMap<TYPES::View, i128>,
+    epoch_start_times: BTreeMap<TYPES::Epoch, i128>,
 }
 
 impl<TYPES: NodeType> StatsTaskState<TYPES> {
@@ -115,6 +124,9 @@ impl<TYPES: NodeType> StatsTaskState<TYPES> {
             membership_coordinator,
             leader_stats: BTreeMap::new(),
             replica_stats: BTreeMap::new(),
+            latencies_by_view: BTreeMap::new(),
+            sizes_by_view: BTreeMap::new(),
+            epoch_start_times: BTreeMap::new(),
         }
     }
     fn leader_entry(&mut self, view: TYPES::View) -> &mut LeaderViewStats<TYPES> {
@@ -130,6 +142,8 @@ impl<TYPES: NodeType> StatsTaskState<TYPES> {
     fn garbage_collect(&mut self, view: TYPES::View) {
         self.leader_stats = self.leader_stats.split_off(&view);
         self.replica_stats = self.replica_stats.split_off(&view);
+        self.latencies_by_view = self.latencies_by_view.split_off(&view);
+        self.sizes_by_view = self.sizes_by_view.split_off(&view);
     }
 
     fn dump_stats(&self) -> Result<()> {
@@ -162,6 +176,24 @@ impl<TYPES: NodeType> StatsTaskState<TYPES> {
                 .map_err(|e| warn!("Failed to convert replica stats to string: {}", e))?
         );
         Ok(())
+    }
+
+    fn log_basic_stats(&self, now: i128, epoch: &TYPES::Epoch) {
+        let num_views = self.latencies_by_view.len();
+        let total_latency = self.latencies_by_view.values().sum::<i128>();
+        let average_latency = total_latency / num_views as i128;
+        tracing::warn!("Average latency: {}ms", average_latency);
+        let total_size = self.sizes_by_view.values().sum::<i128>();
+        if total_size == 0 {
+            // Either no TXNs or we are not in the DA committee and don't know block sizes
+            return;
+        }
+        if let Some(epoch_start_time) = self.epoch_start_times.get(epoch) {
+            let elapsed_time = now - epoch_start_time;
+            // multiply by 1000 to convert to seconds
+            let throughput = (total_size / elapsed_time) * 1000;
+            tracing::warn!("Throughput: {} bytes/s", throughput);
+        }
     }
 }
 
@@ -240,6 +272,9 @@ impl<TYPES: NodeType> TaskState for StatsTaskState<TYPES> {
             HotShotEvent::QuorumProposalValidated(proposal, _) => {
                 self.replica_entry(proposal.data.view_number())
                     .proposal_validated = Some(now);
+                self.replica_entry(proposal.data.view_number())
+                    .proposal_timestamp =
+                    Some(proposal.data.block_header().timestamp_millis() as i128);
             },
             HotShotEvent::DaProposalSend(proposal, _) => {
                 self.leader_entry(proposal.data.view_number())
@@ -288,6 +323,7 @@ impl<TYPES: NodeType> TaskState for StatsTaskState<TYPES> {
                 if self.view < *view {
                     self.view = *view;
                 }
+                let prev_epoch = self.epoch;
                 let mut new_epoch = false;
                 if self.epoch < *epoch {
                     self.epoch = *epoch;
@@ -298,6 +334,9 @@ impl<TYPES: NodeType> TaskState for StatsTaskState<TYPES> {
                 }
 
                 if new_epoch {
+                    if let Some(prev_epoch) = prev_epoch {
+                        self.log_basic_stats(now, &prev_epoch);
+                    }
                     let _ = self.dump_stats();
                     self.garbage_collect(*view - 1);
                 }
@@ -333,6 +372,23 @@ impl<TYPES: NodeType> TaskState for StatsTaskState<TYPES> {
             HotShotEvent::QuorumProposalPreliminarilyValidated(proposal) => {
                 self.replica_entry(proposal.data.view_number())
                     .proposal_prelim_validated = Some(now);
+            },
+            HotShotEvent::LeavesDecided(leaves) => {
+                for leaf in leaves {
+                    if leaf.view_number() == TYPES::View::genesis() {
+                        continue;
+                    }
+                    let view = leaf.view_number();
+                    let timestamp = leaf.block_header().timestamp_millis() as i128;
+                    let now_millis = now / 1_000_000;
+                    let latency = now_millis - timestamp;
+                    tracing::debug!("View {} Latency: {}ms", view, latency);
+                    self.latencies_by_view.insert(view, latency);
+                    self.sizes_by_view.insert(
+                        view,
+                        leaf.block_payload().map(|p| p.txn_bytes()).unwrap_or(0) as i128,
+                    );
+                }
             },
             _ => {},
         }

--- a/crates/hotshot/types/src/data/ns_table.rs
+++ b/crates/hotshot/types/src/data/ns_table.rs
@@ -22,7 +22,7 @@ pub fn parse_ns_table(payload_byte_len: usize, bytes: &[u8]) -> Vec<Range<usize>
     if bytes.len() < NUM_NSS_BYTE_LEN
         || (bytes.len() - NUM_NSS_BYTE_LEN) % (NS_OFFSET_BYTE_LEN + NS_ID_BYTE_LEN) != 0
     {
-        tracing::warn!(
+        tracing::info!(
             "Failed to parse the metadata as namespace table. Use a single namespace table \
              instead."
         );
@@ -34,7 +34,7 @@ pub fn parse_ns_table(payload_byte_len: usize, bytes: &[u8]) -> Vec<Range<usize>
             / NS_ID_BYTE_LEN.saturating_add(NS_OFFSET_BYTE_LEN)
         || (num_entries == 0 && payload_byte_len != 0)
     {
-        tracing::warn!(
+        tracing::info!(
             "Failed to parse the metadata as namespace table. Use a single namespace table \
              instead."
         );
@@ -53,7 +53,7 @@ pub fn parse_ns_table(payload_byte_len: usize, bytes: &[u8]) -> Vec<Range<usize>
                 .unwrap(),
         ) as usize;
         if r < l || r > payload_byte_len {
-            tracing::warn!(
+            tracing::info!(
                 "Failed to parse the metadata as namespace table. Use a single namespace table \
                  instead."
             );
@@ -63,7 +63,7 @@ pub fn parse_ns_table(payload_byte_len: usize, bytes: &[u8]) -> Vec<Range<usize>
         l = r;
     }
     if l != payload_byte_len {
-        tracing::warn!(
+        tracing::info!(
             "Failed to parse the metadata as namespace table. Use a single namespace table \
              instead."
         );


### PR DESCRIPTION
### This PR:

Adds simple counting stats to be logged at the end of each epoch.  The stats are 

### This PR does not:

No functional change to consensus

### Key places to review:

Make sure the math makes sense for computing throughput and latency as well as unit conversions

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

### Things tested

I tested this by running some of our unit tests and observing the average latency made sense and was consistent across nodes

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
