### PR TITLE
CI: fix flaky e2e tests with more disk space

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -354,7 +354,7 @@ jobs:
         run: nix profile install nixpkgs/3730d8a308f94996a9ba7c7138ede69c1b9ac4ae#process-compose
 
       - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v2
+        uses: catchpoint/workflow-telemetry-action@master
         with:
           comment_on_pr: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -397,6 +397,12 @@ jobs:
         run: |
           tail -n 1000 ${{ env.NATIVE_DEMO_LOGS }}
 
+      # for debugging: geth may shut down if it detects low disk space
+      - name: Show available disk space
+        if: always()
+        run: |
+          df -h
+
       - name: Upload process compose logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,6 +328,32 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
+
+      # The demo l1 (geth) sometimes shuts down due to perceived low disk space.
+      - uses: cargo-bins/cargo-binstall@main
+      - name: Make more disk space available on public runner
+        run: |
+          # rmz seems to be faster at deleting files than rm
+          cargo binstall -y --version 2.2.0 rmz
+          sudo mv /home/runner/.cargo/bin/rmz /usr/local/bin/rmz
+
+          echo "Available storage before:"
+          sudo df -h
+          echo
+          sudo rmz -f /usr/share/dotnet
+          sudo rmz -f /usr/share/swift
+          sudo rmz -f /usr/share/gradle-*
+          sudo rmz -f /usr/share/az_*
+          sudo rmz -f /usr/local/lib/android
+          sudo rmz -f /opt/ghc
+          sudo rmz -f /opt/az
+          sudo rmz -f /opt/pipx
+          sudo rmz -f /opt/google
+          sudo rmz -f /opt/microsoft
+          echo "Available storage after:"
+          sudo df -h
+          echo
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt,
-    fs::File,
-    io::{stderr, stdout},
+    io::{stderr, stdout, Write},
     path::{Path, PathBuf},
     process::{Child, Command},
     str::FromStr,
@@ -352,8 +351,27 @@ impl NativeDemo {
         });
 
         println!("Writing native demo logs to file: {log_path}");
-        let outputs = File::create(log_path).context("unable to create log file")?;
-        cmd.stdout(outputs);
+
+        let is_ci = std::env::var("CI").unwrap_or_default() == "true";
+
+        // Open file in append mode if CI, otherwise truncate
+        let mut log_file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(is_ci)
+            .truncate(!is_ci)
+            .write(true)
+            .open(&log_path)
+            .context("unable to open log file")?;
+        writeln!(log_file, "==== process-compose logs =====")?;
+        log_file.flush()?;
+
+        // Redirect both stdout and stderr to the same file
+        cmd.stdout(
+            log_file
+                .try_clone()
+                .context("unable to clone log file for stdout")?,
+        );
+        cmd.stderr(log_file);
 
         println!("Spawning: {cmd:?}");
         let mut child = cmd.spawn().context("failed to spawn command")?;


### PR DESCRIPTION
For some weird reasons in #3623 the integration tests are very flaky. Among other things geth is shutting down due to low disk space. I want to get some visibility into that.

There are some actions to free up disk space but in my experience they are very slow because they try to do things cleanly. Here we just delete some stuff, as quickly as possible.