### PR TITLE
Broadcast view change early from proposal

### DIFF
--- a/crates/hotshot/task-impls/src/helpers.rs
+++ b/crates/hotshot/task-impls/src/helpers.rs
@@ -1179,7 +1179,9 @@ pub(crate) async fn validate_proposal_view_and_certs<
                      preceding view"
                 );
                 let timeout_cert_epoch = timeout_cert.data().epoch();
-                membership = membership.get_new_epoch(timeout_cert_epoch).await?;
+                membership = membership
+                    .get_new_epoch_stake_table(timeout_cert_epoch)
+                    .await?;
 
                 let membership_stake_table = membership.stake_table().await;
                 let membership_success_threshold = membership.success_threshold().await;
@@ -1204,7 +1206,9 @@ pub(crate) async fn validate_proposal_view_and_certs<
                 );
 
                 let view_sync_cert_epoch = view_sync_cert.data().epoch();
-                membership = membership.get_new_epoch(view_sync_cert_epoch).await?;
+                membership = membership
+                    .get_new_epoch_stake_table(view_sync_cert_epoch)
+                    .await?;
 
                 let membership_stake_table = membership.stake_table().await;
                 let membership_success_threshold = membership.success_threshold().await;

--- a/crates/hotshot/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/hotshot/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -344,7 +344,7 @@ async fn view_change_from_proposal<TYPES: NodeType, I: NodeImplementation<TYPES>
                 // since we must have come out of a transition. If the block number is `None`, we unwrap to `0`
                 // which is never the last block and so we always pass this check.
                 && !is_last_block(
-                    justify_qc.data.block_number.unwrap_or(0).saturating_sub(1),
+                    justify_qc.data.block_number.unwrap_or(0),
                     validation_info.epoch_height,
                 )
             {
@@ -378,7 +378,7 @@ async fn view_change_from_proposal<TYPES: NodeType, I: NodeImplementation<TYPES>
         return;
     }
 
-    if (network_epoch > task_state.cur_epoch && network_view > task_state.cur_view)
+    if (network_epoch > task_state.cur_epoch && network_view >= task_state.cur_view)
         || (network_epoch == task_state.cur_epoch && network_view > task_state.cur_view)
     {
         task_state.cur_epoch = network_epoch;
@@ -562,12 +562,8 @@ pub(crate) async fn handle_quorum_proposal_recv<
         quorum_proposal_sender_key,
     )
     .await?;
-
-    validation_info
-        .consensus
-        .write()
-        .await
-        .update_highest_block(proposal_block_number);
+      
+    validation_info.consensus.write().await.highest_block = proposal_block_number;
 
     Ok(())
 }

--- a/crates/hotshot/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/hotshot/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -340,6 +340,13 @@ async fn view_change_from_proposal<TYPES: NodeType, I: NodeImplementation<TYPES>
                 )
                 .await
                 .is_ok()
+                // We skip the view change if the justify qc is signing the last block of an epoch, 
+                // since we must have come out of a transition. If the block number is `None`, we unwrap to `0`
+                // which is never the last block and so we always pass this check.
+                && !is_last_block(
+                    justify_qc.data.block_number.unwrap_or(0).saturating_sub(1),
+                    validation_info.epoch_height,
+                )
             {
                 network_epoch = max(network_epoch, justify_qc.epoch());
                 network_view = max(network_view, justify_qc.view_number()) + 1;

--- a/crates/hotshot/task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/crates/hotshot/task-impls/src/quorum_proposal_recv/handlers.rs
@@ -340,13 +340,6 @@ async fn view_change_from_proposal<TYPES: NodeType, I: NodeImplementation<TYPES>
                 )
                 .await
                 .is_ok()
-                // We skip the view change if the justify qc is signing the last block of an epoch, 
-                // since we must have come out of a transition. If the block number is `None`, we unwrap to `0`
-                // which is never the last block and so we always pass this check.
-                && !is_last_block(
-                    justify_qc.data.block_number.unwrap_or(0),
-                    validation_info.epoch_height,
-                )
             {
                 network_epoch = max(network_epoch, justify_qc.epoch());
                 network_view = max(network_view, justify_qc.view_number()) + 1;

--- a/crates/hotshot/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/hotshot/task-impls/src/quorum_proposal_recv/mod.rs
@@ -191,6 +191,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
                     &event_sender,
                     &event_receiver,
                     validation_info,
+                    self,
                 )
                 .await
                 {

--- a/crates/hotshot/types/src/epoch_membership.rs
+++ b/crates/hotshot/types/src/epoch_membership.rs
@@ -592,6 +592,10 @@ impl<TYPES: NodeType> EpochMembership<TYPES> {
         self.coordinator.membership_for_epoch(epoch).await
     }
 
+    pub async fn get_new_epoch_stake_table(&self, epoch: Option<TYPES::Epoch>) -> Result<Self> {
+        self.coordinator.stake_table_for_epoch(epoch).await
+    }
+
     /// Wraps the same named Membership trait fn
     async fn get_epoch_root(&self, block_height: u64) -> anyhow::Result<Leaf2<TYPES>> {
         let Some(epoch) = self.epoch else {


### PR DESCRIPTION
This PR fixes an issue where consensus stalled due to an early exit in `handle_quorum_proposal_recv`. We now broadcast a view change immediately in that function based on any valid certificates we receive
