### PR TITLE
Update view timeouts on some tests

### DIFF
--- a/crates/hotshot/macros/src/lib.rs
+++ b/crates/hotshot/macros/src/lib.rs
@@ -201,7 +201,7 @@ impl TestData {
         quote! {
             #[cfg(test)]
             #slow_attribute
-            #[test_log::test(tokio::test(flavor = "multi_thread"))]
+            #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
             #[tracing::instrument]
             async fn #test_name() {
                 hotshot_testing::test_builder::TestDescription::<#ty, #imply, #version>::gen_launcher((#metadata)).launch().run_test::<#builder_impl>().await;

--- a/crates/hotshot/testing/tests/test_epoch_success_overlap_2_f.rs
+++ b/crates/hotshot/testing/tests/test_epoch_success_overlap_2_f.rs
@@ -20,6 +20,15 @@ cross_tests!(
     Versions: [EpochsTestVersions],
     Ignore: false,
     Metadata: {
-        TestDescription::default().set_num_nodes(14, 14)
+        let mut metadata = TestDescription::default().set_num_nodes(14, 14);
+
+        let timing_data = TimingData {
+            next_view_timeout: 12_000,
+            ..Default::default()
+        };
+
+        metadata.timing_data = timing_data;
+
+        metadata
     },
 );

--- a/crates/hotshot/testing/tests/test_epoch_success_overlap_3f.rs
+++ b/crates/hotshot/testing/tests/test_epoch_success_overlap_3f.rs
@@ -20,6 +20,15 @@ cross_tests!(
     Versions: [EpochsTestVersions],
     Ignore: false,
     Metadata: {
-        TestDescription::default().set_num_nodes(14, 14)
+        let mut metadata = TestDescription::default().set_num_nodes(14, 14);
+
+        let timing_data = TimingData {
+            next_view_timeout: 12_000,
+            ..Default::default()
+        };
+
+        metadata.timing_data = timing_data;
+
+        metadata
     },
 );

--- a/crates/hotshot/testing/tests/test_success_with_async_delay_2_with_epochs.rs
+++ b/crates/hotshot/testing/tests/test_success_with_async_delay_2_with_epochs.rs
@@ -37,6 +37,14 @@ cross_tests!(
             ..TestDescription::default()
         };
 
+
+        let timing_data = TimingData {
+            next_view_timeout: 12_000,
+            ..Default::default()
+        };
+
+        metadata.timing_data = timing_data;
+
         metadata.test_config.epoch_height = 10;
         metadata.overall_safety_properties.num_successful_views = 30;
         let mut config = DelayConfig::default();

--- a/crates/hotshot/testing/tests/test_success_with_async_delay_with_epochs.rs
+++ b/crates/hotshot/testing/tests/test_success_with_async_delay_with_epochs.rs
@@ -25,6 +25,13 @@ cross_tests!(
     Metadata: {
         let mut metadata = TestDescription::default();
 
+        let timing_data = TimingData {
+            next_view_timeout: 12_000,
+            ..Default::default()
+        };
+
+        metadata.timing_data = timing_data;
+
         metadata.test_config.epoch_height = 10;
         metadata.overall_safety_properties.num_successful_views = 50;
         let mut config = DelayConfig::default();


### PR DESCRIPTION
Updates view timeouts on some tests from the default of 6 to 12
