### PR TITLE
fix(deployer): check token version before V2 upgrade

### DIFF
--- a/contracts/rust/deployer/src/lib.rs
+++ b/contracts/rust/deployer/src/lib.rs
@@ -857,6 +857,16 @@ pub async fn upgrade_esp_token_v2(
     };
 
     let proxy = EspToken::new(proxy_addr, &provider);
+
+    // Check if already on V2
+    let current_version = proxy.getVersion().call().await?;
+    if current_version.majorVersion >= 2 {
+        anyhow::bail!(
+            "EspToken is already on V{}, no upgrade needed",
+            current_version.majorVersion
+        )
+    }
+
     // Deploy the new implementation
     let v2_addr = contracts
         .deploy(Contract::EspTokenV2, EspTokenV2::deploy_builder(&provider))

--- a/contracts/rust/deployer/src/proposals/multisig.rs
+++ b/contracts/rust/deployer/src/proposals/multisig.rs
@@ -526,6 +526,16 @@ pub async fn upgrade_esp_token_v2_multisig_owner(
         .ok_or_else(|| anyhow!("EspTokenProxy (multisig owner) not found, can't upgrade"))?;
     tracing::info!("EspTokenProxy found at {proxy_addr:#x}");
     let proxy = EspToken::new(proxy_addr, &provider);
+
+    // Check if already on V2
+    let current_version = proxy.getVersion().call().await?;
+    if current_version.majorVersion >= 2 {
+        anyhow::bail!(
+            "EspToken is already on V{}, no upgrade needed",
+            current_version.majorVersion
+        )
+    }
+
     let owner_addr = proxy.owner().call().await?;
 
     if !dry_run {


### PR DESCRIPTION
Fixes #3812

Adds a version check at the start of `upgrade_esp_token_v2()` and `upgrade_esp_token_v2_multisig_owner()` to fail early with a clear error message if the token is already on V2.

**Before:** Attempting to upgrade an already-V2 token resulted in a cryptic `InvalidInitialization` revert (`0xf92ee8a9`).

**After:** Users get a clear message: `EspToken is already on V2, no upgrade needed`