### PR TITLE
test: add snapshot test for stake table event signatures

### DIFF
--- a/data/insta_snapshots/espresso_types__reference_tests__stake_table_event_signatures.snap
+++ b/data/insta_snapshots/espresso_types__reference_tests__stake_table_event_signatures.snap
@@ -1,0 +1,25 @@
+---
+source: types/src/reference_tests.rs
+assertion_line: 737
+expression: signatures
+---
+- - ValidatorRegistered
+  - "ValidatorRegistered(address,(uint256,uint256,uint256,uint256),(uint256,uint256),uint16)"
+- - ValidatorRegisteredV2
+  - "ValidatorRegisteredV2(address,(uint256,uint256,uint256,uint256),(uint256,uint256),uint16,(uint256,uint256),bytes,string)"
+- - ValidatorExit
+  - ValidatorExit(address)
+- - ValidatorExitV2
+  - "ValidatorExitV2(address,uint256)"
+- - Delegated
+  - "Delegated(address,address,uint256)"
+- - Undelegated
+  - "Undelegated(address,address,uint256)"
+- - UndelegatedV2
+  - "UndelegatedV2(address,address,uint64,uint256,uint256)"
+- - ConsensusKeysUpdated
+  - "ConsensusKeysUpdated(address,(uint256,uint256,uint256,uint256),(uint256,uint256))"
+- - ConsensusKeysUpdatedV2
+  - "ConsensusKeysUpdatedV2(address,(uint256,uint256,uint256,uint256),(uint256,uint256),(uint256,uint256),bytes)"
+- - CommissionUpdated
+  - "CommissionUpdated(address,uint256,uint16,uint16)"

--- a/types/src/reference_tests.rs
+++ b/types/src/reference_tests.rs
@@ -697,3 +697,43 @@ async fn test_reward_proof_endpoint_serialization() {
         insta::assert_yaml_snapshot!("reward_claim_input_v2", reward_claim_input);
     });
 }
+
+/// Snapshot test for stake table event signatures.
+///
+/// These signatures are consensus-critical: changing event names or types will change
+/// their signatures, which breaks consensus because older versions of the rust code
+/// filter events using these signatures. This test ensures any changes are caught.
+///
+/// See: https://github.com/EspressoSystems/espresso-network/issues/3769
+#[test]
+fn test_stake_table_event_signatures() {
+    use alloy::sol_types::SolEvent;
+    use hotshot_contract_adapter::sol_types::StakeTableV2::{
+        CommissionUpdated, ConsensusKeysUpdated, ConsensusKeysUpdatedV2, Delegated, Undelegated,
+        UndelegatedV2, ValidatorExit, ValidatorExitV2, ValidatorRegistered, ValidatorRegisteredV2,
+    };
+
+    // These signatures are consensus-critical. If this test fails, you are making
+    // a breaking change that will cause consensus failures between different versions.
+    let signatures = vec![
+        ("ValidatorRegistered", ValidatorRegistered::SIGNATURE),
+        ("ValidatorRegisteredV2", ValidatorRegisteredV2::SIGNATURE),
+        ("ValidatorExit", ValidatorExit::SIGNATURE),
+        ("ValidatorExitV2", ValidatorExitV2::SIGNATURE),
+        ("Delegated", Delegated::SIGNATURE),
+        ("Undelegated", Undelegated::SIGNATURE),
+        ("UndelegatedV2", UndelegatedV2::SIGNATURE),
+        ("ConsensusKeysUpdated", ConsensusKeysUpdated::SIGNATURE),
+        ("ConsensusKeysUpdatedV2", ConsensusKeysUpdatedV2::SIGNATURE),
+        ("CommissionUpdated", CommissionUpdated::SIGNATURE),
+    ];
+
+    let mut settings = insta::Settings::clone_current();
+    let data_dir =
+        Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("../data/insta_snapshots");
+    settings.set_snapshot_path(data_dir);
+
+    settings.bind(|| {
+        insta::assert_yaml_snapshot!("stake_table_event_signatures", signatures);
+    });
+}


### PR DESCRIPTION
Fixes #3769

Adds a snapshot test that captures the signatures of all consensus-critical stake table events. If any event name or type changes, the test will fail, alerting developers that they're making a breaking change that could cause consensus failures between different versions.

**Events tested:**
- ValidatorRegistered, ValidatorRegisteredV2
- ValidatorExit, ValidatorExitV2
- Delegated, Undelegated, UndelegatedV2
- ConsensusKeysUpdated, ConsensusKeysUpdatedV2
- CommissionUpdated