### PR TITLE
Add context to missing key file error

### DIFF
--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -364,7 +364,9 @@ impl Options {
 
     pub fn private_keys(&self) -> anyhow::Result<(BLSPrivKey, StateSignKey)> {
         if let Some(path) = &self.key_file {
-            let vars = dotenvy::from_path_iter(path)?.collect::<Result<HashMap<_, _>, _>>()?;
+            let vars = dotenvy::from_path_iter(path)
+                .with_context(|| format!("failed to read key file: {}", path.display()))?
+                .collect::<Result<HashMap<_, _>, _>>()?;
             let staking = TaggedBase64::parse(
                 vars.get("ESPRESSO_SEQUENCER_PRIVATE_STAKING_KEY")
                     .context("key file missing ESPRESSO_SEQUENCER_PRIVATE_STAKING_KEY")?,


### PR DESCRIPTION
## Summary
- Adds path context to the error when a key file cannot be read
- Fixes #2059

**Before:**
```
Error: No such file or directory (os error 2)
```

**After:**
```
Error: failed to read key file: /path/to/keys.env

Caused by:
    No such file or directory (os error 2)
```

## Test plan
- [x] `cargo check -p sequencer` passes
- Manual verification: attempt to start sequencer with non-existent key file path