### PR TITLE
 Fix SQLite merkle root `STORED` column migration

### DIFF
--- a/sequencer/api/migrations/sqlite/V106__merkle_root_columns.sql
+++ b/sequencer/api/migrations/sqlite/V106__merkle_root_columns.sql
@@ -1,12 +1,12 @@
 -- Add block_merkle_tree_root column as a generated column
 ALTER TABLE header
-ADD COLUMN block_merkle_tree_root TEXT
-GENERATED ALWAYS AS (coalesce(json_extract(data, '$.block_merkle_tree_root'), json_extract(data, '$.fields.block_merkle_tree_root'))) STORED NOT NULL;
+ADD COLUMN block_merkle_tree_root TEXT NOT NULL
+GENERATED ALWAYS AS (coalesce(json_extract(data, '$.block_merkle_tree_root'), json_extract(data, '$.fields.block_merkle_tree_root'))) VIRTUAL;
 
 -- Add fee_merkle_tree_root column as a generated column
 ALTER TABLE header
-ADD COLUMN fee_merkle_tree_root TEXT
-GENERATED ALWAYS AS (coalesce(json_extract(data, '$.fee_merkle_tree_root'), json_extract(data, '$.fields.fee_merkle_tree_root'))) STORED NOT NULL;
+ADD COLUMN fee_merkle_tree_root TEXT NOT NULL
+GENERATED ALWAYS AS (coalesce(json_extract(data, '$.fee_merkle_tree_root'), json_extract(data, '$.fields.fee_merkle_tree_root'))) VIRTUAL;
 
 CREATE INDEX header_block_merkle_tree_root_idx ON header (block_merkle_tree_root);
 CREATE INDEX header_fee_merkle_tree_root_idx ON header (fee_merkle_tree_root);


### PR DESCRIPTION
  SQLite does not allow adding `STORED` generated columns using `ALTER TABLE`. 