### PR TITLE
fix: verify CDN signatures only over namespaced message

### DIFF
--- a/sequencer/src/network/cdn.rs
+++ b/sequencer/src/network/cdn.rs
@@ -78,8 +78,7 @@ impl<T: SignatureKey> SignatureScheme for WrappedSignatureKey<T> {
             Err(_) => return false,
         };
 
-        public_key.0.validate(&signature, message)
-            || public_key.0.validate(&signature, &namespaced_message)
+        public_key.0.validate(&signature, &namespaced_message)
     }
 }
 


### PR DESCRIPTION
Previously WrappedSignatureKey::verify first validated the signature against the raw message and only then against namespace + message, which contradicted the namespacing intent, weakened replay protection across protocols sharing the same key, and added unnecessary extra validation work.

Updated WrappedSignatureKey::verify in the sequencer CDN adapter to validate signatures exclusively over the concatenated namespace + message, aligning the behavior with the HotShot implementation and removing the redundant raw-message validation.