### PR TITLE
Add PeerConfigLegacy for stake-table endpoint

### DIFF
--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -5206,7 +5206,7 @@ mod test {
 
         for i in 1..=3 {
             let _st = client
-                .get::<Vec<PeerConfigLegacy<SeqTypes>>>(&format!("node/stake-table/{}", i as u64))
+                .get::<Vec<PeerConfig<SeqTypes>>>(&format!("node/stake-table/{}", i as u64))
                 .send()
                 .await
                 .expect("failed to get stake table");

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -5206,7 +5206,7 @@ mod test {
 
         for i in 1..=3 {
             let _st = client
-                .get::<Vec<PeerConfig<SeqTypes>>>(&format!("node/stake-table/{}", i as u64))
+                .get::<Vec<PeerConfigLegacy<SeqTypes>>>(&format!("node/stake-table/{}", i as u64))
                 .send()
                 .await
                 .expect("failed to get stake table");

--- a/crates/espresso/node/src/api/endpoints.rs
+++ b/crates/espresso/node/src/api/endpoints.rs
@@ -534,13 +534,21 @@ where
                 })?
                 .map(EpochNumber::new);
 
-            state
+            let stake_table = state
                 .read(|state| state.get_stake_table(epoch).boxed())
                 .await
                 .map_err(|err| node::Error::Custom {
                     message: format!("failed to get stake table for epoch={epoch:?}. err={err:#}"),
                     status: StatusCode::NOT_FOUND,
-                })
+                })?;
+
+            // Convert to legacy format for backward compatibility
+            let legacy_stake_table: Vec<_> = stake_table
+                .into_iter()
+                .map(|peer| peer.to_legacy())
+                .collect();
+
+            Ok(legacy_stake_table)
         }
         .boxed()
     })?
@@ -568,7 +576,7 @@ where
                 })?
                 .map(EpochNumber::new);
 
-            state
+            let da_stake_table = state
                 .read(|state| state.get_da_stake_table(epoch).boxed())
                 .await
                 .map_err(|err| node::Error::Custom {
@@ -576,7 +584,15 @@ where
                         "failed to get DA stake table for epoch={epoch:?}. err={err:#}"
                     ),
                     status: StatusCode::NOT_FOUND,
-                })
+                })?;
+
+            // Convert to legacy format for backward compatibility
+            let legacy_da_stake_table: Vec<_> = da_stake_table
+                .into_iter()
+                .map(|peer| peer.to_legacy())
+                .collect();
+
+            Ok(legacy_da_stake_table)
         }
         .boxed()
     })?

--- a/crates/hotshot/types/src/lib.rs
+++ b/crates/hotshot/types/src/lib.rs
@@ -155,6 +155,18 @@ pub struct PeerConnectInfo {
     pub p2p_addr: NetAddr,
 }
 
+/// Legacy structure of peers' config without connect_info, for backward compatibility.
+#[derive(Clone, Debug, Display, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(bound(deserialize = ""))]
+pub struct PeerConfigLegacy<TYPES: NodeType> {
+    /// The peer's public key and stake value. The key is the BLS Public Key used to
+    /// verify Stake Holder in the application layer.
+    pub stake_table_entry: <TYPES::SignatureKey as SignatureKey>::StakeTableEntry,
+    /// The peer's state public key. This is the Schnorr Public Key used to
+    /// verify HotShot state in the state-prover.
+    pub state_ver_key: TYPES::StateSignatureKey,
+}
+
 /// Structure of peers' config, including public key, stake value, and state key.
 #[derive(Clone, Display, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(bound(deserialize = ""))]
@@ -165,7 +177,7 @@ pub struct PeerConfig<TYPES: NodeType> {
     /// The peer's state public key. This is the Schnorr Public Key used to
     /// verify HotShot state in the state-prover.
     pub state_ver_key: TYPES::StateSignatureKey,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub connect_info: Option<PeerConnectInfo>,
 }
 
@@ -174,6 +186,23 @@ impl<TYPES: NodeType> PeerConfig<TYPES> {
     pub fn test_default() -> Self {
         let default_validator_config = ValidatorConfig::<TYPES>::test_default();
         default_validator_config.public_config()
+    }
+
+    /// Convert to legacy format (without connect_info) for backward compatibility
+    pub fn to_legacy(&self) -> PeerConfigLegacy<TYPES> {
+        PeerConfigLegacy {
+            stake_table_entry: self.stake_table_entry.clone(),
+            state_ver_key: self.state_ver_key.clone(),
+        }
+    }
+
+    /// Convert from legacy format (connect_info will be None)
+    pub fn from_legacy(legacy: PeerConfigLegacy<TYPES>) -> Self {
+        Self {
+            stake_table_entry: legacy.stake_table_entry,
+            state_ver_key: legacy.state_ver_key,
+            connect_info: None,
+        }
     }
 
     /// Serialize a peer's config to bytes

--- a/crates/hotshot/types/src/lib.rs
+++ b/crates/hotshot/types/src/lib.rs
@@ -165,6 +165,7 @@ pub struct PeerConfig<TYPES: NodeType> {
     /// The peer's state public key. This is the Schnorr Public Key used to
     /// verify HotShot state in the state-prover.
     pub state_ver_key: TYPES::StateSignatureKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connect_info: Option<PeerConnectInfo>,
 }
 


### PR DESCRIPTION
The addition of `connect_info` was a breaking serialization change; this PR fixes that
