### PR TITLE
Migrate hash sequence key to bigint

### DIFF
--- a/crates/espresso/node/api/migrations/postgres/V1501__increase_hash_id_to_bigint.sql
+++ b/crates/espresso/node/api/migrations/postgres/V1501__increase_hash_id_to_bigint.sql
@@ -1,0 +1,10 @@
+-- hash.id was SERIAL (32-bit INTEGER), which exhausted its sequence at 2^31-1.
+-- Widen the sequence, the primary key, and all foreign-key references to BIGINT.
+ALTER SEQUENCE hash_id_seq AS BIGINT;
+
+ALTER TABLE hash ALTER COLUMN id TYPE BIGINT;
+
+ALTER TABLE fee_merkle_tree     ALTER COLUMN hash_id TYPE BIGINT;
+ALTER TABLE block_merkle_tree   ALTER COLUMN hash_id TYPE BIGINT;
+ALTER TABLE reward_merkle_tree  ALTER COLUMN hash_id TYPE BIGINT;
+ALTER TABLE reward_merkle_tree_v2 ALTER COLUMN hash_id TYPE BIGINT;

--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -1263,7 +1263,7 @@ pub mod testing {
                 (
                     "BIT(8)",
                     "BYTEA",
-                    "SERIAL PRIMARY KEY",
+                    "BIGSERIAL PRIMARY KEY",
                     "(data->>'test_merkle_tree_root')",
                 )
             };

--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -1283,7 +1283,7 @@ pub mod testing {
             (
                 path JSONB NOT NULL,
                 created BIGINT NOT NULL,
-                hash_id INT NOT NULL,
+                hash_id BIGINT NOT NULL,
                 children JSONB,
                 children_bitvec {bit_vec},
                 idx JSONB,

--- a/hotshot-query-service/src/data_source/storage/sql/queries/state.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/state.rs
@@ -77,9 +77,9 @@ where
         for node in nodes.iter() {
             hash_ids.insert(node.hash_id);
             if let Some(children) = &node.children {
-                let children: Vec<i32> =
+                let children: Vec<i64> =
                     serde_json::from_value(children.clone()).map_err(|e| QueryError::Error {
-                        message: format!("Error deserializing 'children' into Vec<i32>: {e}"),
+                        message: format!("Error deserializing 'children' into Vec<i64>: {e}"),
                     })?;
                 hash_ids.extend(children);
             }
@@ -92,7 +92,7 @@ where
             query
                 .query_as(&sql)
                 .fetch(self.as_mut())
-                .try_collect::<HashMap<i32, Vec<u8>>>()
+                .try_collect::<HashMap<i64, Vec<u8>>>()
                 .await?
         } else {
             HashMap::new()
@@ -116,11 +116,11 @@ where
                 match (children, children_bitvec, idx, entry) {
                     // If the row has children then its a branch
                     (Some(children), Some(children_bitvec), None, None) => {
-                        let children: Vec<i32> =
+                        let children: Vec<i64> =
                             serde_json::from_value(children.clone()).map_err(|e| {
                                 QueryError::Error {
                                     message: format!(
-                                        "Error deserializing 'children' into Vec<i32>: {e}"
+                                        "Error deserializing 'children' into Vec<i64>: {e}"
                                     ),
                                 }
                             })?;
@@ -366,7 +366,7 @@ pub(crate) fn build_hash_batch_insert(
 pub(crate) async fn batch_insert_hashes(
     hashes: Vec<Vec<u8>>,
     tx: &mut Transaction<Write>,
-) -> QueryResult<HashMap<Vec<u8>, i32>> {
+) -> QueryResult<HashMap<Vec<u8>, i64>> {
     if hashes.is_empty() {
         return Ok(HashMap::new());
     }
@@ -375,7 +375,7 @@ pub(crate) async fn batch_insert_hashes(
     let sql = "INSERT INTO hash(value) SELECT * FROM UNNEST($1::bytea[]) ON CONFLICT (value) DO \
                UPDATE SET value = EXCLUDED.value RETURNING value, id";
 
-    let result: HashMap<Vec<u8>, i32> = sqlx::query_as(sql)
+    let result: HashMap<Vec<u8>, i64> = sqlx::query_as(sql)
         .bind(&hashes)
         .fetch(tx.as_mut())
         .try_collect()
@@ -524,7 +524,7 @@ where
 pub(crate) struct Node {
     pub(crate) path: JsonValue,
     pub(crate) created: i64,
-    pub(crate) hash_id: i32,
+    pub(crate) hash_id: i64,
     pub(crate) children: Option<JsonValue>,
     pub(crate) children_bitvec: Option<BitVec>,
     pub(crate) idx: Option<JsonValue>,
@@ -662,7 +662,7 @@ impl Node {
         let sql = format!(
             r#"
             INSERT INTO "{name}" (path, created, hash_id, children, children_bitvec, idx, entry)
-            SELECT * FROM UNNEST($1::jsonb[], $2::bigint[], $3::int[], $4::jsonb[], $5::bit varying[], $6::jsonb[], $7::jsonb[])
+            SELECT * FROM UNNEST($1::jsonb[], $2::bigint[], $3::bigint[], $4::jsonb[], $5::bit varying[], $6::jsonb[], $7::jsonb[])
             ON CONFLICT (path, created) DO UPDATE SET
                 hash_id = EXCLUDED.hash_id,
                 children = EXCLUDED.children,

--- a/hotshot-query-service/src/data_source/storage/sql/transaction.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/transaction.rs
@@ -848,14 +848,14 @@ impl<Types: NodeType, State: MerklizedState<Types, ARITY>, const ARITY: usize>
         let hashes: Vec<Vec<u8>> = all_hashes.into_iter().collect();
 
         #[cfg(not(feature = "embedded-db"))]
-        let nodes_hash_ids: HashMap<Vec<u8>, i32> = batch_insert_hashes(hashes, self).await?;
+        let nodes_hash_ids: HashMap<Vec<u8>, i64> = batch_insert_hashes(hashes, self).await?;
 
         #[cfg(feature = "embedded-db")]
-        let nodes_hash_ids: HashMap<Vec<u8>, i32> = {
-            let mut hash_ids: HashMap<Vec<u8>, i32> = HashMap::with_capacity(hashes.len());
+        let nodes_hash_ids: HashMap<Vec<u8>, i64> = {
+            let mut hash_ids: HashMap<Vec<u8>, i64> = HashMap::with_capacity(hashes.len());
             for hash_chunk in hashes.chunks(20) {
                 let (query, sql) = build_hash_batch_insert(hash_chunk)?;
-                let chunk_ids: HashMap<Vec<u8>, i32> = query
+                let chunk_ids: HashMap<Vec<u8>, i64> = query
                     .query_as(&sql)
                     .fetch(self.as_mut())
                     .try_collect()
@@ -875,7 +875,7 @@ impl<Types: NodeType, State: MerklizedState<Types, ARITY>, const ARITY: usize>
                 let children_hashes = children
                     .iter()
                     .map(|c| nodes_hash_ids.get(c).copied())
-                    .collect::<Option<Vec<i32>>>()
+                    .collect::<Option<Vec<i64>>>()
                     .ok_or(QueryError::Error {
                         message: "Missing child hash".to_string(),
                     })?;


### PR DESCRIPTION
We hit the sequence limit for the hash table on a decaf node, and it's likely we'll hit the same limit on mainnet/other decaf nodes in the next few months. This PR switches the postgres id to a bigint, which should resolve the issue.

No sqlite migration is needed since that is already a u64.
