### PR TITLE
Commit to full Common Data in VID Commitment

### DIFF
--- a/vid/src/avidm_gf2/namespaced.rs
+++ b/vid/src/avidm_gf2/namespaced.rs
@@ -10,6 +10,7 @@ use super::{AvidmGf2Commit, AvidmGf2Share};
 use crate::{
     VidError, VidResult, VidScheme,
     avidm_gf2::{AvidmGf2Scheme, MerkleTree},
+    utils::blake3::Blake3Node,
 };
 
 /// Dummy struct for namespaced AvidmGf2 scheme
@@ -35,6 +36,42 @@ impl NsAvidmGf2Common {
     /// Return the total payload byte length
     pub fn payload_byte_len(&self) -> usize {
         self.ns_lens.iter().sum()
+    }
+
+    /// Commitment to this common data: the root of [`Self::merkle_tree`].
+    pub fn commitment(&self) -> VidResult<NsAvidmGf2Commit> {
+        Ok(NsAvidmGf2Commit {
+            commit: self.merkle_tree()?.commitment(),
+        })
+    }
+
+    /// The merkle tree underlying the namespaced VID commitment: one leaf
+    /// per namespace commitment, plus a final leaf binding the rest of the
+    /// common data. Binding the entire common means `is_consistent` rejects
+    /// a tampered `param` or `ns_lens`, not just tampered namespace
+    /// commitments — nobody can pass off altered decoding parameters as
+    /// belonging to an honest commitment.
+    pub(crate) fn merkle_tree(&self) -> VidResult<MerkleTree> {
+        let leaves = self
+            .ns_commits
+            .iter()
+            .map(|c| c.commit)
+            .chain([self.binding_leaf()]);
+        MerkleTree::from_elems(None, leaves).map_err(|err| VidError::Internal(err.into()))
+    }
+
+    /// Hash of the common data fields that the namespace commitment leaves
+    /// don't already bind.
+    fn binding_leaf(&self) -> Blake3Node {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"NS_AVIDM_GF2_COMMON");
+        hasher.update(&(self.param.recovery_threshold as u64).to_le_bytes());
+        hasher.update(&(self.param.total_weights as u64).to_le_bytes());
+        hasher.update(&(self.ns_lens.len() as u64).to_le_bytes());
+        for len in &self.ns_lens {
+            hasher.update(&(*len as u64).to_le_bytes());
+        }
+        hasher.finalize().into()
     }
 }
 
@@ -97,20 +134,18 @@ impl NsAvidmGf2Scheme {
             ns_commits,
             ns_lens,
         };
-        let commit = MerkleTree::from_elems(None, common.ns_commits.iter().map(|c| c.commit))
-            .map_err(|err| VidError::Internal(err.into()))?
-            .commitment();
-        Ok((NsAvidmGf2Commit { commit }, common))
+        let commit = common.commitment()?;
+        Ok((commit, common))
     }
 
-    /// Check whether the namespaced commitment is consistent with the common data
+    /// Check whether the namespaced commitment is consistent with the common
+    /// data. The commitment binds the entire common (namespace commitments,
+    /// `param`, and `ns_lens`), so a `true` result authenticates every field
+    /// of `common` against `commit`.
     pub fn is_consistent(commit: &NsAvidmGf2Commit, common: &NsAvidmGf2Common) -> bool {
-        let Ok(mt) =
-            MerkleTree::from_elems(None, common.ns_commits.iter().map(|commit| commit.commit))
-        else {
-            return false;
-        };
-        commit.commit == mt.commitment()
+        common
+            .commitment()
+            .is_ok_and(|recomputed| recomputed == *commit)
     }
 
     /// Disperse a payload according to a distribution table and a namespace
@@ -145,11 +180,7 @@ impl NsAvidmGf2Scheme {
             ns_commits,
             ns_lens,
         };
-        let commit = NsAvidmGf2Commit {
-            commit: MerkleTree::from_elems(None, common.ns_commits.iter().map(|c| c.commit))
-                .map_err(|err| VidError::Internal(err.into()))?
-                .commitment(),
-        };
+        let commit = common.commitment()?;
         let mut shares = vec![NsAvidmGf2Share::default(); num_storage_nodes];
         disperses.into_iter().for_each(|ns_disperse| {
             shares
@@ -345,6 +376,37 @@ pub mod tests {
         let mut tampered_common = common;
         tampered_common.ns_commits = different_common.ns_commits;
         assert!(!NsAvidmGf2Scheme::is_consistent(&commit, &tampered_common));
+    }
+
+    /// The commitment must bind `param`, not just the namespace commitments:
+    /// otherwise a Byzantine node could pass off forged decoding parameters
+    /// alongside the honest `ns_commits` as belonging to an honest
+    /// commitment.
+    #[test]
+    fn is_consistent_rejects_tampered_param() {
+        let (commit, common, _shares) = setup_test_data();
+
+        let mut tampered = common.clone();
+        tampered.param.recovery_threshold = 1;
+        assert!(!NsAvidmGf2Scheme::is_consistent(&commit, &tampered));
+
+        let mut tampered = common;
+        tampered.param.total_weights *= 2;
+        assert!(!NsAvidmGf2Scheme::is_consistent(&commit, &tampered));
+    }
+
+    /// Same as `is_consistent_rejects_tampered_param`, for `ns_lens`.
+    #[test]
+    fn is_consistent_rejects_tampered_ns_lens() {
+        let (commit, common, _shares) = setup_test_data();
+
+        let mut tampered = common.clone();
+        tampered.ns_lens[0] += 1;
+        assert!(!NsAvidmGf2Scheme::is_consistent(&commit, &tampered));
+
+        let mut tampered = common;
+        tampered.ns_lens.push(0);
+        assert!(!NsAvidmGf2Scheme::is_consistent(&commit, &tampered));
     }
 
     #[test]

--- a/vid/src/avidm_gf2/proofs.rs
+++ b/vid/src/avidm_gf2/proofs.rs
@@ -48,7 +48,7 @@ impl NsAvidmGf2Scheme {
             )));
         }
 
-        let mt = MerkleTree::from_elems(None, common.ns_commits.iter().map(|c| c.commit))?;
+        let mt = common.merkle_tree()?;
         Ok(NsProof {
             ns_index,
             ns_payload: payload[ns_payload_range_start..ns_payload_range_end].to_vec(),
@@ -61,11 +61,23 @@ impl NsAvidmGf2Scheme {
     }
 
     /// Verify a namespace proof against a namespaced VID commitment.
+    ///
+    /// `common` may come from an untrusted source: it is first checked for
+    /// consistency against `commit` (which binds all of it), so a forged
+    /// `param` or `ns_lens` fails verification outright.
     pub fn verify_namespace_proof(
         commit: &NsAvidmGf2Commit,
         common: &NsAvidmGf2Common,
         proof: &NsProof,
     ) -> VidResult<VerificationResult> {
+        if !Self::is_consistent(commit, common) {
+            return Ok(Err(()));
+        }
+        // Excludes the final binding leaf of the commitment's merkle tree,
+        // which is not a namespace commitment.
+        if proof.ns_index >= common.ns_commits.len() {
+            return Ok(Err(()));
+        }
         let ns_commit = AvidmGf2Scheme::commit(&common.param, &proof.ns_payload)?;
         Ok(MerkleTree::verify(
             &commit.commit,
@@ -113,6 +125,38 @@ mod tests {
         proof.ns_index = 100;
         assert!(
             NsAvidmGf2Scheme::verify_namespace_proof(&commit, &common, &proof)
+                .unwrap()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn ns_proof_rejects_tampered_common() {
+        let param = AvidmGf2Scheme::setup(5usize, 10usize).unwrap();
+        let payload = vec![1u8; 100];
+        let ns_table = vec![(0..10), (10..100)];
+        let (commit, common) = NsAvidmGf2Scheme::commit(&param, &payload, ns_table).unwrap();
+        let proof = NsAvidmGf2Scheme::namespace_proof(&common, &payload, 1).unwrap();
+        assert!(
+            NsAvidmGf2Scheme::verify_namespace_proof(&commit, &common, &proof)
+                .unwrap()
+                .is_ok()
+        );
+
+        // A common with forged params does not belong to this commitment.
+        let mut tampered = common.clone();
+        tampered.param.recovery_threshold = 1;
+        assert!(
+            NsAvidmGf2Scheme::verify_namespace_proof(&commit, &tampered, &proof)
+                .unwrap()
+                .is_err()
+        );
+
+        // The binding leaf's index cannot be claimed as a namespace.
+        let mut out_of_range = proof.clone();
+        out_of_range.ns_index = common.ns_commits.len();
+        assert!(
+            NsAvidmGf2Scheme::verify_namespace_proof(&commit, &common, &out_of_range)
                 .unwrap()
                 .is_err()
         );


### PR DESCRIPTION
The namespaced AvidmGf2 commitment was the merkle root over ns_commits alone, so is_consistent() could not detect a common carrying honest namespace commitments alongside a forged param or ns_lens. A Byzantine node could exploit this to pass off altered decoding parameters as belonging to an honest commitment (e.g. to poison a VID share accumulator keyed by commitment, blocking payload reconstruction).

Append one leaf to the commitment's merkle tree hashing param and ns_lens, so the commitment binds the entire common and is_consistent() authenticates every field. verify_namespace_proof() now also checks common consistency itself, since verifiers receive the common from untrusted sources, and rejects the binding leaf's index.

No serialized formats change (the commitment stays a 32-byte root, and common, shares, and NsProof are untouched); all V0_6 commitment values change, which is safe while V0_6 is unshipped. The shipped AvidM (V0_3) scheme is untouched.

Regression tests: is_consistent_rejects_tampered_param, is_consistent_rejects_tampered_ns_lens, ns_proof_rejects_tampered_common.

Closes #<ISSUE_NUMBER>
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
