### PR TITLE
Backport on label

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,7 @@
 name: Backport merged pull request
 on:
   pull_request_target:
-    types: [closed]
+    types: [closed, labeled]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,20 +15,24 @@ on:
 permissions:
   contents: write
   pull-requests: write
-concurrency:
-  group: backport-${{ github.event.pull_request.number || inputs.pr_number }}
-  cancel-in-progress: false
 jobs:
   backport:
     name: Backport pull request
     runs-on: ubuntu-latest
-    # The `labeled` trigger fires for every label. Only run it for backport
-    # labels, which match the action's default `^backport ([^ ]+)$`.
+    # The `labeled` trigger fires for every label. Only run for backport
+    # labels, matching `label_pattern` below.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged &&
        (github.event.action != 'labeled' ||
         startsWith(github.event.label.name, 'backport ')))
+    # The dispatch and label paths push the same backport-<pr>-to-<target>
+    # branch, so runs for one PR must not overlap. Keep this at job level: a
+    # workflow-level group is entered before `if` is evaluated, so an unrelated
+    # label would queue a run that evicts a pending real backport.
+    concurrency:
+      group: backport-${{ github.event.pull_request.number || inputs.pr_number }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
         with:
@@ -70,6 +74,8 @@ jobs:
         if: github.event_name == 'pull_request_target'
         uses: korthout/backport-action@v3
         with:
+          # Kept in sync with the `labeled` guard on this job.
+          label_pattern: '^backport ([^ ]+)$'
           experimental: '{"conflict_resolution":"draft_commit_conflicts"}'
 
       - name: Detect remaining conflicts

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,11 +15,20 @@ on:
 permissions:
   contents: write
   pull-requests: write
+concurrency:
+  group: backport-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
 jobs:
   backport:
     name: Backport pull request
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged
+    # The `labeled` trigger fires for every label. Only run it for backport
+    # labels, which match the action's default `^backport ([^ ]+)$`.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged &&
+       (github.event.action != 'labeled' ||
+        startsWith(github.event.label.name, 'backport ')))
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Triggers a backport when a backport label is added to a PR, if the PR has already been merged.
