### PR TITLE
refactor(request-response): typed per-caller response waiters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11084,8 +11084,6 @@ name = "request-response"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-broadcast",
- "async-lock 3.4.2",
  "async-trait",
  "bincode",
  "blake3",

--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -280,7 +280,6 @@ where
         let request_response_config = RequestResponseConfig {
             incoming_request_ttl: Duration::from_secs(40),
             incoming_request_timeout: Duration::from_secs(5),
-            incoming_response_timeout: Duration::from_secs(5),
             request_batch_size: 5,
             request_batch_interval: Duration::from_secs(2),
             // A node catching up legitimately issues several distinct requests concurrently
@@ -289,7 +288,6 @@ where
             // (possibly from SQL), so the global limit bounds concurrent storage work.
             max_incoming_requests: 32,
             max_incoming_requests_per_key: 4,
-            max_incoming_responses: 200,
         };
 
         // Create the request-response protocol

--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -69,6 +69,16 @@ use crate::{
 pub(crate) type ConsensusNode<N, P> = Node<N, P>;
 pub type Consensus<N, P> = hotshot::types::SystemContextHandle<SeqTypes, ConsensusNode<N, P>>;
 
+/// Capacity of the channel feeding inbound request-response messages from the consensus event
+/// loop to the protocol. Messages are dropped (not queued) when it is full, and a single
+/// broadcast request can fan in a response from every node at once, so this must comfortably
+/// exceed the network size. Entries are `Arc<Vec<u8>>`, so slots are pointer-sized.
+const REQUEST_RESPONSE_CHANNEL_CAPACITY: usize = 256;
+
+/// Capacity of the outbound message channel drained by the external event handler. Responders
+/// block on this channel while holding request-response admission permits.
+const OUTBOUND_MESSAGE_CHANNEL_CAPACITY: usize = 128;
+
 /// The sequencer context contains a consensus handle and other sequencer specific information.
 #[derive(Derivative, Clone)]
 #[derivative(Debug(bound = ""))]
@@ -261,8 +271,10 @@ where
         }
 
         // Create the channel for sending outbound messages from the external event handler
-        let (outbound_message_sender, outbound_message_receiver) = channel(20);
-        let (request_response_sender, request_response_receiver) = channel(20);
+        let (outbound_message_sender, outbound_message_receiver) =
+            channel(OUTBOUND_MESSAGE_CHANNEL_CAPACITY);
+        let (request_response_sender, request_response_receiver) =
+            channel(REQUEST_RESPONSE_CHANNEL_CAPACITY);
 
         // Configure the request-response protocol
         let request_response_config = RequestResponseConfig {
@@ -271,8 +283,12 @@ where
             incoming_response_timeout: Duration::from_secs(5),
             request_batch_size: 5,
             request_batch_interval: Duration::from_secs(2),
-            max_incoming_requests: 10,
-            max_incoming_requests_per_key: 1,
+            // A node catching up legitimately issues several distinct requests concurrently
+            // (accounts, frontier, leaves, chain config), so the per-key limit must allow that.
+            // Permits are held for up to `incoming_request_timeout` while a response is derived
+            // (possibly from SQL), so the global limit bounds concurrent storage work.
+            max_incoming_requests: 32,
+            max_incoming_requests_per_key: 4,
             max_incoming_responses: 200,
         };
 
@@ -310,6 +326,10 @@ where
             outbound_message_receiver,
             network,
             pub_key,
+            metrics
+                .subgroup("request_response".into())
+                .create_counter("inbound_dropped".into(), None)
+                .into(),
         )
         .await
         .with_context(|| "Failed to create external event handler")?;

--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -69,14 +69,12 @@ use crate::{
 pub(crate) type ConsensusNode<N, P> = Node<N, P>;
 pub type Consensus<N, P> = hotshot::types::SystemContextHandle<SeqTypes, ConsensusNode<N, P>>;
 
-/// Capacity of the channel feeding inbound request-response messages from the consensus event
-/// loop to the protocol. Messages are dropped (not queued) when it is full, and a single
+/// Inbound request-response messages are dropped (not queued) when this channel is full, and a
 /// broadcast request can fan in a response from every node at once, so this must comfortably
-/// exceed the network size. Entries are `Arc<Vec<u8>>`, so slots are pointer-sized.
+/// exceed the network size.
 const REQUEST_RESPONSE_CHANNEL_CAPACITY: usize = 256;
 
-/// Capacity of the outbound message channel drained by the external event handler. Responders
-/// block on this channel while holding request-response admission permits.
+/// Responders block on the outbound channel while holding request-response admission permits.
 const OUTBOUND_MESSAGE_CHANNEL_CAPACITY: usize = 128;
 
 /// The sequencer context contains a consensus handle and other sequencer specific information.
@@ -282,10 +280,8 @@ where
             incoming_request_timeout: Duration::from_secs(5),
             request_batch_size: 5,
             request_batch_interval: Duration::from_secs(2),
-            // A node catching up legitimately issues several distinct requests concurrently
-            // (accounts, frontier, leaves, chain config), so the per-key limit must allow that.
-            // Permits are held for up to `incoming_request_timeout` while a response is derived
-            // (possibly from SQL), so the global limit bounds concurrent storage work.
+            // Permits are held while a response is derived (possibly from SQL), and a peer
+            // catching up legitimately issues several distinct requests concurrently
             max_incoming_requests: 32,
             max_incoming_requests_per_key: 4,
         };

--- a/crates/espresso/node/src/external_event_handler.rs
+++ b/crates/espresso/node/src/external_event_handler.rs
@@ -7,7 +7,10 @@ use espresso_types::{PubKey, SeqTypes};
 use hotshot::types::Message;
 use hotshot_types::{
     message::MessageKind,
-    traits::network::{BroadcastDelay, ConnectedNetwork, Topic, ViewMessage},
+    traits::{
+        metrics::Counter,
+        network::{BroadcastDelay, ConnectedNetwork, Topic, ViewMessage},
+    },
 };
 use request_response::network::Bytes;
 use serde::{Deserialize, Serialize};
@@ -27,6 +30,9 @@ pub enum ExternalMessage {
 pub struct ExternalEventHandler {
     /// The sender to the request-response protocol
     request_response_sender: Sender<Bytes>,
+
+    /// Counts inbound request-response messages dropped because the channel was full
+    dropped_messages: Arc<dyn Counter>,
 }
 
 // The different types of outbound messages (broadcast or direct)
@@ -45,6 +51,7 @@ impl ExternalEventHandler {
         outbound_message_receiver: Receiver<OutboundMessage>,
         network: Arc<N>,
         public_key: PubKey,
+        dropped_messages: Arc<dyn Counter>,
     ) -> Result<Self> {
         // Spawn the outbound message handling loop
         tasks.spawn(
@@ -54,6 +61,7 @@ impl ExternalEventHandler {
 
         Ok(Self {
             request_response_sender,
+            dropped_messages,
         })
     }
 
@@ -74,7 +82,10 @@ impl ExternalEventHandler {
                     .try_send(request_response.into())
                 {
                     Ok(()) => Ok(()),
-                    Err(TrySendError::Full(..)) => bail!("request-response channel full"),
+                    Err(TrySendError::Full(..)) => {
+                        self.dropped_messages.add(1);
+                        bail!("request-response channel full")
+                    },
                     Err(TrySendError::Closed(..)) => bail!("request-response channel closed"),
                 }
             },

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -7,12 +7,7 @@ edition.workspace = true
 [features]
 default = ["rlp"]
 rlp = ["alloy-rlp", "hotshot-types/rlp", "espresso-types/rlp"]
-testing = [
-    "espresso-types/testing",
-    "bitvec",
-    "hotshot-contract-adapter",
-    "rand",
-]
+testing = ["espresso-types/testing", "bitvec", "hotshot-contract-adapter", "rand"]
 
 [dependencies]
 alloy = { workspace = true }

--- a/request-response/Cargo.toml
+++ b/request-response/Cargo.toml
@@ -6,8 +6,6 @@ license = "MIT"
 
 [dependencies]
 anyhow = { workspace = true }
-async-broadcast = { workspace = true }
-async-lock = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }

--- a/request-response/src/lib.rs
+++ b/request-response/src/lib.rs
@@ -116,10 +116,6 @@ pub struct RequestResponseConfig {
     /// The maximum amount of time we will spend trying to both derive a response for a request and
     /// send the response over the wire.
     pub incoming_request_timeout: Duration,
-    /// The maximum amount of time we will spend trying to validate a response. This is used to prevent
-    /// an attack where a malicious participant sends us a bunch of requests that take a long time to
-    /// validate.
-    pub incoming_response_timeout: Duration,
     /// The batch size for outgoing requests. This is the number of request messages that we will
     /// send out at a time for a single request before waiting for the [`request_batch_interval`].
     pub request_batch_size: usize,
@@ -129,10 +125,6 @@ pub struct RequestResponseConfig {
     pub max_incoming_requests: usize,
     /// The maximum number of incoming requests that can be processed for a single key at any given time.
     pub max_incoming_requests_per_key: usize,
-    /// The maximum (global) number of incoming responses that can be processed at any given time.
-    /// We need this because responses coming in need to be validated [asynchronously] that they
-    /// satisfy the request they are responding to
-    pub max_incoming_responses: usize,
 }
 
 /// A protocol that allows for request-response communication. Is cheaply cloneable, so there is no
@@ -798,8 +790,6 @@ mod tests {
             request_batch_interval: Duration::from_millis(100),
             max_incoming_requests: 10,
             max_incoming_requests_per_key: 1,
-            incoming_response_timeout: Duration::from_secs(1),
-            max_incoming_responses: 5,
         }
     }
 

--- a/request-response/src/lib.rs
+++ b/request-response/src/lib.rs
@@ -57,10 +57,9 @@ type ActiveRequestsMap<Req> = Arc<RwLock<HashMap<RequestHash, Vec<Waiter<Req>>>>
 /// A type alias for the list of tasks that are responding to requests
 pub type IncomingRequests<K> = NamedSemaphore<K>;
 
-/// The number of responses that can be buffered for each waiter before responses are dropped.
-/// Must comfortably cover the maximum number of simultaneous responders: a broadcast request can
-/// be answered by every node at once while its single waiter validates responses serially.
-/// Buffered entries are `Arc`s, so slots are pointer-sized
+/// The number of responses that can be buffered for each waiter before drops occur. Must cover
+/// the maximum number of simultaneous responders: a broadcast request can be answered by every
+/// node at once while its single waiter validates responses serially
 const RESPONSE_BUFFER_SIZE: usize = 128;
 
 /// The type of request to make
@@ -317,19 +316,17 @@ impl<
         Fut: Future<Output = anyhow::Result<O>> + Send,
         O: Send,
     {
-        // Calculate the hash of the request. It identifies the request on the wire and joins
-        // concurrent callers requesting the same data
+        // The hash identifies the request on the wire and joins concurrent callers
         let request_hash = blake3::hash(&request_message.request.to_bytes().map_err(|e| {
             RequestError::InvalidRequest(anyhow::anyhow!(
                 "failed to serialize request message: {e}"
             ))
         })?);
 
-        // Register for responses before sending the request so none can be missed. Deregisters
-        // itself when dropped (on success, timeout, and cancellation alike)
+        // Register before sending so no response can be missed. Deregisters itself when
+        // dropped, on success, timeout, and cancellation alike
         let mut response_receiver = self.register_waiter(request_hash);
 
-        // Create a request message and serialize it
         let message = Bytes::from(
             Message::Request(request_message.clone())
                 .to_bytes()
@@ -340,8 +337,8 @@ impl<
                 })?,
         );
 
-        // Broadcast requests go out once; batched requests are re-sent by a background task for
-        // as long as we wait. The task is aborted when the handle drops with this function
+        // Broadcast requests go out once; batched requests are re-sent by a background task
+        // that is aborted when the handle drops with this function
         let _batched_sending_task = match request_type {
             RequestType::Broadcast => {
                 trace!("Sending request {request_message:?} to all participants");
@@ -363,7 +360,6 @@ impl<
             ),
         };
 
-        // Return the first response that passes the caller's validation
         timeout(timeout_duration, async {
             loop {
                 let response = response_receiver.recv().await.ok_or_else(|| {
@@ -413,8 +409,7 @@ impl<
         message: Bytes,
         timeout_duration: Duration,
     ) -> std::result::Result<AbortOnDropHandle<()>, RequestError> {
-        // Get the recipients that the request should expect responses from. Shuffle them so
-        // that we don't always send to the same recipients in the same order
+        // Shuffle so we don't always send to the same recipients in the same order
         let mut recipients = self
             .recipient_source
             .get_expected_responders(&request_message.request)
@@ -426,30 +421,22 @@ impl<
             })?;
         recipients.shuffle(&mut rand::thread_rng());
 
-        // Get the current time so we can check when the timeout has elapsed
         let start_time = Instant::now();
 
         let self_clone = Arc::clone(self);
         Ok(AbortOnDropHandle::new(spawn(async move {
-            // Create a bounded queue for the outgoing requests. We use this to make sure
-            // we have less than [`config.request_batch_size`] requests in flight at any time.
-            //
-            // When newer requests are added, older ones are removed from the queue. Because we use
-            // `AbortOnDropHandle`, the older ones will automatically get cancelled
+            // At most `request_batch_size` sends in flight at a time: pushing beyond the queue's
+            // capacity evicts (and thereby aborts) the oldest send task
             let mut outgoing_requests = BoundedVecDeque::new(self_clone.config.request_batch_size);
 
-            // While the timeout hasn't elapsed, send out requests to the network
             while start_time.elapsed() < timeout_duration {
-                // Send out requests to the network in their own separate tasks
                 for recipient_batch in recipients.chunks(self_clone.config.request_batch_size) {
                     for recipient in recipient_batch {
-                        // Clone ourselves, the message, and the recipient so they can be moved
                         let self_clone = Arc::clone(&self_clone);
                         let request_message_clone = request_message.clone();
                         let recipient_clone = recipient.clone();
                         let message_clone = Arc::clone(&message);
 
-                        // Spawn the task that sends the request to the participant
                         let individual_sending_task = spawn(async move {
                             trace!(
                                 "Sending request {request_message_clone:?} to {recipient_clone:?}"
@@ -461,12 +448,9 @@ impl<
                                 .await;
                         });
 
-                        // Add the sending task to the queue
                         outgoing_requests.push(AbortOnDropHandle::new(individual_sending_task));
                     }
 
-                    // After we send the batch out, wait the [`config.request_batch_interval`]
-                    // before sending the next one
                     sleep(self_clone.config.request_batch_interval).await;
                 }
             }
@@ -481,12 +465,9 @@ impl<
             Some(self.config.max_incoming_requests),
         );
 
-        // While the receiver is open, we receive messages and handle them
         loop {
-            // Try to receive a message
             match receiver.receive_message().await {
                 Ok(message) => {
-                    // Deserialize the message, warning if it fails
                     let message = match Message::from_bytes(&message) {
                         Ok(message) => message,
                         Err(e) => {
@@ -495,7 +476,6 @@ impl<
                         },
                     };
 
-                    // Handle the message based on its type
                     match message {
                         Message::Request(request_message) => {
                             self.handle_request(request_message, &mut incoming_requests);
@@ -619,10 +599,9 @@ impl<
             waiters.iter().map(|waiter| waiter.sender.clone()).collect()
         };
 
-        // Deliver the response to each waiter. `try_send` drops it when a waiter's buffer is
-        // full: that waiter is backlogged with earlier candidates, and batched senders keep
-        // re-requesting until they are satisfied. A waiter that was dropped concurrently just
-        // yields a `Closed` error, which we also ignore
+        // `try_send` drops the response when a waiter's buffer is full: that waiter is
+        // backlogged with earlier candidates, and batched senders keep re-requesting until
+        // satisfied. A waiter dropped concurrently just yields a `Closed` error, also ignored
         let response = Arc::new(response.response);
         for waiter in waiters {
             let _ = waiter.try_send(Arc::clone(&response));
@@ -633,7 +612,7 @@ impl<
 /// A waiter registered by one [`RequestResponseInner::request`] call, to which incoming
 /// responses for its request hash are delivered
 struct Waiter<Req: Request> {
-    /// The unique id used to deregister this waiter when its receiver is dropped
+    /// Identifies this waiter for deregistration when its receiver is dropped
     id: u64,
     /// Delivers candidate responses to the corresponding [`ResponseReceiver`]
     sender: mpsc::Sender<Arc<Req::Response>>,
@@ -643,18 +622,13 @@ struct Waiter<Req: Request> {
 /// the waiter when dropped, so map entries are cleaned up on success, timeout, and
 /// cancellation alike
 struct ResponseReceiver<Req: Request> {
-    /// The hash of the request this waiter is registered under
     request_hash: RequestHash,
-    /// The id of the waiter to deregister on drop
     id: u64,
-    /// The receiving end of the corresponding [`Waiter`]'s channel
     receiver: mpsc::Receiver<Arc<Req::Response>>,
-    /// The map to deregister from on drop
     active_requests: ActiveRequestsMap<Req>,
 }
 
 impl<Req: Request> ResponseReceiver<Req> {
-    /// Receive the next candidate response
     async fn recv(&mut self) -> Option<Arc<Req::Response>> {
         self.receiver.recv().await
     }
@@ -1105,16 +1079,14 @@ mod tests {
     /// Test that a timed-out request deregisters its waiter (active-requests map leak regression)
     #[tokio::test(flavor = "multi_thread")]
     async fn test_waiter_cleanup_on_timeout() {
-        // Create two participants where nobody has the data
+        // Nobody has the data, so the request must time out
         let mut protocols = create_protocols(2, false);
         let (protocol, (public_key, private_key)) = protocols.remove(0);
 
-        // Create a new signed request message
         let request_message =
             RequestMessage::new_signed(&public_key, &private_key, &TestRequest(vec![1, 2, 3]))
                 .expect("failed to create request message");
 
-        // The request should time out since nobody has the data
         let result = protocol
             .request(
                 request_message,
@@ -1134,11 +1106,9 @@ mod tests {
     /// a downcast error
     #[tokio::test(flavor = "multi_thread")]
     async fn test_join_with_different_output_types() {
-        // Create two participants that both have the data
         let protocols = create_protocols(2, true);
         let (requester, (public_key, private_key)) = &protocols[0];
 
-        // Both callers request the same data
         let request = TestRequest(vec![5; 100]);
         let expected = blake3::hash(&request.0).as_bytes().to_vec();
 
@@ -1170,7 +1140,6 @@ mod tests {
     /// Test that an invalid response does not complete a request, but a later valid one does
     #[tokio::test(flavor = "multi_thread")]
     async fn test_invalid_then_valid_response() {
-        // Create two participants that both have the data
         let protocols = create_protocols(2, true);
         let (requester, (public_key, private_key)) = &protocols[0];
 
@@ -1187,7 +1156,6 @@ mod tests {
             }
         };
 
-        // Make the request
         let request = TestRequest(vec![7; 100]);
         let request_message = RequestMessage::new_signed(public_key, private_key, &request)
             .expect("failed to create request message");
@@ -1201,7 +1169,6 @@ mod tests {
             .await
             .expect("request failed");
 
-        // We should have gotten the data on a later response
         assert_eq!(response, blake3::hash(&request.0).as_bytes().to_vec());
         assert!(attempts.load(std::sync::atomic::Ordering::SeqCst) >= 2);
 

--- a/request-response/src/lib.rs
+++ b/request-response/src/lib.rs
@@ -2,34 +2,34 @@
 //! a set of recipients and wait for responses.
 
 use std::{
-    any::Any,
     collections::HashMap,
     future::Future,
     marker::PhantomData,
-    pin::Pin,
-    sync::{Arc, Weak},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, anyhow};
-use async_lock::RwLock;
 use data_source::DataSource;
 use derive_more::derive::Deref;
 use hotshot_types::traits::signature_key::SignatureKey;
 use message::{Message, RequestMessage, ResponseMessage};
 use network::{Bytes, Receiver, Sender};
+use parking_lot::RwLock;
 use rand::seq::SliceRandom;
 use recipient_source::RecipientSource;
 use request::Request;
 use tokio::{
     spawn,
+    sync::mpsc,
     time::{sleep, timeout},
 };
 use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error, info, trace, warn};
 use util::{BoundedVecDeque, NamedSemaphore, NamedSemaphoreError};
-
-use crate::util::NamedSemaphorePermit;
 
 /// The data source trait. Is what we use to derive the response data for a request
 pub mod data_source;
@@ -49,15 +49,19 @@ mod util;
 /// A type alias for the hash of a request
 pub type RequestHash = blake3::Hash;
 
-/// A type alias for the outgoing requests map
-pub type OutgoingRequestsMap<Req> =
-    Arc<RwLock<HashMap<RequestHash, Weak<OutgoingRequestInner<Req>>>>>;
+/// The map of active outgoing requests: request hash → the waiters registered by concurrent
+/// [`RequestResponseInner::request`] calls for the same data. Guarded by a synchronous lock so
+/// waiters can deregister themselves in `Drop`; it is never held across an `await`
+type ActiveRequestsMap<Req> = Arc<RwLock<HashMap<RequestHash, Vec<Waiter<Req>>>>>;
 
 /// A type alias for the list of tasks that are responding to requests
 pub type IncomingRequests<K> = NamedSemaphore<K>;
 
-/// A type alias for the list of tasks that are validating incoming responses
-pub type IncomingResponses = NamedSemaphore<RequestHash>;
+/// The number of responses that can be buffered for each waiter before responses are dropped.
+/// Must comfortably cover the maximum number of simultaneous responders: a broadcast request can
+/// be answered by every node at once while its single waiter validates responses serially.
+/// Buffered entries are `Arc`s, so slots are pointer-sized
+const RESPONSE_BUFFER_SIZE: usize = 128;
 
 /// The type of request to make
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -192,16 +196,14 @@ impl<
         // response data for a specific request
         data_source: DS,
     ) -> Self {
-        // Create the outgoing requests map
-        let outgoing_requests = OutgoingRequestsMap::default();
-
         // Create the inner implementation
         let inner = Arc::new(RequestResponseInner {
             config,
             sender,
             recipient_source,
             data_source,
-            outgoing_requests,
+            active_requests: ActiveRequestsMap::default(),
+            next_waiter_id: AtomicU64::new(0),
             phantom_data: PhantomData,
         });
 
@@ -218,17 +220,6 @@ impl<
         }
     }
 }
-
-/// A type alias for an `Arc<dyn Any + Send + Sync + 'static>`
-type ThreadSafeAny = Arc<dyn Any + Send + Sync + 'static>;
-
-/// A type alias for the future that validates a response
-type ResponseValidationFuture =
-    Pin<Box<dyn Future<Output = Result<ThreadSafeAny, anyhow::Error>> + Send + Sync + 'static>>;
-
-/// A type alias for the function that returns the above future
-type ResponseValidationFn<R> =
-    Box<dyn Fn(&R, <R as Request>::Response) -> ResponseValidationFuture + Send + Sync + 'static>;
 
 /// The inner implementation for the request-response protocol
 pub struct RequestResponseInner<
@@ -248,7 +239,9 @@ pub struct RequestResponseInner<
     /// The data source to use for the protocol
     data_source: DS,
     /// The map of currently active, outgoing requests
-    outgoing_requests: OutgoingRequestsMap<Req>,
+    active_requests: ActiveRequestsMap<Req>,
+    /// The id to assign to the next registered waiter
+    next_waiter_id: AtomicU64,
     /// Phantom data to help with type inference
     phantom_data: PhantomData<(K, R, Req, DS)>,
 }
@@ -282,9 +275,9 @@ impl<
         response_validation_fn: F,
     ) -> std::result::Result<O, RequestError>
     where
-        F: Fn(&Req, Req::Response) -> Fut + Send + Sync + 'static + Clone,
-        Fut: Future<Output = anyhow::Result<O>> + Send + Sync + 'static,
-        O: Send + Sync + 'static + Clone,
+        F: Fn(&Req, Req::Response) -> Fut + Send + Sync + Clone,
+        Fut: Future<Output = anyhow::Result<O>> + Send,
+        O: Send,
     {
         loop {
             // Sign a request message
@@ -312,13 +305,13 @@ impl<
         }
     }
 
-    /// Request something from the protocol and wait for the response. This function
-    /// will join with an existing request for the same data (determined by `Blake3` hash),
-    /// however both will make requests until the timeout is reached
+    /// Request something from the protocol and wait for the first response that passes
+    /// validation. Concurrent requests for the same data (determined by `Blake3` hash of the
+    /// request) share incoming responses, but each caller validates them independently and all
+    /// of them make requests until their own timeout is reached.
     ///
     /// # Errors
     /// - If the request times out
-    /// - If the channel is closed (this is an internal error)
     /// - If the request we sign is invalid
     pub async fn request<F, Fut, O>(
         self: &Arc<Self>,
@@ -328,80 +321,39 @@ impl<
         response_validation_fn: F,
     ) -> std::result::Result<O, RequestError>
     where
-        F: Fn(&Req, Req::Response) -> Fut + Send + Sync + 'static + Clone,
-        Fut: Future<Output = anyhow::Result<O>> + Send + Sync + 'static,
-        O: Send + Sync + 'static + Clone,
+        F: Fn(&Req, Req::Response) -> Fut + Send + Sync,
+        Fut: Future<Output = anyhow::Result<O>> + Send,
+        O: Send,
     {
-        timeout(timeout_duration, async move {
-            // Calculate the hash of the request
-            let request_hash = blake3::hash(&request_message.request.to_bytes().map_err(|e| {
-                RequestError::InvalidRequest(anyhow::anyhow!(
-                    "failed to serialize request message: {e}"
-                ))
-            })?);
+        // Calculate the hash of the request. It identifies the request on the wire and joins
+        // concurrent callers requesting the same data
+        let request_hash = blake3::hash(&request_message.request.to_bytes().map_err(|e| {
+            RequestError::InvalidRequest(anyhow::anyhow!(
+                "failed to serialize request message: {e}"
+            ))
+        })?);
 
-            let request = {
-                // Get a write lock on the outgoing requests map
-                let mut outgoing_requests_write = self.outgoing_requests.write().await;
+        // Register for responses before sending the request so none can be missed. Deregisters
+        // itself when dropped (on success, timeout, and cancellation alike)
+        let mut response_receiver = self.register_waiter(request_hash);
 
-                // Conditionally get the outgoing request, creating a new one if it doesn't exist or if
-                // the existing one has been dropped and not yet removed
-                if let Some(outgoing_request) = outgoing_requests_write
-                    .get(&request_hash)
-                    .and_then(Weak::upgrade)
-                {
-                    OutgoingRequest(outgoing_request)
-                } else {
-                    // Create a new broadcast channel for the response
-                    let (sender, receiver) = async_broadcast::broadcast(1);
+        // Create a request message and serialize it
+        let message = Bytes::from(
+            Message::Request(request_message.clone())
+                .to_bytes()
+                .map_err(|e| {
+                    RequestError::InvalidRequest(anyhow::anyhow!(
+                        "failed to serialize request message: {e}"
+                    ))
+                })?,
+        );
 
-                    // Modify the response validation function to return an `Arc<dyn Any>`
-                    let response_validation_fn =
-                        Box::new(move |request: &Req, response: Req::Response| {
-                            let fut = response_validation_fn(request, response);
-                            Box::pin(
-                                async move { fut.await.map(|ok| Arc::new(ok) as ThreadSafeAny) },
-                            ) as ResponseValidationFuture
-                        });
-
-                    // Create a new outgoing request
-                    let outgoing_request = OutgoingRequest(Arc::new(OutgoingRequestInner {
-                        sender,
-                        receiver,
-                        response_validation_fn,
-                        request: request_message.request.clone(),
-                    }));
-
-                    // Write the new outgoing request to the map
-                    outgoing_requests_write
-                        .insert(request_hash, Arc::downgrade(&outgoing_request.0));
-
-                    // Return the new outgoing request
-                    outgoing_request
-                }
-            };
-
-            // Create a request message and serialize it
-            let message = Bytes::from(
-                Message::Request(request_message.clone())
-                    .to_bytes()
-                    .map_err(|e| {
-                        RequestError::InvalidRequest(anyhow::anyhow!(
-                            "failed to serialize request message: {e}"
-                        ))
-                    })?,
-            );
-
-            // Create a place to put the handle for the batched sending task. We need this because
-            // otherwise it gets dropped when the closure goes out of scope, instead of when the function
-            // gets cancelled or returns
-            let mut _batched_sending_task = None;
-
-            // Match on the type of request
-            if request_type == RequestType::Broadcast {
+        // Broadcast requests go out once; batched requests are re-sent by a background task for
+        // as long as we wait. The task is aborted when the handle drops with this function
+        let _batched_sending_task = match request_type {
+            RequestType::Broadcast => {
                 trace!("Sending request {request_message:?} to all participants");
 
-                // If the message is a broadcast request, just send it to all participants
                 self.sender
                     .send_broadcast_message(&message)
                     .await
@@ -410,109 +362,132 @@ impl<
                             "failed to send broadcast message: {e}"
                         ))
                     })?;
-            } else {
-                // If the message is a batched request, we need to batch it with other requests
 
-                // Get the recipients that the request should expect responses from. Shuffle them so
-                // that we don't always send to the same recipients in the same order
-                let mut recipients = self
-                    .recipient_source
-                    .get_expected_responders(&request_message.request)
-                    .await
-                    .map_err(|e| {
-                        RequestError::InvalidRequest(anyhow::anyhow!(
-                            "failed to get expected responders for request: {e}"
-                        ))
-                    })?;
-                recipients.shuffle(&mut rand::thread_rng());
+                None
+            },
+            RequestType::Batched => Some(
+                self.spawn_batched_sender(request_message.clone(), message, timeout_duration)
+                    .await?,
+            ),
+        };
 
-                // Get the current time so we can check when the timeout has elapsed
-                let start_time = Instant::now();
+        // Return the first response that passes the caller's validation
+        timeout(timeout_duration, async {
+            loop {
+                let response = response_receiver.recv().await.ok_or_else(|| {
+                    // Unreachable: the active-requests map holds a sender for as long as
+                    // `response_receiver` is registered, and it deregisters only on drop
+                    RequestError::Other(anyhow!("response channel closed"))
+                })?;
 
-                // Spawn a task that sends out requests to the network
-                let self_clone = Arc::clone(self);
-                let batched_sending_handle = AbortOnDropHandle::new(spawn(async move {
-                    // Create a bounded queue for the outgoing requests. We use this to make sure
-                    // we have less than [`config.request_batch_size`] requests in flight at any time.
-                    //
-                    // When newer requests are added, older ones are removed from the queue. Because we use
-                    // `AbortOnDropHandle`, the older ones will automatically get cancelled
-                    let mut outgoing_requests =
-                        BoundedVecDeque::new(self_clone.config.request_batch_size);
+                // Clones only when this request is shared with another concurrent caller
+                let response = Arc::unwrap_or_clone(response);
 
-                    // While the timeout hasn't elapsed, send out requests to the network
-                    while start_time.elapsed() < timeout_duration {
-                        // Send out requests to the network in their own separate tasks
-                        for recipient_batch in
-                            recipients.chunks(self_clone.config.request_batch_size)
-                        {
-                            for recipient in recipient_batch {
-                                // Clone ourselves, the message, and the recipient so they can be moved
-                                let self_clone = Arc::clone(&self_clone);
-                                let request_message_clone = request_message.clone();
-                                let recipient_clone = recipient.clone();
-                                let message_clone = Arc::clone(&message);
-
-                                // Spawn the task that sends the request to the participant
-                                let individual_sending_task = spawn(async move {
-                                    trace!(
-                                        "Sending request {request_message_clone:?} to \
-                                         {recipient_clone:?}"
-                                    );
-
-                                    let _ = self_clone
-                                        .sender
-                                        .send_direct_message(&message_clone, recipient_clone)
-                                        .await;
-                                });
-
-                                // Add the sending task to the queue
-                                outgoing_requests
-                                    .push(AbortOnDropHandle::new(individual_sending_task));
-                            }
-
-                            // After we send the batch out, wait the [`config.request_batch_interval`]
-                            // before sending the next one
-                            sleep(self_clone.config.request_batch_interval).await;
-                        }
-                    }
-                }));
-
-                // Store the handle so it doesn't get dropped
-                _batched_sending_task = Some(batched_sending_handle);
+                match response_validation_fn(&request_message.request, response).await {
+                    Ok(validated) => return Ok(validated),
+                    Err(e) => debug!("Received invalid response: {e:#}"),
+                }
             }
-
-            // Wait for a response on the channel
-            request
-                .receiver
-                .clone()
-                .recv()
-                .await
-                .map_err(|_| RequestError::Other(anyhow!("channel was closed")))
         })
         .await
-        .map_err(|_| RequestError::Timeout)
-        .and_then(|result| result)
-        .and_then(|result| {
-            result.downcast::<O>().map_err(|e| {
-                RequestError::Other(anyhow::anyhow!(
-                    "failed to downcast response to expected type: {e:?}"
+        .map_err(|_| RequestError::Timeout)?
+    }
+
+    /// Register a waiter for responses to the request with the given hash
+    fn register_waiter(self: &Arc<Self>, request_hash: RequestHash) -> ResponseReceiver<Req> {
+        let (sender, receiver) = mpsc::channel(RESPONSE_BUFFER_SIZE);
+        let id = self.next_waiter_id.fetch_add(1, Ordering::Relaxed);
+
+        self.active_requests
+            .write()
+            .entry(request_hash)
+            .or_default()
+            .push(Waiter { id, sender });
+
+        ResponseReceiver {
+            request_hash,
+            id,
+            receiver,
+            active_requests: Arc::clone(&self.active_requests),
+        }
+    }
+
+    /// Spawn the task that repeatedly sends a batched request to
+    /// [`config.request_batch_size`] recipients at a time until `timeout_duration` elapses
+    /// or the returned handle is dropped
+    async fn spawn_batched_sender(
+        self: &Arc<Self>,
+        request_message: RequestMessage<Req, K>,
+        message: Bytes,
+        timeout_duration: Duration,
+    ) -> std::result::Result<AbortOnDropHandle<()>, RequestError> {
+        // Get the recipients that the request should expect responses from. Shuffle them so
+        // that we don't always send to the same recipients in the same order
+        let mut recipients = self
+            .recipient_source
+            .get_expected_responders(&request_message.request)
+            .await
+            .map_err(|e| {
+                RequestError::InvalidRequest(anyhow::anyhow!(
+                    "failed to get expected responders for request: {e}"
                 ))
-            })
-        })
-        .map(|result| Arc::unwrap_or_clone(result))
+            })?;
+        recipients.shuffle(&mut rand::thread_rng());
+
+        // Get the current time so we can check when the timeout has elapsed
+        let start_time = Instant::now();
+
+        let self_clone = Arc::clone(self);
+        Ok(AbortOnDropHandle::new(spawn(async move {
+            // Create a bounded queue for the outgoing requests. We use this to make sure
+            // we have less than [`config.request_batch_size`] requests in flight at any time.
+            //
+            // When newer requests are added, older ones are removed from the queue. Because we use
+            // `AbortOnDropHandle`, the older ones will automatically get cancelled
+            let mut outgoing_requests = BoundedVecDeque::new(self_clone.config.request_batch_size);
+
+            // While the timeout hasn't elapsed, send out requests to the network
+            while start_time.elapsed() < timeout_duration {
+                // Send out requests to the network in their own separate tasks
+                for recipient_batch in recipients.chunks(self_clone.config.request_batch_size) {
+                    for recipient in recipient_batch {
+                        // Clone ourselves, the message, and the recipient so they can be moved
+                        let self_clone = Arc::clone(&self_clone);
+                        let request_message_clone = request_message.clone();
+                        let recipient_clone = recipient.clone();
+                        let message_clone = Arc::clone(&message);
+
+                        // Spawn the task that sends the request to the participant
+                        let individual_sending_task = spawn(async move {
+                            trace!(
+                                "Sending request {request_message_clone:?} to {recipient_clone:?}"
+                            );
+
+                            let _ = self_clone
+                                .sender
+                                .send_direct_message(&message_clone, recipient_clone)
+                                .await;
+                        });
+
+                        // Add the sending task to the queue
+                        outgoing_requests.push(AbortOnDropHandle::new(individual_sending_task));
+                    }
+
+                    // After we send the batch out, wait the [`config.request_batch_interval`]
+                    // before sending the next one
+                    sleep(self_clone.config.request_batch_interval).await;
+                }
+            }
+        })))
     }
 
     /// The task responsible for receiving messages from the receiver and handling them
     async fn receiving_task(self: Arc<Self>, mut receiver: R) {
-        // Upper bound the number of outgoing and incoming responses
+        // Upper bound the number of concurrently processed incoming requests
         let mut incoming_requests = NamedSemaphore::new(
             self.config.max_incoming_requests_per_key,
             Some(self.config.max_incoming_requests),
         );
-        // process 1 response per key, with a global maximum of [`config.max_incoming_responses`] responses
-        let mut incoming_responses =
-            NamedSemaphore::new(1, Some(self.config.max_incoming_responses));
 
         // While the receiver is open, we receive messages and handle them
         loop {
@@ -534,7 +509,7 @@ impl<
                             self.handle_request(request_message, &mut incoming_requests);
                         },
                         Message::Response(response_message) => {
-                            self.handle_response(response_message, &mut incoming_responses);
+                            self.handle_response(response_message);
                         },
                     }
                 },
@@ -634,131 +609,85 @@ impl<
         });
     }
 
-    async fn wait_for_permit(
-        incoming_responses: &mut IncomingResponses,
-        request_hash: RequestHash,
-        outgoing_requests: &OutgoingRequestsMap<Req>,
-    ) -> Result<NamedSemaphorePermit<RequestHash>, NamedSemaphoreError> {
-        while outgoing_requests.read().await.contains_key(&request_hash) {
-            let permit = incoming_responses.try_acquire(request_hash);
-            let permit = match permit {
-                Ok(permit) => permit,
-                Err(NamedSemaphoreError::PerKeyLimitReached) => {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    continue;
-                },
-                Err(NamedSemaphoreError::GlobalLimitReached) => {
-                    warn!(
-                        "Failed to process response: too many responses are already being \
-                         processed"
-                    );
-                    return Err(NamedSemaphoreError::GlobalLimitReached);
-                },
-            };
-            return Ok(permit);
-        }
-        Err(NamedSemaphoreError::GlobalLimitReached)
-    }
-
-    /// Handle a response sent to us
-    fn handle_response(
-        self: &Arc<Self>,
-        response: ResponseMessage<Req>,
-        incoming_responses: &mut IncomingResponses,
-    ) {
+    /// Handle a response sent to us: fan it out to every waiter registered for the request hash
+    fn handle_response(&self, response: ResponseMessage<Req>) {
         trace!("Handling response {response:?}");
 
-        let outgoing_requests_clone = self.outgoing_requests.clone();
-        let mut incoming_responses_clone = incoming_responses.clone();
+        // Snapshot the waiting senders so the lock is not held while sending
+        let waiters: Vec<mpsc::Sender<Arc<Req::Response>>> = {
+            let active_requests = self.active_requests.read();
+            let Some(waiters) = active_requests.get(&response.request_hash) else {
+                // Not an error: a response for a request that was already satisfied or timed out
+                trace!(
+                    "Received response for inactive request {}",
+                    response.request_hash
+                );
+                return;
+            };
+            waiters.iter().map(|waiter| waiter.sender.clone()).collect()
+        };
 
-        // Spawn a task to validate the response and send it to the requester (us)
-        let response_validate_timeout = self.config.incoming_response_timeout;
-        tokio::spawn(async move {
-            if timeout(response_validate_timeout, async move {
-                // Attempt to acquire a permit for the request. Warn if there are too many responses currently being processed
-                let permit = Self::wait_for_permit(
-                    &mut incoming_responses_clone,
-                    response.request_hash,
-                    &outgoing_requests_clone,
-                )
-                .await;
-
-                let Ok(permit) = permit else {
-                    warn!(
-                        "Failed to process response: too many responses are already being \
-                         processed"
-                    );
-                    return;
-                };
-                // Get the entry in the map, ignoring it if it doesn't exist
-                let Some(outgoing_request) = outgoing_requests_clone
-                    .read()
-                    .await
-                    .get(&response.request_hash)
-                    .cloned()
-                    .and_then(|r| r.upgrade())
-                else {
-                    return;
-                };
-                // Make sure the response is valid for the given request
-                let validation_result = match (outgoing_request.response_validation_fn)(
-                    &outgoing_request.request,
-                    response.response,
-                )
-                .await
-                {
-                    Ok(validation_result) => validation_result,
-                    Err(e) => {
-                        debug!("Received invalid response: {e:#}");
-                        return;
-                    },
-                };
-
-                // Send the response to the requester (the user of [`RequestResponse::request`])
-                let _ = outgoing_request.sender.try_broadcast(validation_result);
-
-                outgoing_requests_clone
-                    .write()
-                    .await
-                    .remove(&response.request_hash);
-
-                // Drop the permit
-                _ = permit;
-                drop(permit);
-            })
-            .await
-            .is_err()
-            {
-                warn!("Timed out while validating response");
-            }
-        });
+        // Deliver the response to each waiter. `try_send` drops it when a waiter's buffer is
+        // full: that waiter is backlogged with earlier candidates, and batched senders keep
+        // re-requesting until they are satisfied. A waiter that was dropped concurrently just
+        // yields a `Closed` error, which we also ignore
+        let response = Arc::new(response.response);
+        for waiter in waiters {
+            let _ = waiter.try_send(Arc::clone(&response));
+        }
     }
 }
 
-/// An outgoing request. This is what we use to track a request and its corresponding response
-/// in the protocol
-#[derive(Clone, Deref)]
-pub struct OutgoingRequest<R: Request>(Arc<OutgoingRequestInner<R>>);
+/// A waiter registered by one [`RequestResponseInner::request`] call, to which incoming
+/// responses for its request hash are delivered
+struct Waiter<Req: Request> {
+    /// The unique id used to deregister this waiter when its receiver is dropped
+    id: u64,
+    /// Delivers candidate responses to the corresponding [`ResponseReceiver`]
+    sender: mpsc::Sender<Arc<Req::Response>>,
+}
 
-/// The inner implementation of an outgoing request
-pub struct OutgoingRequestInner<R: Request> {
-    /// The sender to use for the protocol
-    sender: async_broadcast::Sender<ThreadSafeAny>,
-    /// The receiver to use for the protocol
-    receiver: async_broadcast::Receiver<ThreadSafeAny>,
+/// Receives candidate responses for one [`RequestResponseInner::request`] call. Deregisters
+/// the waiter when dropped, so map entries are cleaned up on success, timeout, and
+/// cancellation alike
+struct ResponseReceiver<Req: Request> {
+    /// The hash of the request this waiter is registered under
+    request_hash: RequestHash,
+    /// The id of the waiter to deregister on drop
+    id: u64,
+    /// The receiving end of the corresponding [`Waiter`]'s channel
+    receiver: mpsc::Receiver<Arc<Req::Response>>,
+    /// The map to deregister from on drop
+    active_requests: ActiveRequestsMap<Req>,
+}
 
-    /// The request that we are waiting for a response to
-    request: R,
+impl<Req: Request> ResponseReceiver<Req> {
+    /// Receive the next candidate response
+    async fn recv(&mut self) -> Option<Arc<Req::Response>> {
+        self.receiver.recv().await
+    }
+}
 
-    /// The function used to validate the response
-    response_validation_fn: ResponseValidationFn<R>,
+impl<Req: Request> Drop for ResponseReceiver<Req> {
+    fn drop(&mut self) {
+        let mut active_requests = self.active_requests.write();
+        if let Some(waiters) = active_requests.get_mut(&self.request_hash) {
+            waiters.retain(|waiter| waiter.id != self.id);
+            if waiters.is_empty() {
+                active_requests.remove(&self.request_hash);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
         collections::HashMap,
-        sync::{Mutex, atomic::AtomicBool},
+        sync::{
+            Mutex,
+            atomic::{AtomicBool, AtomicUsize},
+        },
     };
 
     use async_trait::async_trait;
@@ -1146,5 +1075,147 @@ mod tests {
                 .expect("failed to join task")
                 .expect("failed to request data");
         }
+    }
+
+    /// The concrete protocol type used in tests
+    type TestProtocol = RequestResponse<
+        TestSender,
+        mpsc::Receiver<Bytes>,
+        TestRequest,
+        TestSender,
+        TestDataSource,
+        BLSPubKey,
+    >;
+
+    /// Create a protocol per participant, where each participant may or may not have the data
+    fn create_protocols(
+        num: usize,
+        has_data: bool,
+    ) -> Vec<(TestProtocol, (BLSPubKey, BLSPrivKey))> {
+        create_participants(num)
+            .into_iter()
+            .map(|(sender, receiver, keypair)| {
+                let protocol = RequestResponse::new(
+                    default_protocol_config(),
+                    sender.clone(),
+                    receiver,
+                    sender,
+                    TestDataSource {
+                        has_data,
+                        data_available_time: Instant::now(),
+                        take_data: false,
+                        taken: Arc::new(AtomicBool::new(false)),
+                    },
+                );
+                (protocol, keypair)
+            })
+            .collect()
+    }
+
+    /// Test that a timed-out request deregisters its waiter (active-requests map leak regression)
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_waiter_cleanup_on_timeout() {
+        // Create two participants where nobody has the data
+        let mut protocols = create_protocols(2, false);
+        let (protocol, (public_key, private_key)) = protocols.remove(0);
+
+        // Create a new signed request message
+        let request_message =
+            RequestMessage::new_signed(&public_key, &private_key, &TestRequest(vec![1, 2, 3]))
+                .expect("failed to create request message");
+
+        // The request should time out since nobody has the data
+        let result = protocol
+            .request(
+                request_message,
+                RequestType::Batched,
+                Duration::from_millis(250),
+                |_request, response| async move { Ok(response) },
+            )
+            .await;
+        assert!(matches!(result, Err(RequestError::Timeout)));
+
+        // The waiter must have deregistered itself
+        assert!(protocol.active_requests.read().is_empty());
+    }
+
+    /// Test that two concurrent requests for the same data can validate to different output
+    /// types. With the previous type-erased validation this would have failed at runtime with
+    /// a downcast error
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_join_with_different_output_types() {
+        // Create two participants that both have the data
+        let protocols = create_protocols(2, true);
+        let (requester, (public_key, private_key)) = &protocols[0];
+
+        // Both callers request the same data
+        let request = TestRequest(vec![5; 100]);
+        let expected = blake3::hash(&request.0).as_bytes().to_vec();
+
+        let request_message_1 = RequestMessage::new_signed(public_key, private_key, &request)
+            .expect("failed to create request message");
+        let request_message_2 = RequestMessage::new_signed(public_key, private_key, &request)
+            .expect("failed to create request message");
+
+        // One caller validates to the raw bytes, the other to their length
+        let (bytes, length) = tokio::join!(
+            requester.request(
+                request_message_1,
+                RequestType::Batched,
+                Duration::from_secs(20),
+                |_request, response| async move { Ok(response) },
+            ),
+            requester.request(
+                request_message_2,
+                RequestType::Batched,
+                Duration::from_secs(20),
+                |_request, response| async move { Ok(response.len()) },
+            )
+        );
+
+        assert_eq!(bytes.expect("bytes request failed"), expected);
+        assert_eq!(length.expect("length request failed"), expected.len());
+    }
+
+    /// Test that an invalid response does not complete a request, but a later valid one does
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_invalid_then_valid_response() {
+        // Create two participants that both have the data
+        let protocols = create_protocols(2, true);
+        let (requester, (public_key, private_key)) = &protocols[0];
+
+        // Reject the first response we see and accept any later one
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = Arc::clone(&attempts);
+        let validation_fn = move |_request: &TestRequest, response: Vec<u8>| {
+            let attempts = Arc::clone(&attempts_clone);
+            async move {
+                if attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                    return Err(anyhow::anyhow!("rejecting the first response"));
+                }
+                Ok(response)
+            }
+        };
+
+        // Make the request
+        let request = TestRequest(vec![7; 100]);
+        let request_message = RequestMessage::new_signed(public_key, private_key, &request)
+            .expect("failed to create request message");
+        let response = requester
+            .request(
+                request_message,
+                RequestType::Batched,
+                Duration::from_secs(20),
+                validation_fn,
+            )
+            .await
+            .expect("request failed");
+
+        // We should have gotten the data on a later response
+        assert_eq!(response, blake3::hash(&request.0).as_bytes().to_vec());
+        assert!(attempts.load(std::sync::atomic::Ordering::SeqCst) >= 2);
+
+        // The waiter must have deregistered itself on success as well
+        assert!(requester.active_requests.read().is_empty());
     }
 }


### PR DESCRIPTION
### This PR:

Reworks the response path of the `request-response` crate and raises the node's inbound capacity for it.

* **Typed per-caller response waiters** (`refactor(request-response): typed per-caller response waiters`). Each `request()` registers an mpsc waiter under the request hash and validates candidate responses itself, with its own concrete output type. `handle_response` becomes a synchronous fan-out of `Arc<Response>` to the registered waiters. This replaces the stored-validation-fn machinery (broadcast channel per request, `Arc<dyn Any>` + runtime downcast, per-hash `NamedSemaphore` with a 100ms poll loop and a 5s timeout that also covered queue wait). Fixes, in one move:
  * joined requests are type-safe; previously the first caller's validation fn won and a caller with a different output type failed at runtime
  * timed-out or cancelled requests no longer leak dead `Weak` entries in the active-requests map; the receiver guard deregisters on drop
  * duplicate/late responses are dropped at a map lookup instead of spawning a task and logging spurious "too many responses are already being processed" warnings
  * response validation is no longer serialized per hash with 100ms poll gaps and is bounded by each caller's own timeout budget
* **Raise inbound capacity and admission limits** (`fix(request-response): raise inbound capacity and admission limits`). The channel feeding inbound request-response messages drops on full (`try_send`) and had capacity 20, which a burst of responses overflows. It is now 256; the outbound channel, which responders block on while holding admission permits, is 128. Responder admission goes from 1 → 4 per key and 10 → 32 global (permits are held for up to 5s of storage work, so 10 capped the whole network at ~2 requests/s). Adds a `request_response.inbound_dropped` counter so drops are visible in metrics.
* **Route responses by hash before deserializing** (`refactor(request-response): route responses by hash before deserializing`). The receiving task now parses only the framing (type byte, and the request hash for a response). Response bodies are delivered to waiters serialized and decoded by each waiter alongside validation, so a response nobody is waiting for is dropped after a 33-byte peek, and a flood of responses costs only the callers that asked for them, bounded by their buffers. `MessageFrame` owns the wire framing; the existing `from_bytes` impls are built on it.
* **Drop dead config** (`refactor(request-response): drop unused response config fields`): `incoming_response_timeout` and `max_incoming_responses` no longer have any effect, and the crate's `async-broadcast` / `async-lock` dependencies go with them.

### This PR does not:

* Authenticate responses or expose the responder's identity to validation functions. `ExternalMessageReceived` already carries the sender key; plumbing it through the `Receiver` trait is a follow-up.
* Change how requests are sent (batching, recipient selection) or how responders derive data.

### Key places to review:

* `crates/request-response/src/lib.rs`: `request`, `register_waiter`, `handle_message`, `handle_response`, and the `ResponseReceiver` `Drop` impl. Note that the active-requests lock is synchronous and never held across an `await`.
* `crates/request-response/src/message.rs`: `MessageFrame::parse` and `split_request_hash` define the framing once; `Message::from_bytes` and `ResponseMessage::from_bytes` delegate to them.
* `crates/espresso/node/src/context.rs`: the new channel capacities and admission limits.

### Things tested

* New regression tests in `crates/request-response/src/lib.rs`: `test_waiter_cleanup_on_timeout`, `test_join_with_different_output_types`, `test_invalid_then_valid_response`, `test_malformed_messages_are_ignored`, plus the existing integration tests. In `message.rs`, `test_message_parity` now also checks the frame against the full decode, and `test_frame_rejects_malformed_messages` covers the framing errors.
* `cargo test -p request-response`, `cargo clippy -p request-response -p espresso-node --all-targets --features testing -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
