### PR TITLE
fix(test): avoid cliquenet bind race

### DIFF
--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -6370,6 +6370,9 @@ mod test {
         // So, we remove this node and re-add it using the same index.
         network.peers.remove(0);
 
+        // the dropped node's socket may still be bound
+        network.cfg.refresh_coordinator_addr(1);
+
         let node_0_storage = &storage[1];
         let node_0_persistence = persistence[1].clone();
         let node_0_port = reserve_tcp_port().expect("OS should have ephemeral ports available");

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -1504,6 +1504,15 @@ pub mod testing {
             self.priv_keys.len()
         }
 
+        pub fn refresh_coordinator_addr(&mut self, i: usize) {
+            let port = reserve_tcp_port().expect("OS should have ephemeral ports available");
+            let addr = NetAddr::Inet(Ipv4Addr::LOCALHOST.into(), port);
+            self.coordinator_addrs[i] = addr.clone();
+            if let Some(info) = self.config.known_nodes_with_stake[i].connect_info.as_mut() {
+                info.p2p_addr = addr;
+            }
+        }
+
         pub fn hotshot_config(&self) -> &HotShotConfig<SeqTypes> {
             &self.config
         }


### PR DESCRIPTION
test_state_reconstruction removes peer 0 then immediately re-added a node at the same index, rebinding the dropped node's cliquenet coordinator address before the OS released the socket. The race fails the faster embedded-db (sqlite) path with "address already in use", postgres seem to pass.

Give the re-added node a fresh coordinator port.

fixes: cliquenet: error binding to address 127.0.0.1:50343: Address already in use (os error 48)
