### PR TITLE
[new-protocol] never use new protocol QCs in HotStuff2 proofs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -33,6 +33,11 @@ filter = 'test(test_light_client_completeness)'
 slow-timeout = { period = "2m", terminate-after = 15 }
 
 [[profile.default.overrides]]
+filter = 'test(test_light_client_new_protocol_upgrade)'
+slow-timeout = { period = "2m", terminate-after = 15 }
+threads-required = 'num-cpus'
+
+[[profile.default.overrides]]
 filter = 'test(slow_test_restart_new_protocol)'
 slow-timeout = { period = "2m", terminate-after = 5 }
 threads-required = 'num-cpus'

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -3204,7 +3204,7 @@ mod test {
         RegisteredValidatorMap, RewardDistributor, StakeTableState, StateCertQueryDataV1,
         StateCertQueryDataV2, ValidatedState, ValidatorLeaderCounts,
         config::PublicHotShotConfig,
-        traits::{MembershipPersistence, NullEventConsumer, PersistenceOptions},
+        traits::{NullEventConsumer, PersistenceOptions},
         v0_3::{COMMISSION_BASIS_POINTS, Fetcher, RewardAmount, RewardMerkleProofV1},
         v0_4::{RewardAccountV2, RewardMerkleProofV2},
         validators_from_l1_events,
@@ -10290,7 +10290,7 @@ mod test {
         // Epochs run from genesis, so `first_epoch` is 1 and the endpoint is
         // queryable from epoch 3, which the chain has long passed.
         let first_epoch = EpochNumber::new(epoch_from_block_number(0, EPOCH_HEIGHT));
-        check_light_client_stake_table(&client, &network.server, first_epoch).await;
+        check_light_client_stake_table(client, &network.server, first_epoch).await;
     }
 
     /// Test that `fetch_leaf` returns a leaf with exactly the requested block height.

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -3180,7 +3180,7 @@ mod test {
     use ::light_client::{
         consensus::{
             header::HeaderProof,
-            leaf::{LeafProof, LeafProofHint},
+            leaf::{FinalityProof, LeafProof, LeafProofHint},
             payload::PayloadProof,
         },
         testing::{EpochChangeQuorum, LEGACY_VERSION},
@@ -3189,7 +3189,7 @@ mod test {
         eips::BlockId,
         network::EthereumWallet,
         primitives::{Address, U256},
-        providers::ProviderBuilder,
+        providers::{ProviderBuilder, ext::AnvilApi},
     };
     use async_lock::Mutex;
     use committable::{Commitment, Committable};
@@ -9718,6 +9718,135 @@ mod test {
         network.server.shut_down().await;
     }
 
+    /// Verify the light client leaf, header, and payload proofs at each height
+    /// against the ground truth captured from the availability streams.
+    ///
+    /// Only checks that proofs verify, not which `FinalityProof` variant they
+    /// use
+    async fn check_light_client_proofs(
+        client: &Client<ServerError, StaticVersion<0, 1>>,
+        actual_leaves: &[LeafQueryData<SeqTypes>],
+        actual_blocks: &[BlockQueryData<SeqTypes>],
+        heights: impl IntoIterator<Item = u64>,
+        epoch_height: u64,
+    ) {
+        let quorum = EpochChangeQuorum::new(epoch_height);
+        for i in heights {
+            let leaf = &actual_leaves[i as usize];
+            let block = &actual_blocks[i as usize];
+            let version = leaf.header().version();
+            tracing::info!(i, %version, "check light client proofs");
+
+            // Get the same leaf proof by various IDs.
+            let proofs = try_join_all(
+                [
+                    format!("light-client/leaf/{i}"),
+                    format!("light-client/leaf/hash/{}", leaf.hash()),
+                    format!("light-client/leaf/block-hash/{}", leaf.block_hash()),
+                ]
+                .into_iter()
+                .map(|path| async move {
+                    tracing::info!(i, path, "fetch leaf proof");
+                    let proof = client.get::<LeafProof>(&path).send().await?;
+                    Ok::<_, anyhow::Error>((path, proof))
+                }),
+            )
+            .await
+            .unwrap();
+
+            // Check proofs against the expected leaf.
+            for (path, proof) in proofs {
+                tracing::info!(i, path, "check leaf proof");
+                assert_eq!(
+                    proof
+                        .verify(LeafProofHint::Quorum(&quorum))
+                        .await
+                        .unwrap_or_else(|err| panic!("{path}: proof failed to verify: {err:#}")),
+                    *leaf
+                );
+            }
+
+            // Get the corresponding header.
+            let root_height = i + 1;
+            let root = actual_leaves[root_height as usize].header();
+            let proofs = try_join_all(
+                [
+                    format!("light-client/header/{root_height}/{i}"),
+                    format!(
+                        "light-client/header/{root_height}/hash/{}",
+                        leaf.block_hash()
+                    ),
+                ]
+                .into_iter()
+                .map(|path| async move {
+                    tracing::info!(i, path, "fetch header proof");
+                    let proof = client.get::<HeaderProof>(&path).send().await?;
+                    Ok::<_, anyhow::Error>((path, proof))
+                }),
+            )
+            .await
+            .unwrap();
+            for (path, proof) in proofs {
+                tracing::info!(i, path, "check header proof");
+                assert_eq!(
+                    proof.verify_ref(root.block_merkle_tree_root()).unwrap(),
+                    leaf.header()
+                );
+            }
+
+            // Get the corresponding payload.
+            let proof = client
+                .get::<PayloadProof>(&format!("light-client/payload/{i}"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(proof.verify(leaf.header()).unwrap(), *block.payload());
+        }
+    }
+
+    /// Check the light client stake table endpoint: replaying `first_epoch + 2`
+    /// reproduces the validator set loaded from storage, and an earlier epoch
+    /// is a `BAD_REQUEST`.
+    async fn check_light_client_stake_table<N, P>(
+        client: &Client<ServerError, StaticVersion<0, 1>>,
+        server: &SequencerContext<N, P>,
+        first_epoch: EpochNumber,
+    ) where
+        N: ConnectedNetwork<PubKey>,
+        P: SequencerPersistence,
+    {
+        let events: Vec<StakeTableEvent> = client
+            .get(&format!("light-client/stake-table/{}", first_epoch + 2))
+            .send()
+            .await
+            .unwrap();
+        let mut state_from_events = StakeTableState::default();
+        for event in events {
+            state_from_events.apply_event(event).unwrap().unwrap();
+        }
+        assert_eq!(
+            state_from_events.into_validators(),
+            server
+                .consensus_handle()
+                .storage()
+                .await
+                .load_all_validators(first_epoch + 2, 0, 1_000_000)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|v| (v.account, v))
+                .collect::<RegisteredValidatorMap>()
+        );
+
+        // Querying for a stake table before the first real epoch is an error.
+        let err = client
+            .get::<Vec<StakeTableEvent>>(&format!("light-client/stake-table/{}", first_epoch + 1))
+            .send()
+            .await
+            .unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_light_client_completeness() {
         // Run the through a protocol upgrade and epoch change, then check that we are able to get a
@@ -9853,109 +9982,210 @@ mod test {
         // * A few blocks just before and after the stake table comes into effect
             .chain(epoch_heights[1]-1..=max_block);
 
-        let quorum = EpochChangeQuorum::new(EPOCH_HEIGHT);
-        for i in heights {
-            let leaf = &actual_leaves[i as usize];
-            let block = &actual_blocks[i as usize];
-            tracing::info!(i, ?leaf, ?block, "check leaf");
+        check_light_client_proofs(
+            &client,
+            &actual_leaves,
+            &actual_blocks,
+            heights,
+            EPOCH_HEIGHT,
+        )
+        .await;
+        check_light_client_stake_table(&client, &network.server, first_epoch).await;
+    }
 
-            // Get the same leaf proof by various IDs.
-            let client = &client;
-            let proofs = try_join_all(
-                [
-                    format!("light-client/leaf/{i}"),
-                    format!("light-client/leaf/hash/{}", leaf.hash()),
-                    format!("light-client/leaf/block-hash/{}", leaf.block_hash()),
-                ]
-                .into_iter()
-                .map(|path| async move {
-                    tracing::info!(i, path, "fetch leaf proof");
-                    let proof = client.get::<LeafProof>(&path).send().await?;
-                    Ok::<_, anyhow::Error>((path, proof))
-                }),
-            )
+    /// run through the new protocol upgrade and a following epoch change, then check the
+    /// light client serves correct leaf, header, payload, and stake table
+    /// proofs around both boundaries.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_light_client_new_protocol_upgrade() {
+        const NUM_NODES: usize = 5;
+        const EPOCH_HEIGHT: u64 = 70;
+        const UPGRADE_START_PROPOSING_VIEW: u64 = 3 * EPOCH_HEIGHT + 5;
+        const UPGRADE: Upgrade = Upgrade::new(EPOCH_REWARD_VERSION, NEW_PROTOCOL_VERSION);
+
+        let port = reserve_tcp_port().expect("OS should have ephemeral ports available");
+        let url: Url = format!("http://localhost:{port}").parse().unwrap();
+
+        let test_config = TestConfigBuilder::<NUM_NODES>::default()
+            .epoch_height(EPOCH_HEIGHT)
+            .epoch_start_block(0)
+            .builder_timeout(Duration::from_millis(500))
+            .set_upgrades(NEW_PROTOCOL_VERSION)
             .await
+            .upgrade_proposing_views(UPGRADE_START_PROPOSING_VIEW, 1000)
+            .build();
+
+        test_config
+            .anvil()
+            .expect("TestConfigBuilder starts an anvil")
+            .anvil_set_interval_mining(1)
+            .await
+            .expect("interval mining");
+
+        // Base version V5 already has epochs, so genesis must carry the stake
+        // table contract deployed above.
+        let genesis_state = ValidatedState {
+            chain_config: test_config
+                .get_upgrade_map()
+                .chain_config(NEW_PROTOCOL_VERSION)
+                .into(),
+            ..Default::default()
+        };
+
+        let storage = join_all((0..NUM_NODES).map(|_| SqlDataSource::create_storage())).await;
+        let persistence: [_; NUM_NODES] = storage
+            .iter()
+            .map(<SqlDataSource as TestableSequencerDataSource>::persistence_options)
+            .collect::<Vec<_>>()
+            .try_into()
             .unwrap();
 
-            // Check proofs against expected leaf.
-            for (path, proof) in proofs {
-                tracing::info!(i, path, ?proof, "check leaf proof");
-                assert_eq!(
-                    proof.verify(LeafProofHint::Quorum(&quorum)).await.unwrap(),
-                    *leaf
-                );
-            }
-
-            // Get the corresponding header.
-            let root_height = i + 1;
-            let root = actual_leaves[root_height as usize].header();
-            let proofs = try_join_all(
-                [
-                    format!("light-client/header/{root_height}/{i}"),
-                    format!(
-                        "light-client/header/{root_height}/hash/{}",
-                        leaf.block_hash()
-                    ),
-                ]
-                .into_iter()
-                .map(|path| async move {
-                    tracing::info!(i, path, "get header proof");
-                    let proof = client.get::<HeaderProof>(&path).send().await?;
-                    Ok::<_, anyhow::Error>((path, proof))
-                }),
+        let config = TestNetworkConfigBuilder::<NUM_NODES, _, _>::with_num_nodes()
+            .api_config(
+                SqlDataSource::options(&storage[0], Options::with_port(port))
+                    .light_client(Default::default()),
             )
+            .persistences(persistence)
+            .states(std::array::from_fn(|_| genesis_state.clone()))
+            .catchups(std::array::from_fn(|_| {
+                StatePeers::<SequencerApiVersion>::from_urls(
+                    vec![url.clone()],
+                    Default::default(),
+                    Duration::from_secs(2),
+                    &NoMetrics,
+                )
+            }))
+            .network_config(test_config)
+            .build();
+
+        let mut network = TestNetwork::new(config, UPGRADE).await;
+        let client: Client<ServerError, StaticVersion<0, 1>> = Client::new(url);
+        client.connect(None).await;
+
+        // Track each leaf and block served by the query service; they are the
+        // ground truth the light client proofs are checked against.
+        let mut actual_leaves = vec![];
+        let mut actual_blocks = vec![];
+        let mut leaves = client
+            .socket("availability/stream/leaves/0")
+            .subscribe::<LeafQueryData<SeqTypes>>()
             .await
-            .unwrap();
-            for (path, proof) in proofs {
-                tracing::info!(i, path, ?proof, "check header proof");
-                assert_eq!(
-                    proof.verify_ref(root.block_merkle_tree_root()).unwrap(),
-                    leaf.header()
+            .unwrap()
+            .zip(
+                client
+                    .socket("availability/stream/blocks/0")
+                    .subscribe::<BlockQueryData<SeqTypes>>()
+                    .await
+                    .unwrap(),
+            )
+            .map(|(leaf, block)| {
+                let leaf = leaf.unwrap();
+                actual_leaves.push(leaf.clone());
+                actual_blocks.push(block.unwrap());
+                leaf
+            });
+
+        // Wait for the upgrade to take effect.
+        let upgrade_height = timeout(Duration::from_secs(600), async {
+            loop {
+                let leaf = leaves.next().await.unwrap();
+                if leaf.header().version() >= NEW_PROTOCOL_VERSION {
+                    break leaf.height();
+                }
+                tracing::info!(
+                    version = %leaf.header().version(),
+                    height = leaf.header().height(),
+                    view = ?leaf.leaf().view_number(),
+                    "waiting for new protocol upgrade"
                 );
             }
+        })
+        .await
+        .expect("the network did not upgrade to the new protocol");
+        let upgrade_epoch = epoch_from_block_number(upgrade_height, EPOCH_HEIGHT);
+        tracing::info!(upgrade_height, upgrade_epoch, "new protocol enabled");
 
-            // Get the corresponding payload.
+        // Wait for the first post upgrade epoch change, to also cover proofs
+        // across a V6 epoch boundary
+        let epoch_change_height = timeout(Duration::from_secs(300), async {
+            loop {
+                let leaf = leaves.next().await.unwrap();
+                let epoch = epoch_from_block_number(leaf.height(), EPOCH_HEIGHT);
+                if epoch > upgrade_epoch {
+                    break leaf.height();
+                }
+                tracing::info!(
+                    height = leaf.height(),
+                    ?epoch,
+                    "waiting for a post-upgrade epoch change"
+                );
+            }
+        })
+        .await
+        .expect("no epoch change happened after the upgrade");
+        tracing::info!(epoch_change_height, "post upgrade epoch change");
+
+        // Run a few more blocks so every queried height has the descendants its
+        // proof needs (QC chains, header roots, and a finalizing `Certificate2`).
+        let max_block = epoch_change_height + 3;
+        timeout(Duration::from_secs(120), async {
+            loop {
+                let leaf = leaves.next().await.unwrap();
+                if leaf.height() > max_block {
+                    break;
+                }
+                tracing::info!(max_block, height = leaf.height(), "waiting for block");
+            }
+        })
+        .await
+        .expect("the chain stopped making progress after the upgrade");
+
+        // Stop consensus: every block we query has already been produced.
+        network.stop_consensus().await;
+
+        // Sample blocks around the two boundaries where proof logic changes
+        // the V5 -> V6 upgrade and the following V6 epoch change.
+        let heights =
+            (upgrade_height - 3..=upgrade_height + 1).chain(epoch_change_height - 1..=max_block);
+
+        check_light_client_proofs(
+            &client,
+            &actual_leaves,
+            &actual_blocks,
+            heights,
+            EPOCH_HEIGHT,
+        )
+        .await;
+
+        // every V5 leaf up to the last one before the cutover is
+        // still proven by a HotStuff2 QC chain
+        for h in upgrade_height - 3..=upgrade_height - 1 {
             let proof = client
-                .get::<PayloadProof>(&format!("light-client/payload/{i}"))
+                .get::<LeafProof>(&format!("light-client/leaf/{h}"))
                 .send()
                 .await
                 .unwrap();
-            assert_eq!(proof.verify(leaf.header()).unwrap(), *block.payload());
+            assert!(
+                matches!(proof.proof(), FinalityProof::HotStuff2 { .. }),
+                "pre-upgrade leaf {h} should be proven by a HotStuff2 QC chain, got {:?}",
+                proof.proof(),
+            );
         }
-
-        // Check light client stake table.
-        let events: Vec<StakeTableEvent> = client
-            .get(&format!("light-client/stake-table/{}", first_epoch + 2))
+        let v6_proof = client
+            .get::<LeafProof>(&format!("light-client/leaf/{epoch_change_height}"))
             .send()
             .await
             .unwrap();
-        let mut state_from_events = StakeTableState::default();
-        for event in events {
-            state_from_events.apply_event(event).unwrap().unwrap();
-        }
-
-        assert_eq!(
-            state_from_events.into_validators(),
-            network
-                .server
-                .consensus_handle()
-                .storage()
-                .await
-                .load_all_validators(first_epoch + 2, 0, 1_000_000)
-                .await
-                .unwrap()
-                .into_iter()
-                .map(|v| (v.account, v))
-                .collect::<RegisteredValidatorMap>()
+        assert!(
+            matches!(v6_proof.proof(), FinalityProof::NewProtocol { .. }),
+            "post upgrade leaf should be proven by a new protocol certificate, got {:?}",
+            v6_proof.proof(),
         );
 
-        // Querying for a stake table before the first real epoch is an error.
-        let err = client
-            .get::<Vec<StakeTableEvent>>(&format!("light-client/stake-table/{}", first_epoch + 1))
-            .send()
-            .await
-            .unwrap_err();
-        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        // Epochs run from genesis, so `first_epoch` is 1 and the endpoint is
+        // queryable from epoch 3, which the chain has long passed.
+        let first_epoch = EpochNumber::new(epoch_from_block_number(0, EPOCH_HEIGHT));
+        check_light_client_stake_table(&client, &network.server, first_epoch).await;
     }
 
     /// Test that `fetch_leaf` returns a leaf with exactly the requested block height.

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -10157,30 +10157,37 @@ mod test {
         )
         .await;
 
-        // every V5 leaf up to the last one before the cutover is
-        // still proven by a HotStuff2 QC chain
-        for h in upgrade_height - 3..=upgrade_height - 1 {
-            let proof = client
-                .get::<LeafProof>(&format!("light-client/leaf/{h}"))
+        let client = &client;
+        let finality_proof = |height: u64| async move {
+            client
+                .get::<LeafProof>(&format!("light-client/leaf/{height}"))
                 .send()
                 .await
-                .unwrap();
+                .unwrap()
+        };
+        // Everything up to the last two pre cutover leaves is old protocol
+        for height in upgrade_height - 10..=upgrade_height - 3 {
+            let proof = finality_proof(height).await;
             assert!(
                 matches!(proof.proof(), FinalityProof::HotStuff2 { .. }),
-                "pre-upgrade leaf {h} should be proven by a HotStuff2 QC chain, got {:?}",
+                "leaf {height} should be proven by a HotStuff2 QC chain, got {:?}",
                 proof.proof(),
             );
         }
-        let v6_proof = client
-            .get::<LeafProof>(&format!("light-client/leaf/{epoch_change_height}"))
-            .send()
-            .await
-            .unwrap();
-        assert!(
-            matches!(v6_proof.proof(), FinalityProof::NewProtocol { .. }),
-            "post upgrade leaf should be proven by a new protocol certificate, got {:?}",
-            v6_proof.proof(),
-        );
+
+        // A post cutover leaf is proven by a new protocol certificate. The last
+        // two pre cutover leaves will be finalized by new protocol
+        // e.g cutover at 347 the old protocol decides up to 344 (HotStuff2), and the
+        // new protocol's first Cert2 directly commits 347 and finalizes
+        // 345 and 346 with it via the indirect commit rule.
+        for height in [upgrade_height - 2, upgrade_height - 1, epoch_change_height] {
+            let proof = finality_proof(height).await;
+            assert!(
+                matches!(proof.proof(), FinalityProof::NewProtocol { .. }),
+                "leaf {height} should be proven by a new protocol certificate, got {:?}",
+                proof.proof(),
+            );
+        }
 
         // Epochs run from genesis, so `first_epoch` is 1 and the endpoint is
         // queryable from epoch 3, which the chain has long passed.

--- a/crates/espresso/node/src/api/light_client.rs
+++ b/crates/espresso/node/src/api/light_client.rs
@@ -211,10 +211,9 @@ where
     let start_height = leaf.height();
     let start_commit = leaf.leaf().commit();
 
-    // The new leaf may already complete a HotStuff chain begun before the protocol cutover.
-    if proof.push(leaf) {
-        return Ok(());
-    }
+    // HotStuff commit rules cannot terminate a chain of new protocol leaves
+    // cert2 proves finality.
+    proof.append(leaf);
 
     let cert2 = state
         .read()
@@ -266,14 +265,11 @@ where
             if leaf.leaf().commit() != cert2.data.leaf_commit {
                 return Err(internal("stored cert2 does not finalize the expected leaf"));
             }
-            if !proof.push(leaf) {
-                proof.add_certificate(Arc::new(cert2), requested_leaf_qc);
-            }
+            proof.append(leaf);
+            proof.add_certificate(Arc::new(cert2), requested_leaf_qc);
             return Ok(());
         }
-        if proof.push(leaf) {
-            return Ok(());
-        }
+        proof.append(leaf);
     }
 
     Err(not_found("missing cert2 leaf"))
@@ -1402,6 +1398,73 @@ mod test {
         .await
         .unwrap_err();
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// Upgrade mid chain with consecutive views, mirroring a clean cutover
+    ///  the justify QCs of the first two new protocol leaves form a 2-chain over the last two pre-upgrade leaves,
+    /// but those leaves are finalized by the first cert2 (indirect commit rule) and must serve
+    /// NewProtocol proofs. Only leaves whose 2-chain completes within pre upgrade leaves keep
+    /// HotStuff2 proofs.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_last_pre_cutover_leaves_use_cert2() {
+        let storage = <DataSource as TestableSequencerDataSource>::create_storage().await;
+        let ds = DataSource::create(
+            DataSource::persistence_options(&storage),
+            Default::default(),
+            false,
+        )
+        .await
+        .unwrap();
+
+        let leaves = leaf_chain_with_upgrade(
+            1..=5,
+            4,
+            Upgrade::new(DRB_AND_HEADER_UPGRADE_VERSION, NEW_PROTOCOL_VERSION),
+        )
+        .await;
+        assert_eq!(leaves[2].header().version(), DRB_AND_HEADER_UPGRADE_VERSION);
+        assert_eq!(leaves[3].header().version(), NEW_PROTOCOL_VERSION);
+        let cert2_leaf = &leaves[3];
+        let cert2 = cert2_for_leaf(cert2_leaf);
+
+        {
+            let mut tx = ds.write().await.unwrap();
+            for leaf in &leaves {
+                tx.insert_leaf(leaf).await.unwrap();
+            }
+            tx.insert_cert2(cert2_leaf.height(), cert2).await.unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        // The upgrade leaf is at height 4, so heights 2 and 3 are the last pre-cutover leaves.
+        for requested in [&leaves[1], &leaves[2]] {
+            let proof =
+                get_leaf_proof_with_qc_chain(&ds, requested.clone(), Duration::MAX, CHAIN_LIMIT)
+                    .await
+                    .unwrap();
+            assert!(matches!(proof.proof(), FinalityProof::NewProtocol { .. }));
+            assert_eq!(
+                proof
+                    .verify(LeafProofHint::Quorum(&AlwaysTrueQuorum))
+                    .await
+                    .unwrap(),
+                *requested
+            );
+        }
+
+        // Height 1 completes its 2-chain within pre-upgrade leaves and keeps a HotStuff2 proof.
+        let proof =
+            get_leaf_proof_with_qc_chain(&ds, leaves[0].clone(), Duration::MAX, CHAIN_LIMIT)
+                .await
+                .unwrap();
+        assert!(matches!(proof.proof(), FinalityProof::HotStuff2 { .. }));
+        assert_eq!(
+            proof
+                .verify(LeafProofHint::Quorum(&AlwaysTrueQuorum))
+                .await
+                .unwrap(),
+            leaves[0]
+        );
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/light-client/src/consensus/leaf.rs
+++ b/light-client/src/consensus/leaf.rs
@@ -34,6 +34,8 @@ pub enum FinalityProof {
     /// * Both QCs have a valid threshold signature given a stake table. When the leaf is the last
     ///   leaf of an epoch, the deciding QC is produced in the subsequent epoch and is checked
     ///   against the next epoch's stake table.
+    ///
+    /// Both QCs must have been produced by HotStuff2 protocol
     HotStuff2 {
         committing_qc: Arc<Certificate>,
         deciding_qc: Arc<Certificate>,
@@ -243,10 +245,12 @@ impl LeafProof {
         let len = self.leaves.len();
 
         // Check if the new leaf plus the last saved leaf contain justifying QCs that form a
-        // HotStuff2 QC chain for the leaf before.
+        // HotStuff2 QC chain for the leaf before. The deciding QC comes from the new leaf, so the
+        // new leaf must predate the new protocol cutover. QCs of new protocol leaves are not
+        // produced by HotStuff2 voting.
         if len >= 2
             && self.leaves[len - 2].block_header().version() >= EPOCH_VERSION
-            && self.leaves[len - 2].block_header().version() < NEW_PROTOCOL_VERSION
+            && new_leaf.leaf().block_header().version() < NEW_PROTOCOL_VERSION
         {
             let committing_qc = Certificate::for_parent(&self.leaves[len - 1]);
             let deciding_qc = Certificate::for_parent(new_leaf.leaf());
@@ -303,8 +307,15 @@ impl LeafProof {
         }
 
         // Nothing is finalized yet, just save the new leaf.
-        self.leaves.push(new_leaf.leaf().clone());
+        self.append(new_leaf);
         false
+    }
+
+    /// Append a new leaf to the proof's chain without attempting to complete a finality proof.
+    ///
+    /// This is meant for chains that terminate with cert2 finality
+    pub fn append(&mut self, new_leaf: LeafQueryData<SeqTypes>) {
+        self.leaves.push(new_leaf.leaf().clone());
     }
 
     /// Complete a finality proof by appending 2 QCs which extend from the last pushed leaf.
@@ -363,9 +374,12 @@ impl LeafProof {
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
+    use versions::{DRB_AND_HEADER_UPGRADE_VERSION, Upgrade};
 
     use super::*;
-    use crate::testing::{AlwaysFalseQuorum, AlwaysTrueQuorum, LEGACY_VERSION, leaf_chain};
+    use crate::testing::{
+        AlwaysFalseQuorum, AlwaysTrueQuorum, LEGACY_VERSION, leaf_chain, leaf_chain_with_upgrade,
+    };
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_hotstuff2() {
@@ -383,6 +397,27 @@ mod test {
                 .unwrap(),
             leaves[0]
         );
+    }
+
+    /// A HotStuff2 proof must never use QCs from new protocol leaves, even when consecutive
+    /// views across the cutover make them look like a valid 2 chain.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_no_hotstuff2_completion_across_cutover() {
+        let mut proof = LeafProof::default();
+
+        let leaves = leaf_chain_with_upgrade(
+            1..=4,
+            3,
+            Upgrade::new(DRB_AND_HEADER_UPGRADE_VERSION, NEW_PROTOCOL_VERSION),
+        )
+        .await;
+        assert!(leaves[1].header().version() < NEW_PROTOCOL_VERSION);
+        assert!(leaves[2].header().version() >= NEW_PROTOCOL_VERSION);
+
+        assert!(!proof.push(leaves[0].clone()));
+        assert!(!proof.push(leaves[1].clone()));
+        assert!(!proof.push(leaves[2].clone()));
+        assert!(!proof.push(leaves[3].clone()));
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]


### PR DESCRIPTION
During the V5→V6 upgrade, the light client leaf endpoint could serve HotStuff2 finality proofs built from QCs that new protocol voting produced. Observed on the water devnet (upgrade at height 12772): the proof for leaf 12771 used the justify QCs of the first two V6 leaves as its 2-chain. With consecutive views across the upgrade, these QCs pattern-match the HotStuff2 commit rule, but that rule's safety argument only holds for QCs produced by HotStuff2 voting. This PR fixes that by adding a check for the deciding QC protocol version

This PR also adds `test_light_client_new_protocol_upgrade`, which runs a network through the new protocol upgrade and a following epoch change, then checks that the light client serves correct proofs around both boundaries.