### PR TITLE
fix(catchup): verify leaf chains crossing epoch boundaries against each epoch's stake table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6423,6 +6423,7 @@ dependencies = [
  "async-broadcast",
  "async-lock 3.4.2",
  "async-trait",
+ "bitvec 1.1.0",
  "bon",
  "cliquenet",
  "committable",
@@ -6442,6 +6443,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.23",
+ "vbs",
  "versions",
 ]
 

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -3202,6 +3202,7 @@ mod test {
         data::EpochNumber,
         event::LeafInfo,
         new_protocol::CoordinatorEvent,
+        stake_table::{EpochStakeTable, EpochStakeTables},
         traits::{block_contents::BlockHeader, election::Membership, metrics::NoMetrics},
         utils::epoch_from_block_number,
         x25519,
@@ -8646,12 +8647,15 @@ mod test {
             Client::new(format!("http://localhost:{port}").parse().unwrap());
         wait_until_block_height(&height_client, "node/block-height", TARGET_HEIGHT + 5).await;
 
-        // Get the stake table and threshold for the epoch containing TARGET_HEIGHT
+        // Get the stake tables for the epoch containing TARGET_HEIGHT
         let coordinator = network.server.node_state().coordinator;
         let epoch = EpochNumber::new(epoch_from_block_number(TARGET_HEIGHT, EPOCH_HEIGHT));
         let membership = coordinator.membership().read().await;
-        let stake_table = membership.stake_table(Some(epoch));
-        let success_threshold = membership.success_threshold(Some(epoch));
+        let stake_tables = EpochStakeTables(vec![EpochStakeTable {
+            epoch: Some(epoch),
+            stake_table: membership.stake_table(Some(epoch)),
+            success_threshold: membership.success_threshold(Some(epoch)),
+        }]);
         drop(membership);
 
         // Use StatePeers to fetch the leaf at the exact target height
@@ -8662,9 +8666,7 @@ mod test {
             &NoMetrics,
         );
 
-        let leaf = catchup
-            .fetch_leaf(TARGET_HEIGHT, stake_table, success_threshold)
-            .await?;
+        let leaf = catchup.fetch_leaf(TARGET_HEIGHT, stake_tables).await?;
 
         assert_eq!(
             leaf.height(),

--- a/crates/espresso/node/src/catchup.rs
+++ b/crates/espresso/node/src/catchup.rs
@@ -6,7 +6,6 @@ use std::{
     time::Duration,
 };
 
-use alloy::primitives::U256;
 use anyhow::{Context, anyhow, bail, ensure};
 use async_lock::RwLock;
 use async_trait::async_trait;
@@ -37,7 +36,7 @@ use hotshot_types::{
     message::UpgradeLock,
     network::NetworkConfig,
     simple_certificate::LightClientStateUpdateCertificateV2,
-    stake_table::HSStakeTable,
+    stake_table::EpochStakeTables,
     traits::{
         ValidatedState as ValidatedStateTrait,
         metrics::{Counter, CounterFamily, Metrics},
@@ -368,8 +367,7 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
         &self,
         retry: usize,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
+        stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2> {
         // Fetch the leaf chain. For new protocol heights this is a leaf range
         // `[height..=cert2_height]`
@@ -403,28 +401,17 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
                 .await
                 .with_context(|| format!("failed to fetch cert2 for height {height}"))?;
 
-            verify_leaf_chain_with_cert2(
-                leaf_chain,
-                &stake_table,
-                success_threshold,
-                height,
-                &upgrade_lock,
-                cert2,
-            )
-            .await
-            .with_context(|| format!("failed to verify leaf chain with cert2 at height {height}"))
+            verify_leaf_chain_with_cert2(leaf_chain, &stake_tables, height, &upgrade_lock, cert2)
+                .await
+                .with_context(|| {
+                    format!("failed to verify leaf chain with cert2 at height {height}")
+                })
         } else {
             let upgrade_lock =
                 UpgradeLock::<SeqTypes>::new(versions::Upgrade::trivial(EPOCH_VERSION));
-            verify_leaf_chain(
-                leaf_chain,
-                &stake_table,
-                success_threshold,
-                height,
-                &upgrade_lock,
-            )
-            .await
-            .with_context(|| format!("failed to verify leaf chain at height {height}"))
+            verify_leaf_chain(leaf_chain, &stake_tables, height, &upgrade_lock)
+                .await
+                .with_context(|| format!("failed to verify leaf chain at height {height}"))
         }
     }
 
@@ -759,8 +746,7 @@ where
         &self,
         _retry: usize,
         height: u64,
-        _stake_table: HSStakeTable<SeqTypes>,
-        _success_threshold: U256,
+        _stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2> {
         // Leaves in our local DB were verified before they were stored, so we can return the leaf
         // at `height` directly without re-verifying.
@@ -954,8 +940,7 @@ impl StateCatchup for NullStateCatchup {
         &self,
         _retry: usize,
         _height: u64,
-        _stake_table: HSStakeTable<SeqTypes>,
-        _success_threshold: U256,
+        _stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2> {
         bail!("state catchup is disabled")
     }
@@ -1174,15 +1159,14 @@ impl StateCatchup for ParallelStateCatchup {
         &self,
         retry: usize,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
+        stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2> {
         // Try fetching the leaf on the local providers first
         let local_result = self
-            .on_local_providers(clone! {(stake_table) move |provider| {
-                clone!{(stake_table) async move {
+            .on_local_providers(clone! {(stake_tables) move |provider| {
+                clone!{(stake_tables) async move {
                     provider
-                        .try_fetch_leaf(retry, height, stake_table, success_threshold)
+                        .try_fetch_leaf(retry, height, stake_tables)
                         .await
                 }}
             }})
@@ -1195,10 +1179,10 @@ impl StateCatchup for ParallelStateCatchup {
         }
 
         // If that fails, try the remote ones
-        self.on_remote_providers(clone! {(stake_table) move |provider| {
-            clone!{(stake_table) async move {
+        self.on_remote_providers(clone! {(stake_tables) move |provider| {
+            clone!{(stake_tables) async move {
                 provider
-                    .try_fetch_leaf(retry, height, stake_table, success_threshold)
+                    .try_fetch_leaf(retry, height, stake_tables)
                     .await
             }}
         }})
@@ -1537,15 +1521,14 @@ impl StateCatchup for ParallelStateCatchup {
     async fn fetch_leaf(
         &self,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
+        stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2> {
         // Try fetching the leaf on the local providers first
         let local_result = self
-            .on_local_providers(clone! {(stake_table) move |provider| {
-                clone!{(stake_table) async move {
+            .on_local_providers(clone! {(stake_tables) move |provider| {
+                clone!{(stake_tables) async move {
                     provider
-                        .try_fetch_leaf(0, height, stake_table, success_threshold)
+                        .try_fetch_leaf(0, height, stake_tables)
                         .await
                 }}
             }})
@@ -1558,10 +1541,10 @@ impl StateCatchup for ParallelStateCatchup {
         }
 
         // If that fails, try the remote ones (with retry)
-        self.on_remote_providers(clone! {(stake_table) move |provider| {
-        clone!{(stake_table) async move {
+        self.on_remote_providers(clone! {(stake_tables) move |provider| {
+        clone!{(stake_tables) async move {
             provider
-                .fetch_leaf(height, stake_table, success_threshold)
+                .fetch_leaf(height, stake_tables)
                 .await
         }}
         }})

--- a/crates/espresso/node/src/request_response/catchup/state.rs
+++ b/crates/espresso/node/src/request_response/catchup/state.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use alloy::primitives::U256;
 use anyhow::Context;
 use async_trait::async_trait;
 use committable::{Commitment, Committable};
@@ -18,7 +17,7 @@ use hotshot::traits::NodeImplementation;
 use hotshot_new_protocol::utils::verify_leaf_chain_with_cert2;
 use hotshot_types::{
     data::ViewNumber, message::UpgradeLock,
-    simple_certificate::LightClientStateUpdateCertificateV2, stake_table::HSStakeTable,
+    simple_certificate::LightClientStateUpdateCertificateV2, stake_table::EpochStakeTables,
     traits::network::ConnectedNetwork, utils::verify_leaf_chain,
 };
 use jf_merkle_tree_compat::{ForgetableMerkleTreeScheme, MerkleTreeScheme};
@@ -42,19 +41,15 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
         &self,
         _retry: usize,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
+        stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2> {
         // Timeout after a few batches
         let timeout_duration = self.config.request_batch_interval * 3;
 
         // Fetch the leaf
-        timeout(
-            timeout_duration,
-            self.fetch_leaf(height, stake_table, success_threshold),
-        )
-        .await
-        .with_context(|| "timed out while fetching leaf")?
+        timeout(timeout_duration, self.fetch_leaf(height, stake_tables))
+            .await
+            .with_context(|| "timed out while fetching leaf")?
     }
 
     async fn try_fetch_accounts(
@@ -242,8 +237,7 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
     async fn fetch_leaf(
         &self,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
+        stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2> {
         tracing::info!("Fetching leaf for height: {height}");
 
@@ -292,28 +286,15 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
                 .await
                 .with_context(|| format!("failed to request cert2 at or above height {height}"))?;
 
-            verify_leaf_chain_with_cert2(
-                leaf_chain,
-                &stake_table,
-                success_threshold,
-                height,
-                &upgrade_lock,
-                cert2,
-            )
-            .await
-            .with_context(|| "leaf chain verification with cert2 failed")?
+            verify_leaf_chain_with_cert2(leaf_chain, &stake_tables, height, &upgrade_lock, cert2)
+                .await
+                .with_context(|| "leaf chain verification with cert2 failed")?
         } else {
             let upgrade_lock =
                 UpgradeLock::<SeqTypes>::new(versions::Upgrade::trivial(EPOCH_VERSION));
-            verify_leaf_chain(
-                leaf_chain,
-                &stake_table,
-                success_threshold,
-                height,
-                &upgrade_lock,
-            )
-            .await
-            .with_context(|| "leaf chain verification failed")?
+            verify_leaf_chain(leaf_chain, &stake_tables, height, &upgrade_lock)
+                .await
+                .with_context(|| "leaf chain verification failed")?
         };
 
         tracing::info!("Fetched leaf for height: {height}");

--- a/crates/espresso/types/src/v0/impls/instance_state.rs
+++ b/crates/espresso/types/src/v0/impls/instance_state.rs
@@ -514,13 +514,12 @@ impl Upgrade {
 pub mod mock {
     use std::collections::HashMap;
 
-    use alloy::primitives::U256;
     use anyhow::Context;
     use async_trait::async_trait;
     use committable::Commitment;
     use hotshot_types::{
         data::ViewNumber, simple_certificate::LightClientStateUpdateCertificateV2,
-        stake_table::HSStakeTable,
+        stake_table::EpochStakeTables,
     };
     use jf_merkle_tree_compat::{ForgetableMerkleTreeScheme, MerkleTreeScheme};
 
@@ -572,8 +571,7 @@ pub mod mock {
             &self,
             _retry: usize,
             _height: u64,
-            _stake_table: HSStakeTable<SeqTypes>,
-            _success_threshold: U256,
+            _stake_tables: EpochStakeTables<SeqTypes>,
         ) -> anyhow::Result<Leaf2> {
             Err(anyhow::anyhow!("todo"))
         }

--- a/crates/espresso/types/src/v0/impls/reward.rs
+++ b/crates/espresso/types/src/v0/impls/reward.rs
@@ -1197,17 +1197,31 @@ impl EpochRewardsCalculator {
         let leader_counts = if let Some(lc) = leader_counts {
             lc
         } else {
+            // The chain deciding the epoch's last block extends into the next
+            // epoch and is partly signed by the next epoch's quorum, so that
+            // stake table must be available too.
+            let next_epoch = EpochNumber::new(*epoch + 1);
+            if let Err(err) = coordinator.membership_for_epoch(Some(next_epoch)).await {
+                tracing::info!(
+                    %next_epoch,
+                    "stake table missing for epoch, triggering catchup: {err:#}"
+                );
+                coordinator
+                    .wait_for_catchup(next_epoch)
+                    .await
+                    .context(format!("failed to catch up for epoch={next_epoch}"))?;
+            }
+
             // Fetch the leaf at the last block of the epoch so we can verify
             // the header via QC against the stake table
             let membership = coordinator.membership().read().await;
-            let stake_table = membership.stake_table(Some(epoch));
-            let success_threshold = membership.success_threshold(Some(epoch));
+            let stake_tables = membership.leaf_chain_stake_tables(epoch);
             drop(membership);
 
             let leaf = instance_state
                 .state_catchup
                 .as_ref()
-                .fetch_leaf(epoch_last_block_height, stake_table, success_threshold)
+                .fetch_leaf(epoch_last_block_height, stake_tables)
                 .await
                 .with_context(|| {
                     format!(

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -45,7 +45,7 @@ use hotshot_types::{
         election::{RandomizedCommittee, generate_stake_cdf, select_randomized_leader},
     },
     epoch_membership::EpochMembershipCoordinator,
-    stake_table::{HSStakeTable, StakeTableEntry},
+    stake_table::{EpochStakeTable, EpochStakeTables, HSStakeTable, StakeTableEntry},
     traits::{
         block_contents::BlockHeader, election::Membership, node_implementation::NodeType,
         signature_key::StakeTableEntryType,
@@ -1761,6 +1761,27 @@ impl EpochCommittees {
         self.first_epoch
     }
 
+    /// Stake tables for verifying a leaf chain whose expected leaf is in
+    /// `epoch`. A chain deciding a leaf near the end of an epoch contains
+    /// certificates signed by the next epoch's quorum, so include the next
+    /// epoch's stake table whenever we have it.
+    pub(crate) fn leaf_chain_stake_tables(&self, epoch: Epoch) -> EpochStakeTables<SeqTypes> {
+        let mut tables = vec![EpochStakeTable {
+            epoch: Some(epoch),
+            stake_table: self.stake_table(Some(epoch)),
+            success_threshold: self.success_threshold(Some(epoch)),
+        }];
+        let next_epoch = EpochNumber::new(*epoch + 1);
+        if self.has_stake_table(next_epoch) {
+            tables.push(EpochStakeTable {
+                epoch: Some(next_epoch),
+                stake_table: self.stake_table(Some(next_epoch)),
+                success_threshold: self.success_threshold(Some(next_epoch)),
+            });
+        }
+        EpochStakeTables(tables)
+    }
+
     pub fn fetcher(&self) -> &Fetcher {
         &self.fetcher
     }
@@ -2020,17 +2041,16 @@ impl EpochCommittees {
                          root height",
                     )?;
 
-                    let prev_stake_table = self
-                        .get_stake_table(&Some(EpochNumber::new(previous_epoch)))
-                        .context("Stake table not found")?
-                        .into();
-
-                    let success_threshold =
-                        self.success_threshold(Some(EpochNumber::new(previous_epoch)));
+                    ensure!(
+                        self.has_stake_table(EpochNumber::new(previous_epoch)),
+                        "Stake table not found"
+                    );
+                    let stake_tables =
+                        self.leaf_chain_stake_tables(EpochNumber::new(previous_epoch));
 
                     fetcher
                         .peers
-                        .fetch_leaf(root_height, prev_stake_table, success_threshold)
+                        .fetch_leaf(root_height, stake_tables)
                         .await
                         .context("Epoch root leaf not found")?
                         .block_header()
@@ -2745,14 +2765,11 @@ impl Membership<SeqTypes> for EpochCommittees {
         let membership_reader = membership.read().await;
         let block_height = root_block_in_epoch(*epoch, membership_reader.epoch_height);
         let peers = membership_reader.fetcher.peers.clone();
-        let stake_table = membership_reader.stake_table(Some(epoch)).clone();
-        let success_threshold = membership_reader.success_threshold(Some(epoch));
+        let stake_tables = membership_reader.leaf_chain_stake_tables(epoch);
         drop(membership_reader);
 
         // Fetch leaves from peers
-        let leaf: Leaf2 = peers
-            .fetch_leaf(block_height, stake_table.clone(), success_threshold)
-            .await?;
+        let leaf: Leaf2 = peers.fetch_leaf(block_height, stake_tables).await?;
 
         Ok(leaf)
     }
@@ -2781,8 +2798,7 @@ impl Membership<SeqTypes> for EpochCommittees {
             },
         };
 
-        let stake_table = membership_reader.stake_table(Some(previous_epoch)).clone();
-        let success_threshold = membership_reader.success_threshold(Some(previous_epoch));
+        let stake_tables = membership_reader.leaf_chain_stake_tables(previous_epoch);
 
         let block_height =
             transition_block_for_epoch(*previous_epoch, membership_reader.epoch_height);
@@ -2794,9 +2810,7 @@ impl Membership<SeqTypes> for EpochCommittees {
             epoch,
             block_height
         );
-        let drb_leaf = peers
-            .try_fetch_leaf(1, block_height, stake_table, success_threshold)
-            .await?;
+        let drb_leaf = peers.try_fetch_leaf(1, block_height, stake_tables).await?;
 
         let Some(drb) = drb_leaf.next_drb_result else {
             tracing::error!(

--- a/crates/espresso/types/src/v0/traits.rs
+++ b/crates/espresso/types/src/v0/traits.rs
@@ -2,7 +2,7 @@
 //! It also includes some trait implementations that cannot be implemented in an external crate.
 use std::{cmp::max, collections::BTreeMap, fmt::Debug, ops::Range, sync::Arc};
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::Address;
 use anyhow::{Context, bail, ensure};
 use async_trait::async_trait;
 use committable::Commitment;
@@ -23,7 +23,7 @@ use hotshot_types::{
         CertificatePair, LightClientStateUpdateCertificateV2, NextEpochQuorumCertificate2,
         QuorumCertificate, QuorumCertificate2, UpgradeCertificate,
     },
-    stake_table::HSStakeTable,
+    stake_table::EpochStakeTables,
     traits::{
         ValidatedState as HotShotState, metrics::Metrics, node_implementation::NodeType,
         storage::Storage,
@@ -54,27 +54,29 @@ use crate::{
 #[async_trait]
 pub trait StateCatchup: Send + Sync {
     /// Fetch the leaf at the given height without retrying on transient errors.
+    ///
+    /// `stake_tables` must cover every epoch the verified leaf chain may
+    /// touch: a chain deciding a leaf near the end of an epoch contains
+    /// certificates signed by the next epoch's quorum.
     async fn try_fetch_leaf(
         &self,
         retry: usize,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
+        stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2>;
 
     /// Fetch the leaf at the given height, retrying on transient errors.
     async fn fetch_leaf(
         &self,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
+        stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2> {
         self.backoff()
             .retry(self, |provider, retry| {
-                let stake_table_clone = stake_table.clone();
+                let stake_tables_clone = stake_tables.clone();
                 async move {
                     provider
-                        .try_fetch_leaf(retry, height, stake_table_clone, success_threshold)
+                        .try_fetch_leaf(retry, height, stake_tables_clone)
                         .await
                 }
                 .boxed()
@@ -299,23 +301,17 @@ impl<T: StateCatchup + ?Sized> StateCatchup for Arc<T> {
         &self,
         retry: usize,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
+        stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2> {
-        (**self)
-            .try_fetch_leaf(retry, height, stake_table, success_threshold)
-            .await
+        (**self).try_fetch_leaf(retry, height, stake_tables).await
     }
 
     async fn fetch_leaf(
         &self,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
+        stake_tables: EpochStakeTables<SeqTypes>,
     ) -> anyhow::Result<Leaf2> {
-        (**self)
-            .fetch_leaf(height, stake_table, success_threshold)
-            .await
+        (**self).fetch_leaf(height, stake_tables).await
     }
 
     async fn try_fetch_accounts(

--- a/crates/hotshot/new-protocol/Cargo.toml
+++ b/crates/hotshot/new-protocol/Cargo.toml
@@ -38,5 +38,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 versions = { workspace = true }
 
+[dev-dependencies]
+bitvec = { workspace = true }
+vbs = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/hotshot/new-protocol/src/utils.rs
+++ b/crates/hotshot/new-protocol/src/utils.rs
@@ -1,11 +1,10 @@
-use alloy::primitives::U256;
 use anyhow::{anyhow, ensure};
 use committable::Committable;
 use hotshot_types::{
-    PeerConfig,
     data::Leaf2,
     message::UpgradeLock,
-    stake_table::StakeTableEntries,
+    simple_certificate::QuorumCertificate2,
+    stake_table::{EpochStakeTables, StakeTableEntries},
     traits::node_implementation::NodeType,
     vote::{Certificate, HasViewNumber},
 };
@@ -25,8 +24,7 @@ use crate::message::Certificate2;
 /// commitment, and block height.
 pub async fn verify_leaf_chain_with_cert2<T: NodeType>(
     mut leaf_chain: Vec<Leaf2<T>>,
-    stake_table: &[PeerConfig<T>],
-    success_threshold: U256,
+    stake_tables: &EpochStakeTables<T>,
     expected_height: u64,
     upgrade_lock: &UpgradeLock<T>,
     cert2: Certificate2<T>,
@@ -36,9 +34,25 @@ pub async fn verify_leaf_chain_with_cert2<T: NodeType>(
 
     ensure!(!leaf_chain.is_empty(), "empty leaf chain");
 
-    let stake_table_entries = StakeTableEntries::<T>::from(stake_table.to_vec()).0;
+    // The chain may cross an epoch boundary, in which case its certificates
+    // are signed by different epochs' quorums. Verify each certificate against
+    // the stake table of the epoch committed in its signed payload.
+    let check_qc = |qc: &QuorumCertificate2<T>| -> anyhow::Result<()> {
+        let table = stake_tables.for_epoch(qc.data.epoch)?;
+        qc.is_valid_cert(
+            &StakeTableEntries::<T>::from(table.stake_table.clone()).0,
+            table.success_threshold,
+            upgrade_lock,
+        )?;
+        Ok(())
+    };
 
-    cert2.is_valid_cert(&stake_table_entries, success_threshold, upgrade_lock)?;
+    let cert2_table = stake_tables.for_epoch(Some(cert2.data.epoch))?;
+    cert2.is_valid_cert(
+        &StakeTableEntries::<T>::from(cert2_table.stake_table.clone()).0,
+        cert2_table.success_threshold,
+        upgrade_lock,
+    )?;
 
     ensure!(
         cert2.data.leaf_commit == leaf_chain[0].commit(),
@@ -78,7 +92,7 @@ pub async fn verify_leaf_chain_with_cert2<T: NodeType>(
             leaf.height().checked_add(1) == Some(current.height()),
             "leaf heights do not chain"
         );
-        justify_qc.is_valid_cert(&stake_table_entries, success_threshold, upgrade_lock)?;
+        check_qc(&justify_qc)?;
         if leaf.height() == expected_height {
             return Ok(leaf.clone());
         }
@@ -88,4 +102,321 @@ pub async fn verify_leaf_chain_with_cert2<T: NodeType>(
     Err(anyhow!(
         "expected height was not found in the cert2-finalized chain"
     ))
+}
+
+#[cfg(test)]
+mod test {
+    use alloy::primitives::U256;
+    use bitvec::vec::BitVec;
+    use committable::Commitment;
+    use hotshot_example_types::{
+        block_types::{TestBlockHeader, TestMetadata},
+        node_types::TestTypes,
+    };
+    use hotshot_types::{
+        PeerConfig,
+        data::{EpochNumber, QuorumProposal2, QuorumProposalWrapper, VidCommitment, ViewNumber},
+        signature_key::BLSPubKey,
+        simple_vote::{QuorumData2, VersionedVoteData, Vote2Data},
+        stake_table::{EpochStakeTable, StakeTableEntry, supermajority_threshold},
+        traits::signature_key::SignatureKey,
+        utils::{BuilderCommitment, verify_leaf_chain},
+    };
+    use versions::{EPOCH_VERSION, NEW_PROTOCOL_VERSION, Upgrade};
+
+    use super::*;
+
+    type PrivKey = <BLSPubKey as SignatureKey>::PrivateKey;
+    type Quorum = (Vec<PrivKey>, Vec<PeerConfig<TestTypes>>);
+
+    fn quorum(indexes: std::ops::Range<u64>) -> Quorum {
+        indexes
+            .map(|i| {
+                let (stake_key, priv_key) =
+                    BLSPubKey::generated_from_seed_indexed(Default::default(), i);
+                (
+                    priv_key,
+                    PeerConfig::<TestTypes> {
+                        stake_table_entry: StakeTableEntry {
+                            stake_key,
+                            stake_amount: U256::from(1),
+                        },
+                        state_ver_key: Default::default(),
+                        connect_info: None,
+                    },
+                )
+            })
+            .unzip()
+    }
+
+    fn stake_table_for(epoch: u64, (_, peers): &Quorum) -> EpochStakeTable<TestTypes> {
+        let total: U256 = peers.iter().map(|p| p.stake_table_entry.stake_amount).sum();
+        EpochStakeTable {
+            epoch: Some(EpochNumber::new(epoch)),
+            stake_table: peers.clone().into(),
+            success_threshold: supermajority_threshold(total),
+        }
+    }
+
+    fn sign((keys, peers): &Quorum, msg: &[u8]) -> <BLSPubKey as SignatureKey>::QcType {
+        let entries: Vec<_> = peers.iter().map(|p| p.stake_table_entry.clone()).collect();
+        let total: U256 = entries.iter().map(|e| e.stake_amount).sum();
+        let pp = BLSPubKey::public_parameter(&entries, supermajority_threshold(total));
+        let sigs: Vec<_> = keys
+            .iter()
+            .map(|key| BLSPubKey::sign(key, msg).unwrap())
+            .collect();
+        BLSPubKey::assemble(
+            &pp,
+            &std::iter::repeat_n(true, keys.len()).collect::<BitVec>(),
+            &sigs,
+        )
+    }
+
+    fn signed_qc(
+        data: QuorumData2<TestTypes>,
+        view: u64,
+        quorum: &Quorum,
+        upgrade_lock: &UpgradeLock<TestTypes>,
+    ) -> QuorumCertificate2<TestTypes> {
+        let view = ViewNumber::new(view);
+        let commit = VersionedVoteData::new_infallible(data.clone(), view, upgrade_lock).commit();
+        QuorumCertificate2::create_signed_certificate(
+            commit,
+            data,
+            sign(quorum, commit.as_ref()),
+            view,
+        )
+    }
+
+    fn signed_cert2(
+        data: Vote2Data<TestTypes>,
+        view: u64,
+        quorum: &Quorum,
+        upgrade_lock: &UpgradeLock<TestTypes>,
+    ) -> Certificate2<TestTypes> {
+        let view = ViewNumber::new(view);
+        let commit = VersionedVoteData::new_infallible(data.clone(), view, upgrade_lock).commit();
+        Certificate2::create_signed_certificate(commit, data, sign(quorum, commit.as_ref()), view)
+    }
+
+    fn make_leaf(
+        height: u64,
+        view: u64,
+        epoch: u64,
+        justify_qc: QuorumCertificate2<TestTypes>,
+        version: vbs::version::Version,
+    ) -> Leaf2<TestTypes> {
+        Leaf2::from_quorum_proposal(&QuorumProposalWrapper {
+            proposal: QuorumProposal2 {
+                block_header: TestBlockHeader {
+                    block_number: height,
+                    payload_commitment: VidCommitment::default(),
+                    builder_commitment: BuilderCommitment::from_bytes([]),
+                    metadata: TestMetadata {
+                        num_transactions: 0,
+                    },
+                    timestamp: 0,
+                    timestamp_millis: 0,
+                    random: 0,
+                    version,
+                },
+                view_number: ViewNumber::new(view),
+                epoch: Some(EpochNumber::new(epoch)),
+                justify_qc,
+                next_epoch_justify_qc: None,
+                upgrade_certificate: None,
+                view_change_evidence: None,
+                next_drb_result: None,
+                state_cert: None,
+            },
+        })
+    }
+
+    /// A legacy 3-chain deciding the last block of epoch 1 (epoch height 10), where epochs 1 and
+    /// 2 have disjoint quorums. The QC on the first block of epoch 2 is signed by epoch 2's
+    /// quorum; every other QC is signed by epoch 1's.
+    fn boundary_3_chain(
+        quorum1: &Quorum,
+        deciding_quorum: &Quorum,
+        upgrade_lock: &UpgradeLock<TestTypes>,
+    ) -> Vec<Leaf2<TestTypes>> {
+        let qc9 = signed_qc(
+            QuorumData2 {
+                leaf_commit: Commitment::from_raw([9; 32]),
+                epoch: Some(EpochNumber::new(1)),
+                block_number: Some(9),
+            },
+            9,
+            quorum1,
+            upgrade_lock,
+        );
+        let leaf10 = make_leaf(10, 10, 1, qc9, EPOCH_VERSION);
+        let qc10 = signed_qc(
+            QuorumData2 {
+                leaf_commit: Committable::commit(&leaf10),
+                epoch: Some(EpochNumber::new(1)),
+                block_number: Some(10),
+            },
+            10,
+            quorum1,
+            upgrade_lock,
+        );
+        let leaf11 = make_leaf(11, 11, 2, qc10, EPOCH_VERSION);
+        let qc11 = signed_qc(
+            QuorumData2 {
+                leaf_commit: Committable::commit(&leaf11),
+                epoch: Some(EpochNumber::new(2)),
+                block_number: Some(11),
+            },
+            11,
+            deciding_quorum,
+            upgrade_lock,
+        );
+        let leaf12 = make_leaf(12, 12, 2, qc11, EPOCH_VERSION);
+        vec![leaf10, leaf11, leaf12]
+    }
+
+    /// A 3-chain deciding the last leaf of an epoch contains a QC signed by the next epoch's
+    /// quorum; it must be verified against that quorum's stake table.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_verify_leaf_chain_across_epoch_boundary() {
+        let quorum1 = quorum(0..5);
+        let quorum2 = quorum(5..10);
+        let upgrade_lock = UpgradeLock::<TestTypes>::new(Upgrade::trivial(EPOCH_VERSION));
+
+        let chain = boundary_3_chain(&quorum1, &quorum2, &upgrade_lock);
+        let expected = Committable::commit(&chain[0]);
+
+        let stake_tables = EpochStakeTables(vec![
+            stake_table_for(1, &quorum1),
+            stake_table_for(2, &quorum2),
+        ]);
+        let leaf = verify_leaf_chain(chain.clone(), &stake_tables, 10, &upgrade_lock)
+            .await
+            .unwrap();
+        assert_eq!(Committable::commit(&leaf), expected);
+
+        // With only the leaf's own epoch provided (the pre-fix behavior), verification must fail
+        // instead of checking the next epoch's QC against the wrong stake table.
+        let only_epoch1 = EpochStakeTables(vec![stake_table_for(1, &quorum1)]);
+        verify_leaf_chain(chain, &only_epoch1, 10, &upgrade_lock)
+            .await
+            .unwrap_err();
+    }
+
+    /// A QC claiming epoch 2 in its signed payload but signed by epoch 1's quorum must fail
+    /// verification against epoch 2's stake table.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_verify_leaf_chain_boundary_qc_wrong_quorum() {
+        let quorum1 = quorum(0..5);
+        let quorum2 = quorum(5..10);
+        let upgrade_lock = UpgradeLock::<TestTypes>::new(Upgrade::trivial(EPOCH_VERSION));
+
+        let chain = boundary_3_chain(&quorum1, &quorum1, &upgrade_lock);
+
+        let stake_tables = EpochStakeTables(vec![
+            stake_table_for(1, &quorum1),
+            stake_table_for(2, &quorum2),
+        ]);
+        verify_leaf_chain(chain, &stake_tables, 10, &upgrade_lock)
+            .await
+            .unwrap_err();
+    }
+
+    /// A new-protocol leaf range deciding the last block of epoch 1, finalized by a cert2 on the
+    /// first block of epoch 2, signed by `cert2_quorum`.
+    fn boundary_cert2_chain(
+        quorum1: &Quorum,
+        cert2_quorum: &Quorum,
+        upgrade_lock: &UpgradeLock<TestTypes>,
+    ) -> (Vec<Leaf2<TestTypes>>, Certificate2<TestTypes>) {
+        let qc9 = signed_qc(
+            QuorumData2 {
+                leaf_commit: Commitment::from_raw([9; 32]),
+                epoch: Some(EpochNumber::new(1)),
+                block_number: Some(9),
+            },
+            9,
+            quorum1,
+            upgrade_lock,
+        );
+        let leaf10 = make_leaf(10, 10, 1, qc9, NEW_PROTOCOL_VERSION);
+        let qc10 = signed_qc(
+            QuorumData2 {
+                leaf_commit: Committable::commit(&leaf10),
+                epoch: Some(EpochNumber::new(1)),
+                block_number: Some(10),
+            },
+            10,
+            quorum1,
+            upgrade_lock,
+        );
+        let leaf11 = make_leaf(11, 11, 2, qc10, NEW_PROTOCOL_VERSION);
+        let cert2 = signed_cert2(
+            Vote2Data {
+                leaf_commit: Committable::commit(&leaf11),
+                epoch: EpochNumber::new(2),
+                block_number: 11,
+            },
+            11,
+            cert2_quorum,
+            upgrade_lock,
+        );
+        (vec![leaf10, leaf11], cert2)
+    }
+
+    /// A cert2 finalizing the last leaf of an epoch is produced in the next epoch and must be
+    /// verified against the next epoch's stake table, while the boundary QC inside the chain is
+    /// verified against the previous epoch's.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_verify_leaf_chain_with_cert2_across_epoch_boundary() {
+        let quorum1 = quorum(0..5);
+        let quorum2 = quorum(5..10);
+        let upgrade_lock = UpgradeLock::<TestTypes>::new(Upgrade::trivial(NEW_PROTOCOL_VERSION));
+
+        let (chain, cert2) = boundary_cert2_chain(&quorum1, &quorum2, &upgrade_lock);
+        let expected = Committable::commit(&chain[0]);
+
+        let stake_tables = EpochStakeTables(vec![
+            stake_table_for(1, &quorum1),
+            stake_table_for(2, &quorum2),
+        ]);
+        let leaf = verify_leaf_chain_with_cert2(
+            chain.clone(),
+            &stake_tables,
+            10,
+            &upgrade_lock,
+            cert2.clone(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(Committable::commit(&leaf), expected);
+
+        // With only the leaf's own epoch provided (the pre-fix behavior), verification must fail
+        // instead of checking the cert2 against the wrong stake table.
+        let only_epoch1 = EpochStakeTables(vec![stake_table_for(1, &quorum1)]);
+        verify_leaf_chain_with_cert2(chain, &only_epoch1, 10, &upgrade_lock, cert2)
+            .await
+            .unwrap_err();
+    }
+
+    /// A cert2 claiming epoch 2 in its signed payload but signed by epoch 1's quorum must fail
+    /// verification against epoch 2's stake table.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_verify_leaf_chain_with_cert2_wrong_quorum() {
+        let quorum1 = quorum(0..5);
+        let quorum2 = quorum(5..10);
+        let upgrade_lock = UpgradeLock::<TestTypes>::new(Upgrade::trivial(NEW_PROTOCOL_VERSION));
+
+        let (chain, cert2) = boundary_cert2_chain(&quorum1, &quorum1, &upgrade_lock);
+
+        let stake_tables = EpochStakeTables(vec![
+            stake_table_for(1, &quorum1),
+            stake_table_for(2, &quorum2),
+        ]);
+        verify_leaf_chain_with_cert2(chain, &stake_tables, 10, &upgrade_lock, cert2)
+            .await
+            .unwrap_err();
+    }
 }

--- a/crates/hotshot/types/src/stake_table.rs
+++ b/crates/hotshot/types/src/stake_table.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     NodeType, PeerConfig,
+    data::EpochNumber,
     light_client::{CircuitField, StakeTableState, ToFieldsLightClientCompat},
     traits::signature_key::{SignatureKey, StakeTableEntryType},
 };
@@ -205,6 +206,38 @@ impl<TYPES: NodeType> HSStakeTable<TYPES> {
             .iter()
             .map(|peer| peer.stake_table_entry.stake())
             .sum()
+    }
+}
+
+/// The stake table and vote success threshold of a single epoch.
+///
+/// A fetched leaf chain can cross an epoch boundary, in which case its
+/// certificates are signed by different epochs' quorums. Verifiers take one of
+/// these per epoch the chain may touch and check each certificate against the
+/// stake table of the epoch committed in the certificate's signed payload.
+#[derive(Clone, Debug)]
+pub struct EpochStakeTable<TYPES: NodeType> {
+    /// The epoch whose quorum this stake table describes. `None` for
+    /// certificates produced before the epoch upgrade.
+    pub epoch: Option<EpochNumber>,
+    pub stake_table: HSStakeTable<TYPES>,
+    pub success_threshold: U256,
+}
+
+/// Per-epoch stake tables covering every epoch a fetched leaf chain may touch.
+#[derive(Clone, Debug)]
+pub struct EpochStakeTables<TYPES: NodeType>(pub Vec<EpochStakeTable<TYPES>>);
+
+impl<TYPES: NodeType> EpochStakeTables<TYPES> {
+    /// The stake table for the epoch a certificate claims in its signed
+    /// payload. Dispatching on the claimed epoch is sound: the epoch is part of
+    /// the signed vote data, so a certificate claiming the wrong epoch fails
+    /// signature verification.
+    pub fn for_epoch(&self, epoch: Option<EpochNumber>) -> anyhow::Result<&EpochStakeTable<TYPES>> {
+        self.0
+            .iter()
+            .find(|table| table.epoch == epoch)
+            .ok_or_else(|| anyhow::anyhow!("no stake table provided for epoch {epoch:?}"))
     }
 }
 

--- a/crates/hotshot/types/src/utils.rs
+++ b/crates/hotshot/types/src/utils.rs
@@ -12,7 +12,6 @@ use std::{
     sync::Arc,
 };
 
-use alloy::primitives::U256;
 use anyhow::{anyhow, ensure};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bincode::{
@@ -32,10 +31,10 @@ use vbs::version::Version;
 use versions::EPOCH_VERSION;
 
 use crate::{
-    PeerConfig,
     data::{EpochNumber, Leaf2, VidCommitment, ViewNumber},
     message::UpgradeLock,
-    stake_table::StakeTableEntries,
+    simple_certificate::QuorumCertificate2,
+    stake_table::{EpochStakeTables, StakeTableEntries},
     traits::{ValidatedState, node_implementation::NodeType},
     vote::{Certificate, HasViewNumber},
 };
@@ -105,8 +104,7 @@ pub type StateAndDelta<TYPES> = (
 
 pub async fn verify_leaf_chain<T: NodeType>(
     mut leaf_chain: Vec<Leaf2<T>>,
-    stake_table: &[PeerConfig<T>],
-    success_threshold: U256,
+    stake_tables: &EpochStakeTables<T>,
     expected_height: u64,
     upgrade_lock: &UpgradeLock<T>,
 ) -> anyhow::Result<Leaf2<T>> {
@@ -141,31 +139,30 @@ pub async fn verify_leaf_chain<T: NodeType>(
         ));
     }
 
-    // Get the stake table entries
-    let stake_table_entries = StakeTableEntries::<T>::from(stake_table.to_vec()).0;
+    // The chain may cross an epoch boundary, in which case its QCs are signed
+    // by different epochs' quorums. Verify each QC against the stake table of
+    // the epoch committed in its signed payload.
+    let check_qc = |qc: &QuorumCertificate2<T>| -> anyhow::Result<()> {
+        let table = stake_tables.for_epoch(qc.data.epoch)?;
+        qc.is_valid_cert(
+            &StakeTableEntries::<T>::from(table.stake_table.clone()).0,
+            table.success_threshold,
+            upgrade_lock,
+        )?;
+        Ok(())
+    };
 
     // verify all QCs are valid
-    newest_leaf.justify_qc().is_valid_cert(
-        &stake_table_entries,
-        success_threshold,
-        upgrade_lock,
-    )?;
-    parent
-        .justify_qc()
-        .is_valid_cert(&stake_table_entries, success_threshold, upgrade_lock)?;
-    grand_parent.justify_qc().is_valid_cert(
-        &stake_table_entries,
-        success_threshold,
-        upgrade_lock,
-    )?;
+    check_qc(&newest_leaf.justify_qc())?;
+    check_qc(&parent.justify_qc())?;
+    check_qc(&grand_parent.justify_qc())?;
 
     // Verify the root is in the chain of decided leaves
     let mut last_leaf = parent;
     for leaf in leaf_chain.iter().skip(2) {
         ensure!(last_leaf.justify_qc().view_number() == leaf.view_number());
         ensure!(last_leaf.justify_qc().data().leaf_commit == leaf.commit());
-        leaf.justify_qc()
-            .is_valid_cert(&stake_table_entries, success_threshold, upgrade_lock)?;
+        check_qc(&leaf.justify_qc())?;
         if leaf.height() == expected_height {
             return Ok(leaf.clone());
         }

--- a/light-client/src/consensus/quorum.rs
+++ b/light-client/src/consensus/quorum.rs
@@ -668,7 +668,7 @@ mod test {
         quorum: &QuorumKeys,
     ) -> QuorumCertificate2<SeqTypes> {
         let commit = VersionedVoteData::new_infallible(
-            data,
+            data.clone(),
             view,
             &UpgradeLock::<SeqTypes>::new(Upgrade::trivial(EPOCH_VERSION)),
         )
@@ -724,7 +724,7 @@ mod test {
             block_number: Some(10),
         };
         let committing_qc = Certificate::new(
-            boundary_signed_qc(committing_data, ViewNumber::new(10), &current),
+            boundary_signed_qc(committing_data.clone(), ViewNumber::new(10), &current),
             Some(boundary_signed_next_epoch_qc(
                 committing_data,
                 ViewNumber::new(10),
@@ -805,7 +805,7 @@ mod test {
             block_number: Some(5),
         };
         let committing_qc = Certificate::new(
-            boundary_signed_qc(committing_data, ViewNumber::new(5), &current),
+            boundary_signed_qc(committing_data.clone(), ViewNumber::new(5), &current),
             disguise_as_boundary
                 .then(|| boundary_signed_next_epoch_qc(committing_data, ViewNumber::new(5), &next)),
         );


### PR DESCRIPTION
A leaf chain deciding a block near the end of an epoch contains certificates signed by the next epoch's quorum: the deciding QCs (legacy 3-chain) or the finalizing cert2 (new protocol) are produced in the following epoch. `verify_leaf_chain` and `verify_leaf_chain_with_cert2` checked every certificate against a single stake table, so catchup `fetch_leaf` failed with a signature verification error whenever adjacent epochs have different stake tables. This is the catchup counterpart of the light-client fix in #4733.

## Changes

- New `EpochStakeTable` / `EpochStakeTables` types in `hotshot-types`: per-epoch stake table + success threshold with a `for_epoch()` lookup. Dispatching on the epoch a certificate claims is sound because the epoch is part of the signed vote data, so a certificate claiming the wrong epoch fails signature verification.
- Both verifiers now check each certificate against the stake table of the epoch committed in its own signed payload, and error clearly when that epoch's table was not provided.
- `StateCatchup::{try_fetch_leaf,fetch_leaf}` carry `EpochStakeTables` instead of a single table + threshold; all implementations updated.
- Callers build the set via a new `EpochCommittees::leaf_chain_stake_tables(epoch)` helper that includes epoch + 1's table whenever available (`get_epoch_root`, `get_epoch_drb`, `calculate_dynamic_block_reward`). The epoch-rewards path fetching the epoch's last block now ensures epoch + 1's stake table via `wait_for_catchup` first, since that chain always crosses the boundary.
- Drive-by (separate commit): the tests backported in #4733 move `QuorumData2` values twice, which only compiles where the type is `Copy`; added the missing clones so `cargo clippy --all-targets` passes on this branch again.

## Testing

Six regression tests in `hotshot-new-protocol` with real BLS signatures over disjoint per-epoch quorums, for both verifiers: boundary crossing succeeds with both tables, fails with only the leaf's epoch table (the pre-fix behavior), and a certificate claiming the next epoch but signed by the wrong quorum is rejected.