### PR TITLE
fix(cliquenet): accept authenticated peers from any source IP

### DIFF
--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, mem, net::IpAddr, sync::Arc, time::Duration};
+use std::{collections::HashMap, mem, sync::Arc, time::Duration};
 
 use bytes::{Bytes, BytesMut};
 use tokio::{
@@ -175,24 +175,13 @@ impl Server {
                             self.spawn_hello(conn, Hello::BackOff(Duration::MAX));
                             continue
                         }
-                        let Some(party) = self.parties.get_mut(&conn.key) else {
+                        if !self.parties.contains_key(&conn.key) {
                             info!(
                                 name = %self.conf.name,
                                 node = %self.key,
                                 peer = %conn.key,
                                 addr = %conn.addr,
                                 "unknown party"
-                            );
-                            self.spawn_hello(conn, Hello::BackOff(self.conf.backoff_duration));
-                            continue
-                        };
-                        if party.ip_addr_mismatch(conn.addr.ip()) {
-                            warn!(
-                                name = %self.conf.name,
-                                node = %self.key,
-                                peer = %conn.key,
-                                addr = %conn.addr,
-                                "party has invalid ip addr"
                             );
                             self.spawn_hello(conn, Hello::BackOff(self.conf.backoff_duration));
                             continue
@@ -766,13 +755,6 @@ impl Party {
             retry: DelayQueue::new(c),
             peer: PeerState::None,
         }
-    }
-
-    fn ip_addr_mismatch(&self, addr: IpAddr) -> bool {
-        let NetAddr::Inet(ip, _) = &self.addr else {
-            return false;
-        };
-        *ip != addr
     }
 }
 


### PR DESCRIPTION
## Summary

Remove the source-IP check in cliquenet's inbound accept path. The server rejected connections from known, cryptographically authenticated peers whenever the TCP source IP did not match the party's registered address.

## Why this is safe

- Identity is established by the Noise IK handshake in `Connection::accept`, which authenticates the remote's static x25519 key **before** the party lookup runs. An attacker cannot impersonate a registered key from any IP.
- Promotion to a live peer additionally requires a valid encrypted `Hello` round-trip over the derived session keys, proving live possession of the key (replaying a captured handshake message is not sufficient).
- The check was already skipped for any party registered by hostname (`NetAddr::Name`), so it was never a consistent security boundary.
- It ran *after* the full Noise handshake, so it provided no DoS protection either. The unknown-party rejection (key not in the stake table) is unchanged.

## What it was breaking

Legitimate validators whose egress IP differs from their advertised ingress address were told to back off:

- NAT / cloud setups where outbound traffic leaves via a NAT gateway but the advertised `p2p_addr` is a load balancer or elastic IP
- multi-homed hosts choosing a different source interface
- dual-stack nodes, where an IPv4-mapped IPv6 source (`::ffff:x.x.x.x`) never compares equal to a registered `IpAddr::V4`

The outbound direction is unchanged: when dialing, the initiator still pins the expected key via `remote_public_key`, so we still verify we reached the registered peer.

## Reviewer focus

The IP check came in with #4200 ("Revisiting cliquenet") — flagging in case there was a motivation for it beyond what the history shows.

## Testing

`cargo nextest run -p cliquenet` — 59/59 pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)