### PR TITLE
feat(api): add leader lookup endpoints for arbitrary views

### DIFF
--- a/crates/espresso/api/examples/test_api.rs
+++ b/crates/espresso/api/examples/test_api.rs
@@ -442,6 +442,7 @@ impl v1::NodeApi for TestApi {
     type BlockReward = serde_json::Value;
     type Block = serde_json::Value;
     type Leaf = serde_json::Value;
+    type ViewLeader = serde_json::Value;
 
     async fn block_height(&self) -> Result<u64> {
         Ok(0)
@@ -521,6 +522,12 @@ impl v1::NodeApi for TestApi {
     }
     async fn get_oldest_leaf(&self) -> Result<Option<Self::Leaf>> {
         Ok(None)
+    }
+    async fn leader(&self, _view: u64) -> Result<Self::ViewLeader> {
+        Ok(serde_json::Value::Null)
+    }
+    async fn leaders(&self, _from: u64, _until: u64) -> Result<Vec<Self::ViewLeader>> {
+        Ok(vec![])
     }
 }
 

--- a/crates/espresso/api/src/axum.rs
+++ b/crates/espresso/api/src/axum.rs
@@ -2127,6 +2127,22 @@ where
             .map_err(ApiError::Internal)
     };
 
+    let node_leader = |State(state): State<S>, Path(view): Path<u64>| async move {
+        state
+            .leader(view)
+            .await
+            .map(ApiJson)
+            .map_err(classify_availability_error)
+    };
+
+    let node_leaders = |State(state): State<S>, Path((from, until)): Path<(u64, u64)>| async move {
+        state
+            .leaders(from, until)
+            .await
+            .map(ApiJson)
+            .map_err(classify_availability_error)
+    };
+
     ApiRouter::new()
         .api_route(
             routes::v1::NODE_BLOCK_HEIGHT_ROUTE,
@@ -2432,6 +2448,32 @@ where
                     "Get the oldest (smallest height) leaf present in storage, or null if none is \
                      stored.",
                 )
+            }),
+        )
+        .api_route(
+            routes::v1::NODE_LEADER_ROUTE,
+            get_with(node_leader, |op| {
+                op.summary("Get the leader of a view").description(
+                    "Get the leader of the given view, including views that produced no \
+                     block.\n\nThe epoch is resolved from the decided chain: it is the epoch of \
+                     the first leaf decided at or after the requested view, or the epoch the node \
+                     is currently in for views that are not decided yet. Views older than the \
+                     oldest retained leaf cannot be resolved and return 404. During an epoch \
+                     transition the next epoch's leader is also entitled to propose, so for those \
+                     views the answer is one of two possible leaders.",
+                )
+            }),
+        )
+        .api_route(
+            routes::v1::NODE_LEADERS_ROUTE,
+            get_with(node_leaders, |op| {
+                op.summary("Get the leaders of a range of views")
+                    .description(
+                        "Get the leader of every view in `from..=until` inclusive, up to 10000 \
+                         views per request.\n\nA range crossing an epoch boundary is truncated at \
+                         the boundary: each entry carries its own view, so the caller resumes \
+                         from the last returned view plus one.",
+                    )
             }),
         )
         .with_state(state)
@@ -4449,6 +4491,7 @@ mod tests {
         type BlockReward = ();
         type Block = ();
         type Leaf = ();
+        type ViewLeader = ();
 
         async fn block_height(&self) -> anyhow::Result<u64> {
             unimplemented!()
@@ -4527,6 +4570,12 @@ mod tests {
             unimplemented!()
         }
         async fn get_oldest_leaf(&self) -> anyhow::Result<Option<Self::Leaf>> {
+            unimplemented!()
+        }
+        async fn leader(&self, _view: u64) -> anyhow::Result<Self::ViewLeader> {
+            unimplemented!()
+        }
+        async fn leaders(&self, _from: u64, _until: u64) -> anyhow::Result<Vec<Self::ViewLeader>> {
             unimplemented!()
         }
     }

--- a/crates/espresso/api/src/axum/routes.rs
+++ b/crates/espresso/api/src/axum/routes.rs
@@ -218,6 +218,9 @@ pub mod v1 {
     pub const NODE_OLDEST_BLOCK_ROUTE: &str = "/v1/node/oldest-block";
     pub const NODE_OLDEST_LEAF_ROUTE: &str = "/v1/node/oldest-leaf";
 
+    pub const NODE_LEADER_ROUTE: &str = "/v1/node/leader/{view}";
+    pub const NODE_LEADERS_ROUTE: &str = "/v1/node/leaders/{from}/{until}";
+
     // Catchup routes (under /v1/catchup)
     pub const CATCHUP_ACCOUNT_ROUTE: &str = "/v1/catchup/{height}/{view}/account/{address}";
     pub const CATCHUP_ACCOUNTS_ROUTE: &str = "/v1/catchup/{height}/{view}/accounts";
@@ -749,6 +752,9 @@ pub mod v1 {
     );
     path_fn!(node_oldest_block, NODE_OLDEST_BLOCK_ROUTE);
     path_fn!(node_oldest_leaf, NODE_OLDEST_LEAF_ROUTE);
+
+    path_fn!(node_leader, NODE_LEADER_ROUTE, view);
+    path_fn!(node_leaders, NODE_LEADERS_ROUTE, from, until);
 
     // Catchup
     path_fn!(

--- a/crates/espresso/api/src/v1/node.rs
+++ b/crates/espresso/api/src/v1/node.rs
@@ -34,6 +34,7 @@ pub trait NodeApi {
     type BlockReward: Serialize + Send + Sync + 'static;
     type Block: Serialize + Send + Sync + 'static;
     type Leaf: Serialize + Send + Sync + 'static;
+    type ViewLeader: Serialize + Send + Sync + 'static;
 
     async fn block_height(&self) -> anyhow::Result<u64>;
 
@@ -85,4 +86,7 @@ pub trait NodeApi {
 
     async fn get_oldest_block(&self) -> anyhow::Result<Option<Self::Block>>;
     async fn get_oldest_leaf(&self) -> anyhow::Result<Option<Self::Leaf>>;
+
+    async fn leader(&self, view: u64) -> anyhow::Result<Self::ViewLeader>;
+    async fn leaders(&self, from: u64, until: u64) -> anyhow::Result<Vec<Self::ViewLeader>>;
 }

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, pin::Pin, sync::Arc, time::Duration};
+use std::{collections::HashMap, ops::RangeInclusive, pin::Pin, sync::Arc, time::Duration};
 
 use ::light_client::{
     LightClient,
@@ -92,6 +92,7 @@ use crate::{
 pub mod data_source;
 pub mod endpoints;
 pub mod fs;
+pub mod leader;
 pub mod light_client;
 pub mod options;
 pub mod sql;
@@ -314,6 +315,22 @@ impl<N: ConnectedNetwork<PubKey>, D: Sync, P: SequencerPersistence> StakeTableDa
             .stake_table_events(from_l1_block, to_l1_block)
             .await
     }
+
+    async fn leaders(
+        &self,
+        views: RangeInclusive<ViewNumber>,
+        epoch: Option<EpochNumber>,
+    ) -> anyhow::Result<Vec<PubKey>> {
+        self.as_ref().leaders(views, epoch).await
+    }
+
+    async fn current_epoch(&self) -> Option<EpochNumber> {
+        self.as_ref().current_epoch().await
+    }
+
+    async fn epoch_height(&self) -> u64 {
+        self.as_ref().epoch_height().await
+    }
 }
 
 impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence> TokenDataSource<SeqTypes>
@@ -529,6 +546,43 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence> StakeTableDataSource<
             "some events in range [{from_l1_block}, {to_l1_block}] are not available ({status:?})"
         );
         Ok(events.into_iter().map(|(_, event)| event).collect())
+    }
+
+    /// Get the leader of each view in `views` from `epoch`'s randomized stake table.
+    ///
+    /// Waits for stake table catchup when the epoch is no longer held in memory.
+    async fn leaders(
+        &self,
+        views: RangeInclusive<ViewNumber>,
+        epoch: Option<EpochNumber>,
+    ) -> anyhow::Result<Vec<PubKey>> {
+        let coordinator = self.consensus_handle().await.membership_coordinator().await;
+        let membership = match coordinator.membership_for_epoch(epoch) {
+            Ok(membership) => membership,
+            Err(err) => {
+                let epoch = epoch
+                    .with_context(|| format!("failed to get non-epoch membership: {err:#}"))?;
+                coordinator.wait_for_catchup(epoch).await.map_err(|err| {
+                    anyhow::anyhow!("stake table catchup for epoch {epoch} failed: {err:#}")
+                })?
+            },
+        };
+
+        (views.start().u64()..=views.end().u64())
+            .map(|view| {
+                membership.leader(ViewNumber::new(view)).map_err(|err| {
+                    anyhow::anyhow!("no leader for view {view} in epoch {epoch:?}: {err:#}")
+                })
+            })
+            .collect()
+    }
+
+    async fn current_epoch(&self) -> Option<EpochNumber> {
+        self.consensus_handle().await.current_epoch().await
+    }
+
+    async fn epoch_height(&self) -> u64 {
+        self.consensus_handle().await.epoch_height().await.u64()
     }
 }
 
@@ -6428,6 +6482,173 @@ mod test {
                 break;
             }
         }
+
+        Ok(())
+    }
+
+    /// Verifies the leader endpoints against the leaders the committee elects for the decided views,
+    /// including the epoch each view is resolved to and views that produced no block.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_leader_api() -> anyhow::Result<()> {
+        const EPOCH_HEIGHT: u64 = 10;
+        const NUM_NODES: usize = 5;
+        const LAST_HEIGHT: u64 = 4 * EPOCH_HEIGHT;
+        const V5: Upgrade = Upgrade::trivial(EPOCH_REWARD_VERSION);
+
+        let network_config = TestConfigBuilder::default()
+            .epoch_height(EPOCH_HEIGHT)
+            .build();
+        let api_port = reserve_tcp_port().expect("No ports free for query service");
+        let storage = join_all((0..NUM_NODES).map(|_| SqlDataSource::create_storage())).await;
+        let persistence: [_; NUM_NODES] = storage
+            .iter()
+            .map(<SqlDataSource as TestableSequencerDataSource>::persistence_options)
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        let config = TestNetworkConfigBuilder::with_num_nodes()
+            .api_config(SqlDataSource::options(
+                &storage[0],
+                Options::with_port(api_port),
+            ))
+            .network_config(network_config)
+            .persistences(persistence)
+            .pos_hook(DelegationConfig::MultipleDelegators, Default::default(), V5)
+            .await
+            .unwrap()
+            .build();
+
+        let network = TestNetwork::new(config, V5).await;
+        let client: Client<ServerError, SequencerApiVersion> =
+            Client::new(format!("http://localhost:{api_port}").parse().unwrap());
+        client.connect(None).await;
+
+        // Epochs 1 and 2 are seeded from config by `set_first_epoch`; later epochs use a stake table
+        // fetched from L1.
+        let mut decided: Vec<(ViewNumber, EpochNumber)> = Vec::new();
+        let mut leaves = client
+            .socket("availability/stream/leaves/0")
+            .subscribe::<LeafQueryData<SeqTypes>>()
+            .await
+            .unwrap();
+        while let Some(leaf) = leaves.next().await {
+            let leaf = leaf.unwrap();
+            let height = leaf.header().height();
+            let epoch = leaf.leaf().epoch(EPOCH_HEIGHT).expect("epochs are enabled");
+            if epoch > EpochNumber::new(2) {
+                decided.push((leaf.leaf().view_number(), epoch));
+            }
+            if height >= LAST_HEIGHT {
+                break;
+            }
+        }
+        assert!(
+            decided.iter().any(|(_, epoch)| *epoch != decided[0].1),
+            "the decided range must cross an epoch boundary"
+        );
+
+        let coordinator = network.server.node_state().coordinator;
+        let expected_leader = |view, epoch| {
+            coordinator
+                .membership()
+                .snapshot(epoch)
+                .expect("committee for epoch")
+                .leader(view)
+                .expect("leader for view")
+        };
+
+        for (view, epoch) in &decided {
+            let leader: leader::ViewLeader = client
+                .get(&format!("node/leader/{view}"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                leader,
+                leader::ViewLeader {
+                    view: *view,
+                    epoch: Some(*epoch),
+                    leader: expected_leader(*view, *epoch),
+                }
+            );
+        }
+
+        // A view with no leaf produced no block, so it is elected from the epoch of the next leaf.
+        let mut without_block = 0;
+        for pair in decided.windows(2) {
+            let (previous, _) = pair[0];
+            let (view, epoch) = pair[1];
+            for missing in previous.u64() + 1..view.u64() {
+                without_block += 1;
+                let leader: leader::ViewLeader = client
+                    .get(&format!("node/leader/{missing}"))
+                    .send()
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    leader,
+                    leader::ViewLeader {
+                        view: ViewNumber::new(missing),
+                        epoch: Some(epoch),
+                        leader: expected_leader(ViewNumber::new(missing), epoch),
+                    }
+                );
+            }
+        }
+        tracing::info!("checked {without_block} views that produced no block");
+
+        let (last_view, last_epoch) = *decided.last().unwrap();
+        let epoch_start = decided
+            .iter()
+            .find(|(_, epoch)| *epoch == last_epoch)
+            .unwrap()
+            .0;
+        let range: Vec<leader::ViewLeader> = client
+            .get(&format!("node/leaders/{epoch_start}/{last_view}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(range.len() as u64, last_view.u64() - epoch_start.u64() + 1);
+        for (offset, entry) in range.iter().enumerate() {
+            assert_eq!(entry.view, epoch_start + offset as u64);
+            assert_eq!(entry.epoch, Some(last_epoch));
+            assert_eq!(entry.leader, expected_leader(entry.view, last_epoch));
+        }
+        let (first_view, first_epoch) = decided[0];
+        let spanning: Vec<leader::ViewLeader> = client
+            .get(&format!("node/leaders/{first_view}/{last_view}"))
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            spanning
+                .iter()
+                .all(|entry| entry.epoch == Some(first_epoch))
+        );
+        assert!(spanning.last().unwrap().view < last_view);
+
+        let over_limit = client
+            .get::<Vec<leader::ViewLeader>>(&format!(
+                "node/leaders/0/{}",
+                leader::LEADER_RANGE_LIMIT
+            ))
+            .send()
+            .await
+            .unwrap_err();
+        assert_eq!(over_limit.status(), StatusCode::BAD_REQUEST);
+
+        let inverted = client
+            .get::<Vec<leader::ViewLeader>>("node/leaders/2/1")
+            .send()
+            .await
+            .unwrap_err();
+        assert_eq!(inverted.status(), StatusCode::BAD_REQUEST);
+
+        // Nothing is pruned here, so view 0 resolves; a pruned node reports 404 for views below its
+        // oldest retained leaf.
+        let genesis: leader::ViewLeader = client.get("node/leader/0").send().await.unwrap();
+        assert_eq!(genesis.view, ViewNumber::genesis());
 
         Ok(())
     }

--- a/crates/espresso/node/src/api/data_source.rs
+++ b/crates/espresso/node/src/api/data_source.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, ops::RangeInclusive, time::Duration};
 
 use alloy::primitives::Address;
 use anyhow::Context;
@@ -203,6 +203,19 @@ pub(crate) trait StakeTableDataSource<T: NodeType> {
         from_l1_block: u64,
         to_l1_block: u64,
     ) -> impl Send + Future<Output = anyhow::Result<Vec<StakeTableEvent>>>;
+
+    /// Get the leader of each view in `views`, all elected from `epoch`'s randomized stake table.
+    fn leaders(
+        &self,
+        views: RangeInclusive<ViewNumber>,
+        epoch: Option<EpochNumber>,
+    ) -> impl Send + Future<Output = anyhow::Result<Vec<T::SignatureKey>>>;
+
+    /// Get the epoch the node is currently in, or `None` if epochs are not enabled.
+    fn current_epoch(&self) -> impl Send + Future<Output = Option<EpochNumber>>;
+
+    /// Get the number of blocks per epoch.
+    fn epoch_height(&self) -> impl Send + Future<Output = u64>;
 }
 
 // Thin wrapper trait to access persistence methods from API handlers

--- a/crates/espresso/node/src/api/leader.rs
+++ b/crates/espresso/node/src/api/leader.rs
@@ -1,0 +1,351 @@
+//! Leader lookup for arbitrary views.
+//!
+//! The leader of a view is a pure function of the view, the epoch's stake table and the epoch's DRB
+//! result, so any past view can be answered without per-view records. The epoch is not derivable
+//! from the view alone (epochs are counted in block heights), so it is resolved from the decided
+//! chain: the epoch of the first leaf decided at or after the requested view. A view that produced
+//! no block did not advance the block height, so that next leaf carries the height, and therefore
+//! the epoch, the view would have had.
+//!
+//! Resolution bisects epochs, not leaves. An epoch's first block sits at a height fixed by
+//! arithmetic, so `log2(block height / epoch_height)` reads suffice and they always land on the same
+//! small set of rows, one per epoch, which the database keeps cached across requests. Bisecting
+//! leaves instead costs `log2(block height)` reads at unpredictable heights, cold every time.
+
+use std::{future::Future, time::Duration};
+
+use anyhow::{Context, ensure};
+use espresso_api::error::AvailabilityError;
+use espresso_types::{PubKey, SeqTypes};
+use hotshot_query_service::{
+    availability::{AvailabilityDataSource, LeafId, LeafQueryData},
+    node::NodeDataSource,
+};
+use hotshot_types::data::{EpochNumber, ViewNumber};
+use serde::{Deserialize, Serialize};
+
+use super::data_source::{PruningDataSource, StakeTableDataSource};
+
+/// Maximum number of views one range request may cover.
+pub const LEADER_RANGE_LIMIT: u64 = 10_000;
+
+/// The leader of a single view.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViewLeader {
+    pub view: ViewNumber,
+    /// `None` for views from before epochs were enabled.
+    pub epoch: Option<EpochNumber>,
+    pub leader: PubKey,
+}
+
+/// Data source for leader lookup: leaves to resolve the epoch of a view, the stake table to elect
+/// from it, and the retained height window to keep reads off pruned heights.
+pub(crate) trait LeaderDataSource:
+    AvailabilityDataSource<SeqTypes>
+    + NodeDataSource<SeqTypes>
+    + StakeTableDataSource<SeqTypes>
+    + PruningDataSource
+    + Sync
+{
+}
+
+impl<T> LeaderDataSource for T where
+    T: AvailabilityDataSource<SeqTypes>
+        + NodeDataSource<SeqTypes>
+        + StakeTableDataSource<SeqTypes>
+        + PruningDataSource
+        + Sync
+{
+}
+
+/// Leaders of the views in `from..=until`.
+///
+/// Ranges crossing an epoch boundary are truncated at the boundary: each entry carries its own view,
+/// so the caller resumes from the last returned view plus one.
+pub(crate) async fn leaders<DS: LeaderDataSource>(
+    ds: &DS,
+    from: ViewNumber,
+    until: ViewNumber,
+    timeout: Duration,
+) -> anyhow::Result<Vec<ViewLeader>> {
+    let (epoch, until) = resolve_epoch(ds, from, until, timeout).await?;
+
+    let leaders = ds.leaders(from..=until, epoch).await?;
+    Ok((from.u64()..=until.u64())
+        .zip(leaders)
+        .map(|(view, leader)| ViewLeader {
+            view: ViewNumber::new(view),
+            epoch,
+            leader,
+        })
+        .collect())
+}
+
+/// The epoch of `from`, and the last view of `from..=until` that belongs to it.
+async fn resolve_epoch<DS: LeaderDataSource>(
+    ds: &DS,
+    from: ViewNumber,
+    until: ViewNumber,
+    timeout: Duration,
+) -> anyhow::Result<(Option<EpochNumber>, ViewNumber)> {
+    let block_height = NodeDataSource::block_height(ds)
+        .await
+        .context("failed to get block height")? as u64;
+    ensure!(block_height > 0, "no blocks have been decided");
+    let tip = block_height - 1;
+    let epoch_height = ds.epoch_height().await;
+
+    // Pruning deletes a contiguous prefix of heights, so the retained leaves are `floor..=tip` and
+    // no read may go below `floor`.
+    let oldest = match ds.get_oldest_leaf().await? {
+        Some(oldest) => oldest,
+        None => leaf_at(ds, 0, timeout).await?,
+    };
+    let floor = oldest.leaf().height();
+    if from < oldest.leaf().view_number() {
+        return Err(AvailabilityError::NotFound(format!(
+            "view {from} predates the oldest retained leaf (height {floor}, view {})",
+            oldest.leaf().view_number()
+        ))
+        .into());
+    }
+
+    let newest = leaf_at(ds, tip, timeout).await?;
+    if from > newest.leaf().view_number() {
+        // Nothing in the requested range is decided yet, so the views are elected from the epoch the
+        // node is currently in.
+        return Ok((ds.current_epoch().await, until));
+    }
+
+    let window = Window {
+        floor,
+        tip,
+        epoch_height,
+        timeout,
+    };
+    match (
+        oldest.leaf().epoch(epoch_height),
+        newest.leaf().epoch(epoch_height),
+    ) {
+        (None, None) => Ok((None, until)),
+        (Some(floor_epoch), Some(tip_epoch)) => {
+            let epoch = window
+                .epoch_of_view(ds, from, floor_epoch, tip_epoch)
+                .await?;
+            let until = window.truncate(ds, until, epoch, tip_epoch).await?;
+            Ok((Some(epoch), until))
+        },
+        // The retained window straddles the epoch upgrade, so which side `from` falls on is not
+        // arithmetic and has to be read off the leaf itself.
+        (None, Some(tip_epoch)) => {
+            let height = window
+                .first_leaf_at_or_after(ds, from)
+                .await?
+                .context("leaf at or after the requested view is retained")?;
+            let epoch = leaf_at(ds, height, timeout)
+                .await?
+                .leaf()
+                .epoch(epoch_height);
+            let Some(epoch) = epoch else {
+                let until_height = window.first_leaf_at_or_after(ds, until).await?;
+                let until_epoch = match until_height {
+                    Some(height) => leaf_at(ds, height, timeout)
+                        .await?
+                        .leaf()
+                        .epoch(epoch_height),
+                    None => ds.current_epoch().await,
+                };
+                ensure!(
+                    until_epoch.is_none(),
+                    "view range {from}..={until} crosses the epoch upgrade; request the \
+                     pre-upgrade and post-upgrade views separately"
+                );
+                return Ok((None, until));
+            };
+            let until = window.truncate(ds, until, epoch, tip_epoch).await?;
+            Ok((Some(epoch), until))
+        },
+        // `with_epoch` never goes back to false once an upgrade enables epochs.
+        (Some(floor_epoch), None) => Err(anyhow::anyhow!(
+            "leaf {floor} is in epoch {floor_epoch} but leaf {tip} has no epoch"
+        )),
+    }
+}
+
+/// The retained height window that reads are confined to.
+struct Window {
+    floor: u64,
+    tip: u64,
+    epoch_height: u64,
+    timeout: Duration,
+}
+
+impl Window {
+    /// The view of the first retained leaf of `epoch`.
+    ///
+    /// Non-decreasing in `epoch`, which is what makes it bisectable.
+    async fn epoch_first_view<DS: LeaderDataSource>(
+        &self,
+        ds: &DS,
+        epoch: u64,
+    ) -> anyhow::Result<ViewNumber> {
+        // Epoch `e` covers heights `(e - 1) * epoch_height + 1 ..= e * epoch_height`.
+        let height = ((epoch - 1) * self.epoch_height + 1).max(self.floor);
+        leaf_view(ds, height, self.timeout).await
+    }
+
+    /// The epoch of the first leaf decided at `view` or later.
+    async fn epoch_of_view<DS: LeaderDataSource>(
+        &self,
+        ds: &DS,
+        view: ViewNumber,
+        floor_epoch: EpochNumber,
+        tip_epoch: EpochNumber,
+    ) -> anyhow::Result<EpochNumber> {
+        let first_at_or_after =
+            first_key_at_or_after(view, floor_epoch.u64(), tip_epoch.u64(), |e| {
+                self.epoch_first_view(ds, e)
+            })
+            .await?;
+
+        let Some(first_at_or_after) = first_at_or_after else {
+            return Ok(tip_epoch);
+        };
+        if first_at_or_after == floor_epoch.u64() {
+            return Ok(floor_epoch);
+        }
+        // The preceding epoch may still be the answer: its own first view is below `view`, but its
+        // last leaf need not be.
+        let previous = first_at_or_after - 1;
+        let last_height = (previous * self.epoch_height).min(self.tip);
+        let epoch = if leaf_view(ds, last_height, self.timeout).await? >= view {
+            previous
+        } else {
+            first_at_or_after
+        };
+        Ok(EpochNumber::new(epoch))
+    }
+
+    /// `until`, clamped to the last view of `epoch`.
+    async fn truncate<DS: LeaderDataSource>(
+        &self,
+        ds: &DS,
+        until: ViewNumber,
+        epoch: EpochNumber,
+        tip_epoch: EpochNumber,
+    ) -> anyhow::Result<ViewNumber> {
+        if epoch >= tip_epoch {
+            return Ok(until);
+        }
+        let next = self.epoch_first_view(ds, epoch.u64() + 1).await?;
+        Ok(until.min(next - 1))
+    }
+
+    /// The height of the first leaf decided at `view` or later, by bisecting leaves.
+    ///
+    /// Only for the pre-epoch era, where epoch arithmetic does not apply.
+    async fn first_leaf_at_or_after<DS: LeaderDataSource>(
+        &self,
+        ds: &DS,
+        view: ViewNumber,
+    ) -> anyhow::Result<Option<u64>> {
+        first_key_at_or_after(view, self.floor, self.tip, |h| {
+            leaf_view(ds, h, self.timeout)
+        })
+        .await
+    }
+}
+
+async fn leaf_at<DS: AvailabilityDataSource<SeqTypes> + Sync>(
+    ds: &DS,
+    height: u64,
+    timeout: Duration,
+) -> anyhow::Result<LeafQueryData<SeqTypes>> {
+    ds.get_leaf(LeafId::Number(height as usize))
+        .await
+        .with_timeout(timeout)
+        .await
+        .with_context(|| format!("leaf {height} unavailable"))
+}
+
+async fn leaf_view<DS: AvailabilityDataSource<SeqTypes> + Sync>(
+    ds: &DS,
+    height: u64,
+    timeout: Duration,
+) -> anyhow::Result<ViewNumber> {
+    Ok(leaf_at(ds, height, timeout).await?.leaf().view_number())
+}
+
+/// Smallest key in `lo..=hi` whose view is `view` or later, or `None` if every key up to `hi` is
+/// older than `view`.
+///
+/// `view_at` must be non-decreasing in the key. Used over epochs, and over heights before epochs
+/// were enabled.
+async fn first_key_at_or_after<F, Fut>(
+    view: ViewNumber,
+    lo: u64,
+    hi: u64,
+    view_at: F,
+) -> anyhow::Result<Option<u64>>
+where
+    F: Fn(u64) -> Fut,
+    Fut: Future<Output = anyhow::Result<ViewNumber>>,
+{
+    if view_at(hi).await? < view {
+        return Ok(None);
+    }
+    let (mut lo, mut hi) = (lo, hi);
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if view_at(mid).await? < view {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    Ok(Some(lo))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Exhaustive check of the bisect against a linear scan, over every requested view and every
+    /// window of a key space with gaps (views that produced no block) throughout.
+    #[tokio::test]
+    async fn first_key_at_or_after_matches_linear_scan() {
+        let views = [2u64, 3, 6, 7, 11];
+        let hi = views.len() as u64 - 1;
+
+        for lo in 0..=hi {
+            // A read below `lo` is a read of a pruned height, which the bisect must never do.
+            let view_at = |key: u64| async move {
+                assert!(key >= lo, "read key {key} below the window start {lo}");
+                Ok(ViewNumber::new(views[key as usize]))
+            };
+
+            for view in 0..=13 {
+                let expected = (views[hi as usize] >= view).then(|| {
+                    (lo..=hi)
+                        .find(|key| views[*key as usize] >= view)
+                        .expect("non-decreasing views, so hi qualifies")
+                });
+                let found = first_key_at_or_after(ViewNumber::new(view), lo, hi, view_at)
+                    .await
+                    .unwrap();
+                assert_eq!(found, expected, "view {view}, window start {lo}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn first_key_at_or_after_single_key() {
+        let view_at = |_| async { Ok(ViewNumber::new(5)) };
+        for (view, expected) in [(0, Some(0)), (5, Some(0)), (6, None)] {
+            let found = first_key_at_or_after(ViewNumber::new(view), 0, 0, view_at)
+                .await
+                .unwrap();
+            assert_eq!(found, expected, "view {view}");
+        }
+    }
+}

--- a/crates/espresso/node/src/api/state.rs
+++ b/crates/espresso/node/src/api/state.rs
@@ -45,7 +45,7 @@ use hotshot_query_service::{
     types::HeightIndexed as _,
 };
 use hotshot_types::{
-    data::{EpochNumber, VidShare},
+    data::{EpochNumber, VidShare, ViewNumber},
     utils::{epoch_from_block_number, root_block_in_epoch},
     vid::avidm::AvidMShare,
 };
@@ -70,6 +70,7 @@ use super::{
         StakeTableDataSource, StateCertDataSource, StateCertFetchingDataSource,
         StateSignatureDataSource, TokenDataSource as _,
     },
+    leader,
 };
 
 /// Node API state implementation
@@ -2355,6 +2356,7 @@ impl<D> espresso_api::v1::NodeApi for NodeApiStateImpl<D>
 where
     D: std::ops::Deref + Clone + Send + Sync + 'static,
     D::Target: hotshot_query_service::node::NodeDataSource<espresso_types::SeqTypes>
+        + AvailabilityDataSource<espresso_types::SeqTypes>
         + super::data_source::StakeTableDataSource<espresso_types::SeqTypes>
         + super::data_source::PruningDataSource
         + Send
@@ -2378,6 +2380,7 @@ where
     type BlockReward = Option<espresso_types::v0_3::RewardAmount>;
     type Block = hotshot_query_service::availability::BlockQueryData<espresso_types::SeqTypes>;
     type Leaf = hotshot_query_service::availability::LeafQueryData<espresso_types::SeqTypes>;
+    type ViewLeader = leader::ViewLeader;
 
     async fn block_height(&self) -> anyhow::Result<u64> {
         let ds = &*self.data_source;
@@ -2567,6 +2570,39 @@ where
         let ds = &*self.data_source;
         ds.get_oldest_leaf().await
     }
+
+    async fn leader(&self, view: u64) -> anyhow::Result<Self::ViewLeader> {
+        self.leaders(view, view)
+            .await?
+            .pop()
+            .ok_or_else(|| not_found(format!("no leader for view {view}")))
+    }
+
+    async fn leaders(&self, from: u64, until: u64) -> anyhow::Result<Vec<Self::ViewLeader>> {
+        if from > until {
+            return Err(bad_request(format!(
+                "from {from} is greater than until {until}"
+            )));
+        }
+        if until - from >= leader::LEADER_RANGE_LIMIT {
+            return Err(range_exceeded(format!(
+                "range {from}..={until} exceeds the limit of {} views",
+                leader::LEADER_RANGE_LIMIT
+            )));
+        }
+        leader::leaders(
+            &*self.data_source,
+            ViewNumber::new(from),
+            ViewNumber::new(until),
+            leader_fetch_timeout(),
+        )
+        .await
+    }
+}
+
+/// Timeout for each leaf read done while resolving the epoch of a view.
+fn leader_fetch_timeout() -> Duration {
+    Duration::from_millis(500)
 }
 
 fn node_window_limit() -> usize {


### PR DESCRIPTION
Why:

- Attributing a view that timed out to the validator that should have proposed it currently requires either opt-in telemetry with 30 day retention, or reimplementing weighted-random leader selection and the DRB outside the node. The node can just answer.
- The leader is a pure function of the view, the epoch's stake table and the epoch's DRB result, so any past view is answerable with no new state and no per-view records.
- Telemetry also misattributes views near an epoch boundary: view_sync resolves the leader against the logging node's own cur_epoch, so a lagging node reports a leader from the wrong epoch. Resolving at query time from the decided chain gets it right.

What:

- GET /v1/node/leader/{view}
- GET /v1/node/leaders/{from}/{until}, inclusive, at most 10000 views
- The epoch of a view is the epoch of the first leaf decided at or after it. A view that produced no block did not advance the block height, so that leaf carries the height, and therefore the epoch, the view would have had. This matches how consensus derives a proposal's epoch from the proposed leaf's height.
- Resolution bisects epochs, not leaves. Epoch first-block heights are arithmetic, so log2(block height / epoch_height) reads suffice and always hit the same small set of rows, which stays cached. Bisecting leaves would cost log2(block height) cold reads per request.
- Reads stay within the retained height window, since pruning deletes a contiguous prefix. Views below it return 404 naming the window.
- A range crossing an epoch boundary is truncated there. Each entry carries its own view, so the caller resumes from the last one plus one.
