### PR TITLE
ci: bind process-compose version input via env before shell

### DIFF
--- a/.github/actions/install-process-compose/action.yml
+++ b/.github/actions/install-process-compose/action.yml
@@ -11,12 +11,14 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        PROCESS_COMPOSE_VERSION: ${{ inputs.version }}
       run: |
         set -euxo pipefail
-        if [ "${{ inputs.version }}" = "latest" ]; then
+        if [ "$PROCESS_COMPOSE_VERSION" = "latest" ]; then
           URL="https://github.com/F1bonacc1/process-compose/releases/latest/download/process-compose_linux_amd64.tar.gz"
         else
-          URL="https://github.com/F1bonacc1/process-compose/releases/download/${{ inputs.version }}/process-compose_linux_amd64.tar.gz"
+          URL="https://github.com/F1bonacc1/process-compose/releases/download/${PROCESS_COMPOSE_VERSION}/process-compose_linux_amd64.tar.gz"
         fi
         curl -L "$URL" -o /tmp/process-compose.tar.gz
         tar -xzf /tmp/process-compose.tar.gz -C /tmp


### PR DESCRIPTION
## Summary
- Bind `inputs.version` through `env: PROCESS_COMPOSE_VERSION` before the install shell script that builds the GitHub release download URL.
- Same class as GitHub’s documented script-injection guidance for interpolating composite action inputs into `run:` scripts.

## Test plan
- [ ] `version: latest` still downloads from `/latest/download/`
- [ ] Explicit version tag still downloads from `/download/<version>/`


Made with [Cursor](https://cursor.com)