### PR TITLE
feat(process-metrics): add host-wide per-mode CPU steal metrics

### DIFF
--- a/crates/process-metrics/README.md
+++ b/crates/process-metrics/README.md
@@ -35,6 +35,7 @@ detected once at startup and logged at `info`.
 | `node_load1_milli` | gauge | -    | `/proc/loadavg` 1-min average ×1000 (so 1.25=1250)    |
 | `node_load5_milli` | gauge | -    | `/proc/loadavg` 5-min average ×1000                   |
 | `node_load15_milli`| gauge | -    | `/proc/loadavg` 15-min average ×1000                  |
+| `node_cpu_mode_seconds_total` | counter | seconds | `/proc/stat` aggregate `cpu` line, ticks / `CLK_TCK`, labeled `mode` (`user`, `nice`, `system`, `idle`, `iowait`, `irq`, `softirq`, `steal`, `guest`, `guest_nice`); `guest`/`guest_nice` ticks are already included in `user`/`nice` |
 
 `node_load*_milli` reports the loadavg multiplied by 1000 because the HotShot `Gauge` trait stores `usize`. Divide by
 1000 when graphing.

--- a/crates/process-metrics/src/linux.rs
+++ b/crates/process-metrics/src/linux.rs
@@ -197,8 +197,8 @@ impl LinuxMetrics {
             process_cpu_seconds_total: metrics
                 .create_counter("process_cpu_seconds_total".into(), seconds()),
             cpu_mode_seconds_total: {
-                let family =
-                    metrics.counter_family("node_cpu_seconds_total".into(), vec!["mode".into()]);
+                let family = metrics
+                    .counter_family("node_cpu_mode_seconds_total".into(), vec!["mode".into()]);
                 CpuModeCounters {
                     user: family.create(vec!["user".into()]),
                     nice: family.create(vec!["nice".into()]),
@@ -312,48 +312,31 @@ impl LinuxMetrics {
 
     /// Host-wide CPU time by mode, aggregated across all CPUs. Unlike `process_cpu_seconds_total`,
     /// this exposes time (e.g. `steal`) the process itself never sees but that still explains why
-    /// the host is slow.
+    /// the host is slow. `guest`/`guest_nice` ticks are already included in `user`/`nice`
+    /// respectively (the kernel's `account_guest_time()` double-books them), so summing all modes
+    /// over-counts the denominator on hypervisors and understates utilization.
     fn sample_cpu_stat(&mut self, ticks_per_second: u64) {
         let Some(cpu) = read_or_debug("/proc/stat", KernelStats::current).map(|s| s.total) else {
             return;
         };
         let counters = &self.cpu_mode_seconds_total;
         let prev = &mut self.prev.cpu_modes;
-        counters
-            .user
-            .add(prev.user.observe(cpu.user, ticks_per_second));
-        counters
-            .nice
-            .add(prev.nice.observe(cpu.nice, ticks_per_second));
-        counters
-            .system
-            .add(prev.system.observe(cpu.system, ticks_per_second));
-        counters
-            .idle
-            .add(prev.idle.observe(cpu.idle, ticks_per_second));
-        if let Some(v) = cpu.iowait {
-            counters
-                .iowait
-                .add(prev.iowait.observe(v, ticks_per_second));
-        }
-        if let Some(v) = cpu.irq {
-            counters.irq.add(prev.irq.observe(v, ticks_per_second));
-        }
-        if let Some(v) = cpu.softirq {
-            counters
-                .softirq
-                .add(prev.softirq.observe(v, ticks_per_second));
-        }
-        if let Some(v) = cpu.steal {
-            counters.steal.add(prev.steal.observe(v, ticks_per_second));
-        }
-        if let Some(v) = cpu.guest {
-            counters.guest.add(prev.guest.observe(v, ticks_per_second));
-        }
-        if let Some(v) = cpu.guest_nice {
-            counters
-                .guest_nice
-                .add(prev.guest_nice.observe(v, ticks_per_second));
+        let modes: [(&dyn Counter, &mut SecondsAccumulator, Option<u64>); 10] = [
+            (&*counters.user, &mut prev.user, Some(cpu.user)),
+            (&*counters.nice, &mut prev.nice, Some(cpu.nice)),
+            (&*counters.system, &mut prev.system, Some(cpu.system)),
+            (&*counters.idle, &mut prev.idle, Some(cpu.idle)),
+            (&*counters.iowait, &mut prev.iowait, cpu.iowait),
+            (&*counters.irq, &mut prev.irq, cpu.irq),
+            (&*counters.softirq, &mut prev.softirq, cpu.softirq),
+            (&*counters.steal, &mut prev.steal, cpu.steal),
+            (&*counters.guest, &mut prev.guest, cpu.guest),
+            (&*counters.guest_nice, &mut prev.guest_nice, cpu.guest_nice),
+        ];
+        for (counter, acc, ticks) in modes {
+            if let Some(ticks) = ticks {
+                counter.add(acc.observe(ticks, ticks_per_second));
+            }
         }
     }
 

--- a/crates/process-metrics/src/linux.rs
+++ b/crates/process-metrics/src/linux.rs
@@ -2,7 +2,7 @@ use std::{fs, io::BufReader, path::Path};
 
 use hotshot_types::traits::metrics::{Counter, Gauge, Metrics};
 use procfs::{
-    Current, LoadAverage, PressureRecord, get_pressure,
+    Current, CurrentSI, KernelStats, LoadAverage, PressureRecord, get_pressure,
     process::{Io, Process},
 };
 
@@ -86,6 +86,35 @@ impl U64Delta {
     }
 }
 
+/// Per-mode host CPU time counters, matching the fields of `/proc/stat`'s aggregate `cpu` line.
+struct CpuModeCounters {
+    user: Box<dyn Counter>,
+    nice: Box<dyn Counter>,
+    system: Box<dyn Counter>,
+    idle: Box<dyn Counter>,
+    iowait: Box<dyn Counter>,
+    irq: Box<dyn Counter>,
+    softirq: Box<dyn Counter>,
+    steal: Box<dyn Counter>,
+    guest: Box<dyn Counter>,
+    guest_nice: Box<dyn Counter>,
+}
+
+/// Cross-tick accumulator state mirroring [`CpuModeCounters`].
+#[derive(Default)]
+struct CpuModeAccumulators {
+    user: SecondsAccumulator,
+    nice: SecondsAccumulator,
+    system: SecondsAccumulator,
+    idle: SecondsAccumulator,
+    iowait: SecondsAccumulator,
+    irq: SecondsAccumulator,
+    softirq: SecondsAccumulator,
+    steal: SecondsAccumulator,
+    guest: SecondsAccumulator,
+    guest_nice: SecondsAccumulator,
+}
+
 /// Immutable per-tick context detected once at startup.
 #[derive(Clone, Copy)]
 struct Env {
@@ -98,6 +127,7 @@ struct Env {
 #[derive(Default)]
 struct Previous {
     cpu_ticks: SecondsAccumulator,
+    cpu_modes: CpuModeAccumulators,
     pressure_cpu_some: SecondsAccumulator,
     pressure_memory_some: SecondsAccumulator,
     pressure_memory_full: SecondsAccumulator,
@@ -120,6 +150,7 @@ pub struct LinuxMetrics {
     load15_milli: Box<dyn Gauge>,
 
     process_cpu_seconds_total: Box<dyn Counter>,
+    cpu_mode_seconds_total: CpuModeCounters,
 
     pressure_cpu_some_total: Box<dyn Counter>,
     pressure_memory_some_total: Box<dyn Counter>,
@@ -165,6 +196,22 @@ impl LinuxMetrics {
 
             process_cpu_seconds_total: metrics
                 .create_counter("process_cpu_seconds_total".into(), seconds()),
+            cpu_mode_seconds_total: {
+                let family =
+                    metrics.counter_family("node_cpu_seconds_total".into(), vec!["mode".into()]);
+                CpuModeCounters {
+                    user: family.create(vec!["user".into()]),
+                    nice: family.create(vec!["nice".into()]),
+                    system: family.create(vec!["system".into()]),
+                    idle: family.create(vec!["idle".into()]),
+                    iowait: family.create(vec!["iowait".into()]),
+                    irq: family.create(vec!["irq".into()]),
+                    softirq: family.create(vec!["softirq".into()]),
+                    steal: family.create(vec!["steal".into()]),
+                    guest: family.create(vec!["guest".into()]),
+                    guest_nice: family.create(vec!["guest_nice".into()]),
+                }
+            },
 
             pressure_cpu_some_total: metrics
                 .create_counter("node_pressure_cpu_waiting_seconds_total".into(), seconds()),
@@ -253,11 +300,60 @@ impl LinuxMetrics {
             }
         }
 
+        self.sample_cpu_stat(env.ticks_per_second);
+
         self.sample_pressure(env.pressure);
 
         if env.cgroup_v2 {
             self.sample_cgroup_cpu();
             self.sample_cgroup_memory();
+        }
+    }
+
+    /// Host-wide CPU time by mode, aggregated across all CPUs. Unlike `process_cpu_seconds_total`,
+    /// this exposes time (e.g. `steal`) the process itself never sees but that still explains why
+    /// the host is slow.
+    fn sample_cpu_stat(&mut self, ticks_per_second: u64) {
+        let Some(cpu) = read_or_debug("/proc/stat", KernelStats::current).map(|s| s.total) else {
+            return;
+        };
+        let counters = &self.cpu_mode_seconds_total;
+        let prev = &mut self.prev.cpu_modes;
+        counters
+            .user
+            .add(prev.user.observe(cpu.user, ticks_per_second));
+        counters
+            .nice
+            .add(prev.nice.observe(cpu.nice, ticks_per_second));
+        counters
+            .system
+            .add(prev.system.observe(cpu.system, ticks_per_second));
+        counters
+            .idle
+            .add(prev.idle.observe(cpu.idle, ticks_per_second));
+        if let Some(v) = cpu.iowait {
+            counters
+                .iowait
+                .add(prev.iowait.observe(v, ticks_per_second));
+        }
+        if let Some(v) = cpu.irq {
+            counters.irq.add(prev.irq.observe(v, ticks_per_second));
+        }
+        if let Some(v) = cpu.softirq {
+            counters
+                .softirq
+                .add(prev.softirq.observe(v, ticks_per_second));
+        }
+        if let Some(v) = cpu.steal {
+            counters.steal.add(prev.steal.observe(v, ticks_per_second));
+        }
+        if let Some(v) = cpu.guest {
+            counters.guest.add(prev.guest.observe(v, ticks_per_second));
+        }
+        if let Some(v) = cpu.guest_nice {
+            counters
+                .guest_nice
+                .add(prev.guest_nice.observe(v, ticks_per_second));
         }
     }
 


### PR DESCRIPTION
- Read the aggregate `cpu` line of /proc/stat via procfs::KernelStats
- Emit node_cpu_seconds_total counter family, labeled by mode: user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice
- Convert USER_HZ ticks to seconds using the detected kernel tick rate, not a hardcoded 100
- Reuse the existing SecondsAccumulator pattern so repeated scrapes add deltas, matching process_cpu_seconds_total and the PSI counters
- Skip gracefully via read_or_debug if /proc/stat is unreadable

