### PR TITLE
ci(claude): raise max turns to 60 and bound wall clock

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,7 @@ jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,6 +22,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
@@ -36,4 +37,4 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model opus --max-turns 15"
+          claude_args: "--model opus --max-turns 60"


### PR DESCRIPTION
- both recorded claude.yml failures were error_max_turns at turn 16, losing the whole run's work with no comment posted
- raise --max-turns from 15 to 60
- add timeout-minutes: 30 to both Claude jobs; neither had one, so the effective bound was the Actions default of 360 minutes
