### PR TITLE
Refuse vote2 in a view a later vote1 skipped.

### DIFF
--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -229,6 +229,9 @@ pub struct Consensus<T: NodeType> {
     voted_1_views: BTreeSet<ViewNumber>,
     voted_2_views: BTreeSet<ViewNumber>,
 
+    /// For each view this node cast a vote1 in, the view its proposal was justified at.
+    vote1_parent: BTreeMap<ViewNumber, ViewNumber>,
+
     /// Storage confirmations; sends are gated on these facts.
     stored_proposals: BTreeMap<ViewNumber, Vec<Commitment<Leaf2<T>>>>,
     stored_vids: BTreeSet<ViewNumber>,
@@ -347,6 +350,7 @@ impl<T: NodeType> Consensus<T> {
             stake_table_coordinator: membership_coordinator,
             voted_1_views: BTreeSet::new(),
             voted_2_views: BTreeSet::new(),
+            vote1_parent: BTreeMap::new(),
             stored_proposals: BTreeMap::new(),
             stored_vids: BTreeSet::new(),
             stored_actions: BTreeSet::new(),
@@ -490,6 +494,7 @@ impl<T: NodeType> Consensus<T> {
         for leaf in seed.undecided {
             let view = leaf.view_number();
             let justify_qc = leaf.justify_qc().clone();
+            let parent_view = justify_qc.view_number();
             self.register_legacy_qc(&justify_qc);
 
             let block_number = leaf.block_header().block_number();
@@ -521,6 +526,7 @@ impl<T: NodeType> Consensus<T> {
             self.proposed_views.insert(view);
             self.voted_1_views.insert(view);
             self.voted_2_views.insert(view);
+            self.vote1_parent.insert(view, parent_view);
         }
 
         if let Some(high_qc) = &seed.high_qc {
@@ -887,6 +893,19 @@ impl<T: NodeType> Consensus<T> {
         if anchor_view > self.decide_floor_view {
             self.decide_floor_view = anchor_view;
         }
+        // Which views this node submitted its vote1 in is not persisted, only how far
+        // it acted. A vote1 needs its proposal stored, so treat every seeded proposal
+        // at or below the bar as one, this node may have voted for. Without that, a
+        // vote2 re-cast after the restart could land in a view whose branch this node
+        // had already left behind.
+        let may_have_voted: Vec<_> = self
+            .proposals
+            .range(..=last_barred)
+            .map(|(view, proposal)| (*view, proposal.justify_qc.view_number()))
+            .collect();
+        for (view, justify) in may_have_voted {
+            self.vote1_parent.entry(view).or_insert(justify);
+        }
         // `Coordinator::start` enters `current_view + 1`, so parking the cursor
         // at the high QC makes the node re-enter at `high_qc + 1`.
         let resume_view = self.stored_high_qc.unwrap_or(anchor_view + 1);
@@ -942,6 +961,7 @@ impl<T: NodeType> Consensus<T> {
                 self.certs2 = self.certs2.split_off(&keep_from);
                 self.decided_views = self.decided_views.split_off(&keep_from);
                 self.proposals = self.proposals.split_off(&keep_from);
+                self.vote1_parent = self.vote1_parent.split_off(&keep_from);
                 self.leaves = self.leaves.split_off(&view);
                 self.signed_proposals = self.signed_proposals.split_off(&view);
                 self.vid_shares = self.vid_shares.split_off(&view);
@@ -1946,6 +1966,10 @@ impl<T: NodeType> Consensus<T> {
             return;
         }
         let (vote2, _) = self.pending_vote2.remove(&view).expect("checked above");
+        if self.voted_for_branch_excluding(view) {
+            warn!(%view, "dropping pending vote2 for a view a later vote1 skips");
+            return;
+        }
         outbox.push_back(ConsensusOutput::SendVote2(vote2));
     }
 
@@ -1956,6 +1980,22 @@ impl<T: NodeType> Consensus<T> {
         view <= self.restart_barred_view
             || (self.stored_actions.contains(&(view, ActionKind::Vote))
                 && self.stored_vids.contains(&view))
+    }
+
+    /// Whether a vote1 in a later view endorsed a branch with no block at `view`.
+    ///
+    /// This is what keeps one node out of two conflicting quorums. A vote2 certifies
+    /// `view` for good, but the certificate and the reconstructed block it waits on
+    /// can arrive after the node has submitted vote1 elsewhere. Casting it anyway
+    /// would count the node towards a quorum committing `view` and towards one
+    /// certifying a branch without it.
+    ///
+    /// This covers the order vote1-then-vote2. The reverse is the `is_safe`
+    /// re-check in `maybe_vote_1`; neither alone is enough.
+    fn voted_for_branch_excluding(&self, view: ViewNumber) -> bool {
+        self.vote1_parent
+            .range(view + 1..)
+            .any(|(_, justified_at)| *justified_at < view)
     }
 
     fn release_proposal(&mut self, view: ViewNumber, outbox: &mut Outbox<ConsensusOutput<T>>) {
@@ -2015,6 +2055,20 @@ impl<T: NodeType> Consensus<T> {
         let epoch = proposal.epoch;
         let qc_view = proposal.justify_qc.view_number();
         let qc_epoch = proposal.justify_qc.epoch();
+
+        // The counterpart of `voted_for_branch_excluding`, for the other order.
+        // `handle_proposal_with_vid_share` checked this proposal against the lock
+        // as it stood on arrival, and state validation can complete after that.
+        // A vote2 in the meantime locks this node on a view the proposal's
+        // branch may skip, and voting here would then count it towards a quorum
+        // certifying that branch and towards the one committing the view.
+        if let Err(err) = self.is_safe(proposal) {
+            warn!(
+                %view, block = %block_number, %epoch, %qc_view, ?qc_epoch, %err,
+                "proposal no longer safe against the current lock; refusing to vote1"
+            );
+            return;
+        }
 
         // Don't vote for epoch-transition proposals until we can verify
         // the attached DRB result.  Same guard as `maybe_propose`:
@@ -2146,6 +2200,7 @@ impl<T: NodeType> Consensus<T> {
             && self.is_proposal_stored(view, &proposal_commit);
         let vid_share = can_send.then(|| vid_share.clone());
         self.voted_1_views.insert(view);
+        self.vote1_parent.insert(view, qc_view);
         if let Some(vid_share) = vid_share {
             outbox.push_back(ConsensusOutput::SendVote1(vote));
             outbox.push_back(ConsensusOutput::BroadcastVidShare(vid_share));
@@ -2231,6 +2286,11 @@ impl<T: NodeType> Consensus<T> {
             || self.decided_views.contains(&view)
             || view <= self.decide_floor()
         {
+            return;
+        }
+
+        if self.voted_for_branch_excluding(view) {
+            warn!(%view, %qc_view, %block, "a later vote1 skips this view; refusing to vote2");
             return;
         }
 

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -898,13 +898,10 @@ impl<T: NodeType> Consensus<T> {
         // at or below the bar as one, this node may have voted for. Without that, a
         // vote2 re-cast after the restart could land in a view whose branch this node
         // had already left behind.
-        let may_have_voted: Vec<_> = self
-            .proposals
-            .range(..=last_barred)
-            .map(|(view, proposal)| (*view, proposal.justify_qc.view_number()))
-            .collect();
-        for (view, justify) in may_have_voted {
-            self.vote1_parent.entry(view).or_insert(justify);
+        for (&view, proposal) in self.proposals.range(..=last_barred) {
+            self.vote1_parent
+                .entry(view)
+                .or_insert(proposal.justify_qc.view_number());
         }
         // `Coordinator::start` enters `current_view + 1`, so parking the cursor
         // at the high QC makes the node re-enter at `high_qc + 1`.

--- a/crates/hotshot/new-protocol/src/tests.rs
+++ b/crates/hotshot/new-protocol/src/tests.rs
@@ -9,6 +9,7 @@ mod failures;
 mod integration;
 mod legacy_cutover;
 mod restarts;
+mod safety;
 mod stake_table_changes;
 mod state;
 mod storage;

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
 };
 
@@ -985,6 +985,8 @@ pub(crate) struct ConsensusHarness {
     pub consensus: Consensus<TestTypes>,
     pub membership_coordinator: EpochMembershipCoordinator<TestTypes>,
     pub collected: Outbox<ConsensusOutput<TestTypes>>,
+    deferred_states: BTreeMap<ViewNumber, ConsensusInput<TestTypes>>,
+    defer_state_for: BTreeSet<ViewNumber>,
 }
 
 impl ConsensusHarness {
@@ -1020,6 +1022,8 @@ impl ConsensusHarness {
             consensus,
             membership_coordinator: membership,
             collected: Outbox::new(),
+            deferred_states: BTreeMap::new(),
+            defer_state_for: BTreeSet::new(),
         }
     }
 
@@ -1069,7 +1073,29 @@ impl ConsensusHarness {
             consensus,
             membership_coordinator: membership,
             collected: Outbox::new(),
+            deferred_states: BTreeMap::new(),
+            defer_state_for: BTreeSet::new(),
         }
+    }
+
+    /// Withhold `view`'s state-validation response until [`Self::release_state`].
+    ///
+    /// The harness answers `RequestState` inline, which a real node cannot do:
+    /// validation runs asynchronously and may finish long after the proposal
+    /// was admitted. Tests that turn on that delay need to place it themselves.
+    /// Must be called before the proposal for `view` is applied.
+    pub fn defer_state(&mut self, view: ViewNumber) {
+        self.defer_state_for.insert(view);
+    }
+
+    /// Deliver the response withheld by [`Self::defer_state`].
+    pub async fn release_state(&mut self, view: ViewNumber) {
+        self.defer_state_for.remove(&view);
+        let input = self
+            .deferred_states
+            .remove(&view)
+            .expect("a state request for this view was deferred");
+        self.apply(input).await;
     }
 
     /// Apply a [`ConsensusInput`] and drain outputs, auto-responding to
@@ -1105,7 +1131,11 @@ impl ConsensusHarness {
         match output {
             ConsensusOutput::RequestState(req) => {
                 let input = state_verified_input(&req.proposal, req.view);
-                self.consensus.apply(input, outbox);
+                if self.defer_state_for.contains(&req.view) {
+                    self.deferred_states.insert(req.view, input);
+                } else {
+                    self.consensus.apply(input, outbox);
+                }
             },
             ConsensusOutput::RecordAction(view, _, kind) => {
                 self.consensus.apply(
@@ -1283,6 +1313,109 @@ pub(crate) fn build_cert2(
         private_key,
         &test_upgrade_lock::<TestTypes>(),
     )
+}
+
+/// A single node's signature over some vote data, tagged with who produced it.
+pub(crate) type SignerShare = (u64, <BLSPubKey as SignatureKey>::PureAssembledSignatureType);
+
+/// Aggregate `shares` into a certificate over `data`.
+///
+/// The counterpart of [`build_cert`], which marks *every* committee member as a
+/// signer. That is fine when a test needs only *a* valid certificate, and wrong
+/// when the claim depends on who signed. This records exactly the given signers
+/// in the certificate's bit vector, so the result verifies only if they truly
+/// meet the threshold — and it accepts signatures produced elsewhere, which is
+/// what lets a test aggregate the votes real nodes emitted.
+///
+/// A share's `u64` is the seed index its key was generated from, and doubles as
+/// the position in the stake table's bit vector — the correspondence
+/// [`build_assembled_sig`] relies on too. Order within `shares` does not matter;
+/// BLS aggregation is a sum.
+///
+/// Panics if `shares` is below the success threshold, since such a certificate
+/// would not verify and the caller almost certainly meant otherwise. That count
+/// is compared against a stake-weighted threshold, which only holds while every
+/// member has unit stake, as under [`mock_membership`].
+pub(crate) fn assemble_cert<DATA, CERT>(
+    data: DATA,
+    view_number: ViewNumber,
+    epoch_membership: &hotshot_types::epoch_membership::EpochMembership<TestTypes>,
+    shares: &[SignerShare],
+) -> CERT
+where
+    DATA: hotshot_types::simple_vote::Voteable<TestTypes> + 'static,
+    CERT: hotshot_types::vote::Certificate<TestTypes, DATA, Voteable = DATA>,
+{
+    use bitvec::bitvec;
+    use hotshot_types::{simple_vote::VersionedVoteData, stake_table::StakeTableEntries};
+
+    let upgrade_lock = test_upgrade_lock::<TestTypes>();
+    let stake_table = CERT::stake_table(epoch_membership);
+    let entries = StakeTableEntries::from_iter(stake_table.iter()).0;
+    let threshold = CERT::threshold(epoch_membership);
+    assert!(
+        alloy::primitives::U256::from(shares.len()) >= threshold,
+        "{} signers is below the threshold of {threshold}",
+        shares.len()
+    );
+    let qc_pp = <BLSPubKey as SignatureKey>::public_parameter(&entries, threshold);
+
+    let mut signer_bits = bitvec![0; stake_table.len()];
+    let mut signatures = Vec::new();
+    for (node, signature) in shares {
+        signer_bits.set(*node as usize, true);
+        signatures.push(signature.clone());
+    }
+
+    let assembled =
+        <BLSPubKey as SignatureKey>::assemble(&qc_pp, signer_bits.as_bitslice(), &signatures[..]);
+    let vote_commitment = VersionedVoteData::new(data.clone(), view_number, &upgrade_lock)
+        .expect("versioned vote data")
+        .commit();
+    CERT::create_signed_certificate(vote_commitment, data, assembled, view_number)
+}
+
+/// Sign `data` as `node` would, and return the signature tagged with `node`.
+///
+/// For votes a test must fabricate — an adversary's, or a node it does not run.
+pub(crate) fn sign_vote_as<DATA>(node: u64, data: DATA, view_number: ViewNumber) -> SignerShare
+where
+    DATA: hotshot_types::simple_vote::Voteable<TestTypes> + 'static,
+{
+    use hotshot_types::{simple_vote::SimpleVote, vote::Vote};
+
+    let (public_key, private_key) = BLSPubKey::generated_from_seed_indexed([0u8; 32], node);
+    let vote = SimpleVote::<TestTypes, DATA>::create_signed_vote(
+        data,
+        view_number,
+        &public_key,
+        &private_key,
+        &test_upgrade_lock::<TestTypes>(),
+    )
+    .expect("sign vote");
+    (node, vote.signature())
+}
+
+/// Build a timeout certificate signed by exactly `signers`.
+///
+/// The signer set carries meaning: a node that sent a timeout vote for
+/// `view_number` has raised its `timeout_view` to it, which constrains what it
+/// may do afterwards.
+pub(crate) fn build_timeout_cert_signed_by(
+    view_number: ViewNumber,
+    epoch: EpochNumber,
+    epoch_membership: &hotshot_types::epoch_membership::EpochMembership<TestTypes>,
+    signers: &[u64],
+) -> TimeoutCertificate2<TestTypes> {
+    let data = TimeoutData2 {
+        view: view_number,
+        epoch: Some(epoch),
+    };
+    let shares: Vec<SignerShare> = signers
+        .iter()
+        .map(|node| sign_vote_as(*node, data.clone(), view_number))
+        .collect();
+    assemble_cert(data, view_number, epoch_membership, &shares)
 }
 
 pub(crate) fn build_timeout_cert(

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -8,10 +8,12 @@ use hotshot_example_types::{
 };
 use hotshot_types::{
     data::{EpochNumber, Leaf2, ViewNumber},
+    message::Proposal as SignedProposal,
+    simple_certificate::TimeoutCertificate2,
     traits::signature_key::SignatureKey,
 };
 
-use super::common::utils::TestData;
+use super::common::utils::{TestData, TestView};
 use crate::{
     consensus::{ConsensusInput, ConsensusOutput},
     coordinator::GcScope,
@@ -1667,5 +1669,264 @@ async fn test_seed_proposals_populates_undecided_chain() {
             .map(|v| v.view_number)
             .collect::<Vec<_>>(),
         "every seeded proposal should surface as an undecided leaf"
+    );
+}
+
+/// `template`'s proposal re-parented onto `parent` and re-signed by `template`'s
+/// leader, with `evidence` as the view-change certificate for the gap.
+///
+/// The payload is `template`'s, so the VID shares dispersed for that view still
+/// match it and only the ancestry differs. That is what makes a competing branch
+/// out of material the honest nodes already hold.
+fn reparented_proposal(
+    template: &TestView,
+    parent: &TestView,
+    evidence: TimeoutCertificate2<TestTypes>,
+) -> SignedProposal<TestTypes, Proposal<TestTypes>> {
+    let parent_leaf: Leaf2<TestTypes> = parent.proposal.data.clone().into();
+    let mut proposal = template.proposal.data.clone();
+    proposal.block_header = TestBlockHeader::new(
+        &parent_leaf,
+        template.proposal.data.block_header.payload_commitment,
+        template
+            .proposal
+            .data
+            .block_header
+            .builder_commitment
+            .clone(),
+        template.proposal.data.block_header.metadata,
+        TEST_VERSIONS.test.base,
+    );
+    proposal.justify_qc = parent.cert1.clone();
+    proposal.view_change_evidence = Some(evidence);
+
+    let signature = <BLSPubKey as SignatureKey>::sign(
+        &template.leader_private_key,
+        proposal_commitment(&proposal).as_ref(),
+    )
+    .expect("sign re-parented proposal");
+    SignedProposal::new(proposal, signature)
+}
+
+/// One node does not vote for both sides of a fork.
+///
+/// A single-node version of `tests::safety`, which builds the same conflict out
+/// of a whole committee. The two commits of a fork need two quorums, and two
+/// quorums drawn from `3f + 1` nodes meet in an honest node, so a fork needs one
+/// node to vote on both sides. This drives exactly that node.
+///
+/// The setup is what makes the second vote reachable at all. The lock is the
+/// only thing that rejects a proposal reaching back past view 3, and it advances
+/// only on a phase-2 vote, which needs the block. So a node holding view 3's
+/// *certificate* but not its *block* is past view 3 and still unlocked: it
+/// accepts a proposal parented at view 1 and votes phase-1 for it. When view 3's
+/// block finally lands, everything a phase-2 vote there requires is present.
+///
+/// `Consensus::voted_for_branch_excluding` is what refuses it — the phase-1 vote
+/// at view 6 was justified at view 1, so the branch it endorsed holds no block
+/// for view 3.
+#[tokio::test]
+async fn test_no_fork_votes_from_one_node() {
+    let mut harness = ConsensusHarness::new(0).await;
+    let test_data = TestData::new(6).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+
+    // View 1 arrives in full, so the node locks there. The fork's proposal is
+    // parented here, which is what lets it pass the admission check.
+    harness
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
+        .await;
+    harness
+        .apply(test_data.views[0].block_reconstructed_input())
+        .await;
+    harness.apply(test_data.views[0].cert1_input()).await;
+    assert_eq!(
+        harness.consensus.locked_view(),
+        Some(ViewNumber::new(1)),
+        "view 1 arrived in full, so it should be locked"
+    );
+
+    // The certificate for view 3 arrives but its block does not: the node
+    // leaves view 3 behind without locking on it.
+    harness
+        .apply(ConsensusInput::AdvanceView(
+            crate::cert_verifier::ValidCert::new(
+                test_data.views[2].cert1.clone(),
+                test_data.views[2].epoch_number,
+            ),
+        ))
+        .await;
+    assert_eq!(
+        (
+            harness.consensus.current_view(),
+            harness.consensus.locked_view()
+        ),
+        (ViewNumber::new(4), Some(ViewNumber::new(1))),
+        "past view 3, still locked at view 1"
+    );
+
+    // The competing proposal: view 6, parented at view 1, so it skips view 3
+    // entirely. The timeout certificate for view 5 is what lets it reach back.
+    let signed = reparented_proposal(
+        &test_data.views[5],
+        &test_data.views[0],
+        test_data.views[4].timeout_cert.clone(),
+    );
+
+    harness
+        .apply(ConsensusInput::Proposal(
+            test_data.views[5].leader_public_key,
+            crate::message::ProposalMessage::validated(signed),
+        ))
+        .await;
+    harness
+        .apply(ConsensusInput::VidShare(
+            test_data.views[5].vid_share_for(&node_key),
+        ))
+        .await;
+
+    // The phase-1 vote is parked pending persistence, so the recorded action is
+    // the decision to vote; counting sends alone understates it. At view 6 that
+    // action can only be the phase-1 vote, since no `Certificate1` for view 6 is
+    // ever supplied.
+    let voted_fork = harness.outputs().iter().any(|o| {
+        matches!(o, ConsensusOutput::RecordAction(v, _, ActionKind::Vote)
+            if *v == ViewNumber::new(6))
+    });
+    assert!(
+        voted_fork,
+        "the forked proposal should have been admitted and voted on"
+    );
+
+    // The block for view 3 lands at last. Phase-2 votes are sent directly, so
+    // `SendVote2` at view 3 is unambiguous — unlike the recorded action, which
+    // view 3's phase-1 vote also produces.
+    harness
+        .apply_pair(test_data.views[2].proposal_input_consensus(&node_key))
+        .await;
+    harness
+        .apply(test_data.views[2].block_reconstructed_input())
+        .await;
+    harness.apply(test_data.views[2].cert1_input()).await;
+
+    let view3_commit = proposal_commitment(&test_data.views[2].proposal.data);
+    let voted_committed = harness.outputs().iter().any(|o| {
+        matches!(o, ConsensusOutput::SendVote2(v)
+            if v.data.leaf_commit == view3_commit)
+    });
+
+    assert!(
+        !voted_committed,
+        "one node voted for both sides of a fork: phase-1 at view 6 on a branch parented at view \
+         1, and phase-2 at view 3"
+    );
+}
+
+/// The same fork with the two votes in the opposite order.
+///
+/// [`test_no_fork_votes_from_one_node`] has the phase-1 vote on the competing
+/// branch come first, and `Consensus::voted_for_branch_excluding` refuses the
+/// phase-2 vote that would follow. Swapping the order gives the node the same
+/// pair of votes by a different route, and nothing about a fork says which
+/// arrives first.
+///
+/// What separates the two orders is when a proposal is measured against the
+/// lock. `handle_proposal_with_vid_share` checks it on arrival, once, and the
+/// phase-1 vote can be cast much later: it waits on state validation, which a
+/// real node runs asynchronously. A phase-2 vote in that window takes the lock,
+/// and the check that would have caught the competing proposal has already
+/// passed. `maybe_vote_1` re-checks for that reason.
+///
+/// The harness answers `RequestState` inline, so the window has to be opened
+/// deliberately with [`ConsensusHarness::defer_state`].
+#[tokio::test]
+async fn test_no_fork_votes_from_one_node_reversed() {
+    let mut harness = ConsensusHarness::new(0).await;
+    let test_data = TestData::new(6).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+
+    // View 1 in full, as before: the lock the competing proposal is parented on.
+    harness
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
+        .await;
+    harness
+        .apply(test_data.views[0].block_reconstructed_input())
+        .await;
+    harness.apply(test_data.views[0].cert1_input()).await;
+    assert_eq!(
+        harness.consensus.locked_view(),
+        Some(ViewNumber::new(1)),
+        "view 1 arrived in full, so it should be locked"
+    );
+
+    // The competing proposal arrives while the node is still locked at view 1,
+    // so it is admitted. Its state validation is withheld, which is the only
+    // thing keeping the phase-1 vote from being cast right here.
+    let signed = reparented_proposal(
+        &test_data.views[5],
+        &test_data.views[0],
+        test_data.views[4].timeout_cert.clone(),
+    );
+    let fork_commit = proposal_commitment(&signed.data);
+
+    harness.defer_state(ViewNumber::new(6));
+    harness
+        .apply(ConsensusInput::Proposal(
+            test_data.views[5].leader_public_key,
+            crate::message::ProposalMessage::validated(signed),
+        ))
+        .await;
+    harness
+        .apply(ConsensusInput::VidShare(
+            test_data.views[5].vid_share_for(&node_key),
+        ))
+        .await;
+    let acted_at_6 = |harness: &ConsensusHarness| {
+        harness.outputs().iter().any(|o| {
+            matches!(o, ConsensusOutput::RecordAction(v, _, ActionKind::Vote)
+                if *v == ViewNumber::new(6))
+        })
+    };
+    assert!(
+        !acted_at_6(&harness),
+        "the phase-1 vote should still be waiting on state validation"
+    );
+
+    // View 3 arrives in full and the node commits to it, taking the lock.
+    harness
+        .apply_pair(test_data.views[2].proposal_input_consensus(&node_key))
+        .await;
+    harness
+        .apply(test_data.views[2].block_reconstructed_input())
+        .await;
+    harness.apply(test_data.views[2].cert1_input()).await;
+
+    let view3_commit = proposal_commitment(&test_data.views[2].proposal.data);
+    let voted_committed = harness.outputs().iter().any(|o| {
+        matches!(o, ConsensusOutput::SendVote2(v)
+            if v.data.leaf_commit == view3_commit)
+    });
+    assert!(
+        voted_committed,
+        "view 3 arrived in full, so the node should have voted phase-2 there"
+    );
+    assert_eq!(
+        harness.consensus.locked_view(),
+        Some(ViewNumber::new(3)),
+        "the phase-2 vote should have taken the lock at view 3"
+    );
+
+    // Only now does view 6's state validation come back. The proposal skips
+    // view 3, which the node has since committed to.
+    harness.release_state(ViewNumber::new(6)).await;
+
+    let sent_fork_vote1 = harness.outputs().iter().any(|o| {
+        matches!(o, ConsensusOutput::SendVote1(v)
+            if v.vote.data.leaf_commit == fork_commit)
+    });
+    assert!(
+        !(acted_at_6(&harness) || sent_fork_vote1),
+        "one node voted for both sides of a fork: phase-2 at view 3, and phase-1 at view 6 on a \
+         branch parented at view 1"
     );
 }

--- a/crates/hotshot/new-protocol/src/tests/safety.rs
+++ b/crates/hotshot/new-protocol/src/tests/safety.rs
@@ -1,0 +1,479 @@
+//! Safety of the two-phase vote across nodes.
+//!
+//! A fork needs two quorums: one certifying a block at view `v`, another
+//! certifying a block at a later view whose ancestry skips `v`. The second
+//! quorum can only form from nodes that are not locked at `v`, and a node locks
+//! at `v` exactly when it casts a phase-2 vote there. So the two quorums compete
+//! for the same nodes, and whether they can both form comes down to whether a
+//! node can serve both: voting phase-1 in a later view while unlocked, then
+//! phase-2 in the earlier one once its block arrives. Nothing about when a
+//! certificate and a block turn up orders them against the node's other votes,
+//! so `Consensus::voted_for_branch_excluding` is what refuses the second vote.
+//! This test builds the whole fork and stops at that refusal.
+//!
+//! The nodes here are separate `Consensus` instances fed by hand, which is what
+//! a network does for them. Delivery order is the variable under test, so it is
+//! controlled rather than left to a real network.
+
+use hotshot::types::BLSPubKey;
+use hotshot_example_types::{
+    block_types::TestBlockHeader,
+    node_types::{TEST_VERSIONS, TestTypes},
+};
+use hotshot_types::{
+    data::{EpochNumber, ViewNumber},
+    stake_table::StakeTableEntries,
+    traits::{block_contents::BlockHeader, signature_key::SignatureKey},
+    vote::{Certificate, HasViewNumber, Vote},
+};
+
+use crate::{
+    cert_verifier::ValidCert,
+    consensus::{ConsensusInput, ConsensusOutput},
+    helpers::{proposal_commitment, test_upgrade_lock},
+    message::{Certificate1, Certificate2},
+    tests::common::utils::{
+        ConsensusHarness, SignerShare, TestData, assemble_cert, build_timeout_cert_signed_by,
+        mock_membership, sign_vote_as,
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Two conflicting quorums, assembled from real node behaviour
+// ---------------------------------------------------------------------------
+
+/// The certificate threshold for the 10-node test committee: `(10 * 2) / 3 + 1`.
+const THRESHOLD: usize = 7;
+
+/// Nodes whose signatures the adversary supplies. Node 6 leads view 6, so the
+/// competing proposal is signed by a node the adversary controls.
+const BYZANTINE: [u64; 3] = [6, 7, 8];
+
+/// Honest nodes that never receive view 2's block, so they never lock there.
+///
+/// Node 2 is excluded: it leads view 2 and therefore holds that block whatever
+/// the network does.
+const NEVER_LOCKED: [u64; 3] = [0, 1, 3];
+
+/// Honest nodes that receive view 2 in full and lock on it.
+const LOCKED: [u64; 3] = [2, 4, 5];
+
+/// The honest node that is unlocked when the competing proposal arrives and
+/// receives view 2's block only afterwards.
+const LATE: u64 = 9;
+
+/// Who sent a timeout vote for view 5, and so backs the competing proposal's
+/// view-change evidence.
+///
+/// The honest signers are nodes that left view 2 — 0, 1 and 3 on a timeout
+/// certificate for it, node 2 by locking there — and then timed out through
+/// views 3, 4 and 5. [`LATE`] is not among them because it never left view 2,
+/// which the execution notes on the test below explain.
+///
+/// That exclusion is forced by the execution rather than chosen, and it is also
+/// what keeps the scenario sharp: a timeout vote endorses no branch, so barring
+/// the phase-2 vote on `timeout_view` would stop the nodes that timed out at
+/// view 5 and let [`LATE`], which never timed out at all, walk straight past.
+const TIMED_OUT_AT_5: [u64; 7] = [0, 1, 2, 3, 6, 7, 8];
+
+/// One quorum, not two.
+///
+/// Seven honest nodes are run as separate consensus instances and fed by hand,
+/// which is what a network does for them. Three roles:
+///
+/// - `LOCKED` receive view 2 complete. They vote phase-2 there and lock, so they
+///   refuse the competing proposal.
+/// - `NEVER_LOCKED` receive view 2's proposal and its phase-1 certificate but
+///   never its block. Reconstruction is what a phase-2 vote requires, so they
+///   never lock, and they accept the competing proposal.
+/// - `LATE` is the interesting one. It is in the same state as `NEVER_LOCKED`
+///   when the competing proposal arrives, so it votes phase-1 there — and then
+///   view 2's block lands, which is everything it needs to vote phase-2 at view
+///   2 as well and stand on both sides.
+///
+/// That second vote is refused. `LATE`'s phase-1 vote at view 6 is justified at
+/// view 1, so the branch it endorsed holds no block for view 2, and a commit
+/// vote there afterwards is the double count itself.
+///
+/// The scenario is built out to where that matters. Both sides are driven as far
+/// as the nodes will take them: the competing branch collects its phase-1
+/// certificate and then its commit certificate, since the nodes that voted
+/// phase-1 at view 6 go on to vote phase-2 there. View 2 gets three phase-2
+/// votes and stops one short of a commit, `LATE` no longer being counted twice.
+/// Two quorums drawn from ten nodes meet in four: the three adversary nodes and
+/// one honest one. Everything rests on that one node, and it now stands on a
+/// single side.
+///
+/// So the competing branch wins and view 2's block is orphaned, which is what
+/// safety asks for — orphaned rather than committed and then contradicted.
+///
+/// Nothing here is counted where it could be verified. The only fabricated
+/// signatures are the adversary's, which is what an adversary can do anyway.
+///
+/// # What distinguishes `LATE`
+///
+/// Neither of the two properties that look like they would catch it. `LATE` has
+/// not left view 2 when the second vote comes due, so a guard phrased as "vote
+/// phase-2 only in the vote's own view" would admit it; and its timer never
+/// fires, so `timeout_view` is still 0 and a bar of `view > timeout_view` would
+/// admit it too. The test asserts both states where it reaches them, so
+/// narrowing the scenario to one those guards would catch fails here rather than
+/// passing quietly.
+///
+/// What is left is that it voted phase-1 in a *later* view while unlocked and
+/// would then have voted phase-2 in an earlier one — one node in both quorums.
+/// That is what `Consensus::voted_for_branch_excluding` refuses.
+///
+/// # What the execution requires
+///
+/// **View 1's certificate is withheld from `LATE` until late.** Its view-2 timer
+/// starts when it enters view 2, which is when it locks view 1. Hold that back
+/// until the rest of the network has produced the timeout certificate for view 5,
+/// then deliver in one burst inside a single view duration: view 1 complete, view
+/// 2's proposal and phase-1 certificate without the block, the competing
+/// proposal, and last view 2's block. `LATE` need not have taken part in views 1
+/// to 5 at all — view 2's phase-1 certificate forms from the six other honest
+/// nodes and the adversary without its vote.
+///
+/// **`LATE` never receives a timeout certificate for view 2.** That retires the
+/// view for VID reconstruction, so view 2's block would never arrive and the
+/// second vote could not happen.
+///
+/// Both are permitted under asynchrony, and both are constraints on any execution
+/// matching this scenario.
+///
+#[tokio::test]
+async fn conflicting_quorums_cannot_both_reach_threshold() {
+    let test_data = TestData::new(6).await;
+    let committed = &test_data.views[1]; // view 2, parented at view 1
+    let leader6 = test_data.views[5].leader_public_key;
+
+    // The evidence for the gap, naming exactly who timed out at view 5 — see
+    // `TIMED_OUT_AT_5` for why the late node must not be among them.
+    assert!(
+        !TIMED_OUT_AT_5.contains(&LATE),
+        "the late node never reached view 5, so it cannot be a signer here"
+    );
+    let timeout_cert_5 = {
+        let membership = mock_membership();
+        let epoch_membership = membership
+            .membership_for_epoch(Some(EpochNumber::genesis()))
+            .expect("genesis membership");
+        build_timeout_cert_signed_by(
+            ViewNumber::new(5),
+            EpochNumber::genesis(),
+            &epoch_membership,
+            &TIMED_OUT_AT_5,
+        )
+    };
+
+    // The competing proposal must come from a node the adversary controls.
+    assert!(
+        BYZANTINE
+            .iter()
+            .any(|i| BLSPubKey::generated_from_seed_indexed([0; 32], *i).0 == leader6),
+        "view 6's leader must be one of the adversary's nodes"
+    );
+
+    // View 6, parented at view 1, so it skips view 2 entirely. It reuses view
+    // 6's payload so the honest nodes' VID shares still match, and carries a
+    // timeout certificate for view 5 as the evidence for the gap.
+    let forked = {
+        let template = &test_data.views[5];
+        let parent_leaf = test_data.views[0].proposal.data.clone().into();
+        let mut proposal = template.proposal.data.clone();
+        proposal.block_header = TestBlockHeader::new(
+            &parent_leaf,
+            template.proposal.data.block_header.payload_commitment,
+            template
+                .proposal
+                .data
+                .block_header
+                .builder_commitment
+                .clone(),
+            template.proposal.data.block_header.metadata,
+            TEST_VERSIONS.test.base,
+        );
+        proposal.justify_qc = test_data.views[0].cert1.clone();
+        proposal.view_change_evidence = Some(timeout_cert_5.clone());
+        proposal
+    };
+    let forked_signed = {
+        let signature = <BLSPubKey as SignatureKey>::sign(
+            &test_data.views[5].leader_private_key,
+            proposal_commitment(&forked).as_ref(),
+        )
+        .expect("sign the competing proposal");
+        hotshot_types::message::Proposal::new(forked, signature)
+    };
+
+    let committed_commit = proposal_commitment(&committed.proposal.data);
+    let forked_commit = proposal_commitment(&forked_signed.data);
+    let fork_cert_parent_view = forked_signed.data.justify_qc.view_number();
+    let mut voted_phase2_at_committed = Vec::new();
+    let mut voted_phase1_at_fork = Vec::new();
+    let mut committed_shares: Vec<SignerShare> = Vec::new();
+    let mut fork_shares: Vec<SignerShare> = Vec::new();
+    let mut committed_data = None;
+    let mut fork_data = None;
+    let mut harnesses = Vec::new();
+
+    for node in NEVER_LOCKED.iter().chain(&LOCKED).chain([LATE].iter()) {
+        let node = *node;
+        let key = BLSPubKey::generated_from_seed_indexed([0; 32], node).0;
+        let mut harness = ConsensusHarness::new(node).await;
+
+        // View 1 in full: every honest node holds and locks it. The competing
+        // proposal is parented here, which is why they can admit it at all.
+        harness
+            .apply_pair(test_data.views[0].proposal_input_consensus(&key))
+            .await;
+        harness
+            .apply(test_data.views[0].block_reconstructed_input())
+            .await;
+        harness.apply(test_data.views[0].cert1_input()).await;
+
+        // View 2: everyone gets the proposal and the phase-1 certificate. Only
+        // `LOCKED` gets the block, so only `LOCKED` votes phase-2 and locks.
+        harness
+            .apply_pair(committed.proposal_input_consensus(&key))
+            .await;
+        if LOCKED.contains(&node) {
+            harness.apply(committed.block_reconstructed_input()).await;
+        }
+        harness.apply(committed.cert1_input()).await;
+
+        // A node without view 2's block is still in view 2: the phase-2 vote is
+        // what advances the view, and a phase-1 certificate does not.
+        if !LOCKED.contains(&node) {
+            assert_eq!(
+                harness.consensus.current_view(),
+                ViewNumber::new(2),
+                "a node without view 2's block has not left view 2"
+            );
+        }
+
+        // The `NEVER_LOCKED` nodes sit in view 2 while the rest of the network
+        // times out through views 2 to 5, so their timers fire. It changes
+        // nothing — their phase-1 vote at view 6 needs only `6 > timeout_view` —
+        // but it is what a real execution looks like.
+        //
+        // `LATE` is deliberately not given one. See the note on its timer in the
+        // test's documentation: it enters view 2 only moments before the rest of
+        // the burst, so its timer never fires and its `timeout_view` stays 0.
+        if NEVER_LOCKED.contains(&node) {
+            harness
+                .apply(ConsensusInput::Timeout(
+                    ViewNumber::new(2),
+                    EpochNumber::genesis(),
+                ))
+                .await;
+        }
+
+        // The competing proposal reaches everyone.
+        harness
+            .apply(ConsensusInput::Proposal(
+                leader6,
+                crate::message::ProposalMessage::validated(forked_signed.clone()),
+            ))
+            .await;
+        harness
+            .apply(ConsensusInput::VidShare(
+                test_data.views[5].vid_share_for(&key),
+            ))
+            .await;
+
+        // View 2's block finally reaches the late node, after it has already
+        // voted on the competing branch.
+        if node == LATE {
+            // Still in view 2. Casting a phase-1 vote does not advance the view,
+            // and a received proposal's `view_change_evidence` is never applied
+            // as an input — it is read only when building a proposal. So a guard
+            // phrased as "vote phase-2 only while `current_view` is the vote's
+            // view" would not stop what follows.
+            assert_eq!(
+                harness.consensus.current_view(),
+                ViewNumber::new(2),
+                "the late node is still in view 2 after voting phase-1 at view 6"
+            );
+            harness.apply(committed.block_reconstructed_input()).await;
+        }
+
+        // Take the signatures the node actually produced. The phase-1 vote is
+        // parked until its action is persisted, which the harness does, so it
+        // reaches the outbox like any other.
+        for output in harness.outputs().iter() {
+            match output {
+                ConsensusOutput::SendVote1(v) if v.vote.data.leaf_commit == forked_commit => {
+                    voted_phase1_at_fork.push(node);
+                    fork_shares.push((node, v.vote.signature()));
+                    fork_data.get_or_insert(v.vote.data);
+                },
+                ConsensusOutput::SendVote2(v) if v.data.leaf_commit == committed_commit => {
+                    voted_phase2_at_committed.push(node);
+                    committed_shares.push((node, v.signature()));
+                    committed_data.get_or_insert_with(|| v.data.clone());
+                },
+                _ => {},
+            }
+        }
+        harnesses.push((node, harness));
+    }
+
+    // The late node reached both sides and was admitted to one.
+    assert_eq!(
+        voted_phase1_at_fork,
+        vec![0, 1, 3, 9],
+        "the unlocked nodes and the late node vote phase-1 on the competing branch"
+    );
+    assert_eq!(
+        voted_phase2_at_committed,
+        vec![2, 4, 5],
+        "only the locked nodes vote phase-2 at view 2: the late node has voted for a branch \
+         without it"
+    );
+
+    // The adversary adds its own signatures over the same data, which is all it
+    // has to do: the honest votes above are what it cannot forge.
+    let committed_data = committed_data.expect("a phase-2 vote was cast at view 2");
+    let fork_data = fork_data.expect("a phase-1 vote was cast at view 6");
+    for node in BYZANTINE {
+        committed_shares.push(sign_vote_as(
+            node,
+            committed_data.clone(),
+            committed.view_number,
+        ));
+        fork_shares.push(sign_vote_as(node, fork_data, ViewNumber::new(6)));
+    }
+    assert_eq!(
+        (committed_shares.len(), fork_shares.len()),
+        (THRESHOLD - 1, THRESHOLD),
+        "view 2 should fall exactly one signature short of a quorum, the competing branch not at \
+         all"
+    );
+
+    let membership = mock_membership();
+    let epoch_membership = membership
+        .membership_for_epoch(Some(EpochNumber::genesis()))
+        .expect("genesis membership");
+    let entries = StakeTableEntries::from_iter(epoch_membership.stake_table()).0;
+    let threshold = epoch_membership.success_threshold();
+
+    // The same check the proposal validator applies to a justify QC. Below the
+    // threshold there is nothing to check: `assemble_cert` will not build a
+    // certificate that could never verify.
+    let upgrade_lock = test_upgrade_lock::<TestTypes>();
+    let committed_valid = committed_shares.len() >= THRESHOLD
+        && assemble_cert::<_, Certificate2<TestTypes>>(
+            committed_data,
+            committed.view_number,
+            &epoch_membership,
+            &committed_shares,
+        )
+        .is_valid_cert(&entries, threshold, &upgrade_lock)
+        .is_ok();
+    let fork_cert: Certificate1<TestTypes> = assemble_cert(
+        fork_data,
+        ViewNumber::new(6),
+        &epoch_membership,
+        &fork_shares,
+    );
+    let fork_valid = fork_cert
+        .is_valid_cert(&entries, threshold, &upgrade_lock)
+        .is_ok();
+
+    // The branches conflict: view 6's parent is view 1, so view 2 is not an
+    // ancestor of it.
+    assert_eq!(
+        fork_cert_parent_view,
+        ViewNumber::new(1),
+        "the competing branch must skip the committed view"
+    );
+
+    // Drive the competing branch to a commit as well.
+    //
+    // `maybe_vote_2_and_update_lock` checks the vote mark, the certificate, the
+    // proposal and reconstruction — not whether the branch extends the lock. So
+    // the same nodes that voted phase-1 at view 6 vote phase-2 there once the
+    // certificate and the block arrive, even the one now locked at view 2. That
+    // commit is the one that stands, and it is only harmless because view 2
+    // never reached one.
+    let mut double_commit_shares: Vec<SignerShare> = Vec::new();
+    let mut double_commit_data = None;
+    for (node, harness) in harnesses.iter_mut() {
+        if !voted_phase1_at_fork.contains(node) {
+            continue;
+        }
+        let before = harness.outputs().len();
+        harness
+            .apply(ConsensusInput::Certificate1(ValidCert::new(
+                fork_cert.clone(),
+                EpochNumber::genesis(),
+            )))
+            .await;
+        harness
+            .apply(ConsensusInput::BlockReconstructed(
+                ViewNumber::new(6),
+                test_data.views[5].vid_commitment(),
+            ))
+            .await;
+        for output in harness.outputs().iter().skip(before) {
+            if let ConsensusOutput::SendVote2(v) = output
+                && v.data.leaf_commit == forked_commit
+            {
+                double_commit_shares.push((*node, v.signature()));
+                double_commit_data.get_or_insert_with(|| v.data.clone());
+            }
+        }
+    }
+    for node in BYZANTINE {
+        if let Some(data) = double_commit_data.clone() {
+            double_commit_shares.push(sign_vote_as(node, data, ViewNumber::new(6)));
+        }
+    }
+    let double_commit_valid = double_commit_data.is_some_and(|data| {
+        double_commit_shares.len() >= THRESHOLD
+            && assemble_cert::<_, Certificate2<TestTypes>>(
+                data,
+                ViewNumber::new(6),
+                &epoch_membership,
+                &double_commit_shares,
+            )
+            .is_valid_cert(&entries, threshold, &upgrade_lock)
+            .is_ok()
+    });
+
+    // The two blocks sit at the same height on branches that do not extend one
+    // another, so certifying both is what a fork would look like.
+    assert_eq!(
+        (
+            BlockHeader::<TestTypes>::block_number(&committed.proposal.data.block_header),
+            BlockHeader::<TestTypes>::block_number(&forked_signed.data.block_header)
+        ),
+        (2, 2),
+        "the two blocks should be at the same height"
+    );
+
+    // The competing branch got everything it could: a phase-1 certificate and
+    // then a commit. Asserting it keeps the two below from passing because the
+    // scenario quietly stopped short.
+    assert!(
+        fork_valid,
+        "the competing branch's phase-1 certificate should verify"
+    );
+    assert!(
+        double_commit_valid,
+        "the competing branch should reach a commit certificate"
+    );
+
+    assert!(
+        !(committed_valid && fork_valid),
+        "both certificates verify: a phase-2 certificate at view 2 and a phase-1 certificate at \
+         view 6 whose branch does not extend it"
+    );
+    assert!(
+        !(committed_valid && double_commit_valid),
+        "both branches commit: phase-2 certificates at view 2 and view 6 over different blocks at \
+         height 2"
+    );
+}

--- a/crates/hotshot/new-protocol/src/tests/safety.rs
+++ b/crates/hotshot/new-protocol/src/tests/safety.rs
@@ -22,6 +22,7 @@ use hotshot_example_types::{
 };
 use hotshot_types::{
     data::{EpochNumber, ViewNumber},
+    message::Proposal,
     stake_table::StakeTableEntries,
     traits::{block_contents::BlockHeader, signature_key::SignatureKey},
     vote::{Certificate, HasViewNumber, Vote},
@@ -204,7 +205,7 @@ async fn conflicting_quorums_cannot_both_reach_threshold() {
             proposal_commitment(&forked).as_ref(),
         )
         .expect("sign the competing proposal");
-        hotshot_types::message::Proposal::new(forked, signature)
+        Proposal::new(forked, signature)
     };
 
     let committed_commit = proposal_commitment(&committed.proposal.data);


### PR DESCRIPTION
A node could count towards both quorums of a fork. Nothing ordered its votes across the two phases: the certificate and reconstructed block a vote2 waits on can arrive after the node has cast vote1 on a branch that skips that view. Casting it anyway put the node in the quorum committing the view and in the quorum certifying a branch without it. Two quorums drawn from 3f+1 nodes meet in one honest node, so that node is the whole of the difference — the result was two commit certificates over different blocks at the same height, both verifying.

Record the branch each vote1 endorsed (the view voted in, and the view its proposal was justified at) and refuse a vote2 at `v` when some vote1 at `w > v` was justified at `u < v`, i.e. endorsed a branch holding no block for `v`. A conflicting branch must contain such a gap somewhere, and that proposal's cert1 needs f+1 honest voters, all barred from committing `v`; committing `v` needs f+1 honest voters of its own, and 2(f+1) exceeds 2f+1.

Timeouts are deliberately not covered: a timeout vote endorses no branch, and barring the vote2 on that basis would strand a view whose certificate and block arrive just after the timer fires.

The lock is still taken before the refusal, since it is monotone and only makes the node more restrictive; only the vote is withheld. The record is kept to the decide floor rather than the current view, because a vote2 can lag several views behind the bar that applies to it. On restart it is reseeded conservatively from stored proposals at or below the action bar, since which views the node cast vote1 in is not persisted.