### PR TITLE
feat(deployer): select the Safe per proposal phase by multisig name

### DIFF
--- a/contracts/deployments/proposals/README.md
+++ b/contracts/deployments/proposals/README.md
@@ -48,9 +48,16 @@ touched in a PR, using a public RPC for the target network.
    - Note: `--rpc-url` must follow the `verify-proposal` subcommand; the top-level `deploy --rpc-url` does not apply
      here. CI no longer passes an explicit RPC.
 3. Signers approve and merge the PR.
-4. One signer imports `schedule.json` into the Safe and submits.
+4. One signer imports `schedule.json` into the Safe named by `schedule.safe` and submits.
 5. Other signers reconfirm the step-2 `domain`/`message`/`safe_tx` hashes on their Ledger, then sign.
-6. After the timelock delay, repeat steps 4-5 with `execute.json` (nonce + 1).
+6. After the timelock delay, repeat steps 4-5 with `execute.json` in the Safe named by `execute.safe`, at the nonce
+   recorded there.
+
+Phase Safes: a timelock role may be held by several multisigs (mainnet's OpsTimelock has two proposers). `deploy` then
+requires `--schedule-safe`/`--execute-safe` (values: `espresso_labs`, `serviceco`), and records the chosen Safe per
+phase in `proposal.toml`. When both phases use the same Safe, the execute nonce is the schedule nonce + 1; otherwise
+each Safe's own nonce is used. `verify-proposal` asserts each Safe holds the required role both in deployment-info and
+on chain.
 
 Nonce drift: `proposal.toml` hashes use the Safe nonce at generation time; verify prints a WARN (not FAIL) if the
 on-chain nonce moved. Reconfirm the nonce in the Safe app before signing.

--- a/contracts/rust/deployer/src/builder.rs
+++ b/contracts/rust/deployer/src/builder.rs
@@ -17,6 +17,7 @@ use crate::{
     Contract, Contracts, OwnableContract, encode_function_call,
     output::output_safe_tx_builder,
     proposals::{
+        deployment_info::Multisig,
         multisig::{
             LightClientV2UpgradeParams, MultisigOwnerCheck, StakeTableV2UpgradeParams,
             StakeTableV3UpgradeParams, TransferOwnershipParams, encode_generic_calldata,
@@ -162,6 +163,14 @@ pub struct DeployerArgs<P: Provider + WalletProvider> {
     /// Root for `contracts/deployments/proposals/` tree.
     #[builder(default)]
     proposals_root: Option<PathBuf>,
+    /// Multisig submitting the timelock `schedule` phase (required when the timelock
+    /// has several proposers).
+    #[builder(default)]
+    schedule_safe: Option<Multisig>,
+    /// Multisig submitting the timelock `execute` phase (required when the timelock
+    /// has several executors).
+    #[builder(default)]
+    execute_safe: Option<Multisig>,
 }
 
 impl<P: Provider + WalletProvider> DeployerArgs<P> {
@@ -569,7 +578,8 @@ impl<P: Provider + WalletProvider> DeployerArgs<P> {
                             delay,
                             schedule_calldata: proposal.schedule.data.clone(),
                             execute_calldata: proposal.execute.data.clone(),
-                            safe_override: None,
+                            schedule_safe: self.schedule_safe,
+                            execute_safe: self.execute_safe,
                         },
                         provider,
                     )

--- a/contracts/rust/deployer/src/proposals/deployment_info.rs
+++ b/contracts/rust/deployer/src/proposals/deployment_info.rs
@@ -5,6 +5,8 @@
 
 use alloy::primitives::Address;
 use anyhow::{Result, anyhow};
+use clap::ValueEnum;
+use derive_more::Display;
 use serde::Deserialize;
 
 // ── Embedded TOML sources ─────────────────────────────────────────────────────
@@ -33,8 +35,8 @@ struct RawDeploymentInfo {
 #[derive(Debug, Deserialize)]
 struct RawTimelockSection {
     address: Address,
-    proposers: Option<Vec<RawMember>>,
-    executors: Option<Vec<RawMember>>,
+    proposers: Option<Vec<Member>>,
+    executors: Option<Vec<Member>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -42,21 +44,66 @@ struct RawContractSection {
     address: Address,
 }
 
-#[derive(Debug, Deserialize)]
-struct RawMember {
-    address: Address,
-    #[allow(dead_code)]
-    name: String,
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/// A multisig that can hold a timelock role. Variants are the `name` values used in
+/// the deployment-info TOMLs; an unknown name fails deserialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Display, ValueEnum)]
+pub enum Multisig {
+    #[serde(rename = "espresso_labs")]
+    #[value(name = "espresso_labs")]
+    #[display("espresso_labs")]
+    EspressoLabs,
+    #[serde(rename = "serviceco")]
+    #[value(name = "serviceco")]
+    #[display("serviceco")]
+    ServiceCo,
 }
 
-// ── Public types ──────────────────────────────────────────────────────────────
+/// A multisig holding a timelock role, as listed in deployment-info.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Member {
+    pub address: Address,
+    pub name: Multisig,
+}
+
+/// Address of `name`, if the role set contains it.
+pub fn member_address(members: &[Member], name: Multisig) -> Option<Address> {
+    members.iter().find(|m| m.name == name).map(|m| m.address)
+}
+
+/// The multisig at `address`, if the role set contains it.
+pub fn member_name(members: &[Member], address: Address) -> Option<Multisig> {
+    members
+        .iter()
+        .find(|m| m.address == address)
+        .map(|m| m.name)
+}
+
+/// Comma-separated member names, for error messages.
+pub fn member_names(members: &[Member]) -> String {
+    members
+        .iter()
+        .map(|m| m.name.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Comma-separated `name address` pairs, for error messages.
+pub fn member_addresses(members: &[Member]) -> String {
+    members
+        .iter()
+        .map(|m| format!("{} {}", m.name, m.address))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
 
 /// Resolved timelock wiring for a single timelock (ops or safe_exit).
 #[derive(Debug, Clone)]
 pub struct TimelockInfo {
     pub address: Address,
-    pub proposers: Vec<Address>,
-    pub executors: Vec<Address>,
+    pub proposers: Vec<Member>,
+    pub executors: Vec<Member>,
 }
 
 /// Full deployment-info for a network.
@@ -124,33 +171,13 @@ fn parse_deployment_info(src: &str, network: &str) -> Result<DeploymentInfo> {
     Ok(DeploymentInfo {
         ops_timelock: TimelockInfo {
             address: ops.address,
-            proposers: ops
-                .proposers
-                .unwrap_or_default()
-                .into_iter()
-                .map(|m| m.address)
-                .collect(),
-            executors: ops
-                .executors
-                .unwrap_or_default()
-                .into_iter()
-                .map(|m| m.address)
-                .collect(),
+            proposers: ops.proposers.unwrap_or_default(),
+            executors: ops.executors.unwrap_or_default(),
         },
         safe_exit_timelock: TimelockInfo {
             address: safe_exit.address,
-            proposers: safe_exit
-                .proposers
-                .unwrap_or_default()
-                .into_iter()
-                .map(|m| m.address)
-                .collect(),
-            executors: safe_exit
-                .executors
-                .unwrap_or_default()
-                .into_iter()
-                .map(|m| m.address)
-                .collect(),
+            proposers: safe_exit.proposers.unwrap_or_default(),
+            executors: safe_exit.executors.unwrap_or_default(),
         },
         esp_token,
         fee_contract,
@@ -202,13 +229,26 @@ mod tests {
     }
 
     #[test]
+    fn test_member_unknown_name_fails_parse() {
+        let src = r#"
+[ops_timelock]
+address = "0x67861f1ef4db9bcaddd8c5e86db92386dd4ec700"
+[[ops_timelock.proposers]]
+address = "0x34f5af5158171ffd2475d21db5fc3b311f221982"
+name = "who_dis"
+"#;
+        let err = parse_deployment_info(src, "mainnet").unwrap_err();
+        assert!(err.to_string().contains("failed to parse"), "{err}");
+    }
+
+    #[test]
     fn test_deployment_info_decaf_proposer_address() {
         let info = deployment_info("decaf").unwrap();
         let espresso_labs: Address = "0xb76834e371b666feee48e5d7d9a97ca08b5a0620"
             .parse()
             .unwrap();
-        assert_eq!(info.ops_timelock.proposers[0], espresso_labs);
-        assert_eq!(info.ops_timelock.executors[0], espresso_labs);
+        assert_eq!(info.ops_timelock.proposers[0].address, espresso_labs);
+        assert_eq!(info.ops_timelock.executors[0].address, espresso_labs);
     }
 
     #[test]
@@ -216,5 +256,36 @@ mod tests {
         let info = deployment_info("mainnet").unwrap();
         assert_eq!(info.ops_timelock.proposers.len(), 2);
         assert_eq!(info.ops_timelock.executors.len(), 1);
+    }
+
+    #[test]
+    fn test_member_address_by_name() {
+        let info = deployment_info("mainnet").unwrap();
+        let labs: Address = "0x34f5af5158171ffd2475d21db5fc3b311f221982"
+            .parse()
+            .unwrap();
+        let serviceco: Address = "0x5e37b8038615ef3d75cf28b5982c4cbf065401fb"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            member_address(&info.ops_timelock.proposers, Multisig::EspressoLabs),
+            Some(labs)
+        );
+        assert_eq!(
+            member_address(&info.ops_timelock.executors, Multisig::ServiceCo),
+            Some(serviceco)
+        );
+        assert_eq!(
+            member_address(&info.ops_timelock.executors, Multisig::EspressoLabs),
+            None
+        );
+        assert_eq!(
+            member_name(&info.ops_timelock.executors, serviceco),
+            Some(Multisig::ServiceCo)
+        );
+        assert_eq!(
+            member_names(&info.ops_timelock.proposers),
+            "espresso_labs, serviceco"
+        );
     }
 }

--- a/contracts/rust/deployer/src/proposals/verify.rs
+++ b/contracts/rust/deployer/src/proposals/verify.rs
@@ -1023,7 +1023,7 @@ pub async fn run_verify(
     // Safe validation: assert toml Safes match deployment-info.
     let safe_rows = safe_address_rows(&toml, &kind);
     rows.extend(safe_rows);
-    timelock_role_rows(provider, &toml, &mut rows).await;
+    timelock_role_rows(provider, &toml, &kind, &mut rows).await;
 
     // Recompute Safe hashes for both phases and assert against toml.
     let phase_hashes =
@@ -1303,12 +1303,34 @@ fn compute_and_validate_phase_hashes(
 ///
 /// `safe_address_rows` only proves the Safes match the embedded deployment-info, which is a
 /// snapshot; roles can be granted or revoked after it was written.
+///
+/// Queries the deployment-info timelock, never `toml.timelock`: the proposal is untrusted input,
+/// so roles read from an address it supplies would prove nothing.
 async fn timelock_role_rows(
     provider: &impl Provider,
     toml: &ProposalToml,
+    kind: &ContractKind,
     rows: &mut Vec<CheckRow>,
 ) {
-    let timelock = OpsTimelock::new(toml.timelock, provider);
+    let timelock_addr = match deployment_info(&toml.network) {
+        Err(e) => {
+            rows.push(fail(
+                "schedule.role",
+                format!("deployment-info unavailable: {e}"),
+            ));
+            rows.push(fail(
+                "execute.role",
+                format!("deployment-info unavailable: {e}"),
+            ));
+            return;
+        },
+        Ok(info) => match kind.timelock_kind {
+            TimelockKind::Ops => info.ops_timelock.address,
+            TimelockKind::SafeExit => info.safe_exit_timelock.address,
+        },
+    };
+
+    let timelock = OpsTimelock::new(timelock_addr, provider);
     let roles = [
         (
             "schedule.role",
@@ -1332,10 +1354,7 @@ async fn timelock_role_rows(
                 Ok(true) => pass(label, format!("{safe} holds {role_name} on chain")),
                 Ok(false) => fail(
                     label,
-                    format!(
-                        "{safe} does not hold {role_name} on timelock {}",
-                        toml.timelock
-                    ),
+                    format!("{safe} does not hold {role_name} on timelock {timelock_addr}"),
                 ),
             },
         };

--- a/contracts/rust/deployer/src/proposals/verify.rs
+++ b/contracts/rust/deployer/src/proposals/verify.rs
@@ -25,7 +25,7 @@ use serde::Deserialize;
 use url::Url;
 
 use crate::proposals::{
-    deployment_info::deployment_info,
+    deployment_info::{deployment_info, member_addresses, member_name},
     proposal_toml::ProposalToml,
     safe_hash::{SafeTxHashes, safe_tx_hashes},
     write::{ISafe, default_rpc_url},
@@ -1023,6 +1023,7 @@ pub async fn run_verify(
     // Safe validation: assert toml Safes match deployment-info.
     let safe_rows = safe_address_rows(&toml, &kind);
     rows.extend(safe_rows);
+    timelock_role_rows(provider, &toml, &mut rows).await;
 
     // Recompute Safe hashes for both phases and assert against toml.
     let phase_hashes =
@@ -1190,36 +1191,34 @@ fn safe_address_rows(toml: &ProposalToml, kind: &ContractKind) -> Vec<CheckRow> 
         TimelockKind::SafeExit => &info.safe_exit_timelock,
     };
 
-    let proposer_match = signers.proposers.contains(&toml.schedule.safe);
-    rows.push(if proposer_match {
-        pass(
+    rows.push(match member_name(&signers.proposers, toml.schedule.safe) {
+        Some(name) => pass(
             "toml:schedule.safe",
-            format!("{} is a known proposer", toml.schedule.safe),
-        )
-    } else {
-        fail(
+            format!("{} is proposer {name}", toml.schedule.safe),
+        ),
+        None => fail(
             "toml:schedule.safe",
             format!(
-                "{} not in proposers {:?}",
-                toml.schedule.safe, signers.proposers
+                "{} not in proposers {}",
+                toml.schedule.safe,
+                member_addresses(&signers.proposers)
             ),
-        )
+        ),
     });
 
-    let executor_match = signers.executors.contains(&toml.execute.safe);
-    rows.push(if executor_match {
-        pass(
+    rows.push(match member_name(&signers.executors, toml.execute.safe) {
+        Some(name) => pass(
             "toml:execute.safe",
-            format!("{} is a known executor", toml.execute.safe),
-        )
-    } else {
-        fail(
+            format!("{} is executor {name}", toml.execute.safe),
+        ),
+        None => fail(
             "toml:execute.safe",
             format!(
-                "{} not in executors {:?}",
-                toml.execute.safe, signers.executors
+                "{} not in executors {}",
+                toml.execute.safe,
+                member_addresses(&signers.executors)
             ),
-        )
+        ),
     });
 
     rows
@@ -1297,6 +1296,50 @@ fn compute_and_validate_phase_hashes(
             message: toml.execute.message,
             safe_tx: toml.execute.safe_tx,
         },
+    }
+}
+
+/// Assert on chain that each phase Safe holds the role it needs on the timelock.
+///
+/// `safe_address_rows` only proves the Safes match the embedded deployment-info, which is a
+/// snapshot; roles can be granted or revoked after it was written.
+async fn timelock_role_rows(
+    provider: &impl Provider,
+    toml: &ProposalToml,
+    rows: &mut Vec<CheckRow>,
+) {
+    let timelock = OpsTimelock::new(toml.timelock, provider);
+    let roles = [
+        (
+            "schedule.role",
+            "proposer",
+            timelock.PROPOSER_ROLE().call().await,
+            toml.schedule.safe,
+        ),
+        (
+            "execute.role",
+            "executor",
+            timelock.EXECUTOR_ROLE().call().await,
+            toml.execute.safe,
+        ),
+    ];
+
+    for (label, role_name, role_id, safe) in roles {
+        let row = match role_id {
+            Err(e) => fail(label, format!("{role_name} role query failed: {e}")),
+            Ok(role) => match timelock.hasRole(role, safe).call().await {
+                Err(e) => fail(label, format!("hasRole query failed: {e}")),
+                Ok(true) => pass(label, format!("{safe} holds {role_name} on chain")),
+                Ok(false) => fail(
+                    label,
+                    format!(
+                        "{safe} does not hold {role_name} on timelock {}",
+                        toml.timelock
+                    ),
+                ),
+            },
+        };
+        rows.push(row);
     }
 }
 

--- a/contracts/rust/deployer/src/proposals/write.rs
+++ b/contracts/rust/deployer/src/proposals/write.rs
@@ -12,7 +12,7 @@ use chrono::Local;
 use url::Url;
 
 use crate::proposals::{
-    deployment_info::deployment_info,
+    deployment_info::{Member, Multisig, deployment_info, member_address, member_names},
     proposal_toml::{PhaseToml, ProposalToml},
     safe_hash::safe_tx_hashes,
 };
@@ -109,8 +109,12 @@ pub struct WriteProposalParams {
     pub schedule_calldata: Bytes,
     /// Outer execute calldata (timelock.execute(...)) for hash computation.
     pub execute_calldata: Bytes,
-    /// Optional Safe address override (bypasses deployment-info resolution).
-    pub safe_override: Option<Address>,
+    /// Multisig submitting the `schedule` phase. Required when the timelock has more
+    /// than one proposer.
+    pub schedule_safe: Option<Multisig>,
+    /// Multisig submitting the `execute` phase. Required when the timelock has more
+    /// than one executor.
+    pub execute_safe: Option<Multisig>,
 }
 
 /// Query the Safe nonce on-chain.
@@ -123,6 +127,31 @@ async fn safe_nonce(provider: &impl Provider, safe: Address) -> Result<u64> {
     n.try_into().context("Safe nonce overflows u64")
 }
 
+/// Pick the Safe for one phase: the named multisig must hold the role, and without a
+/// name the role set must contain exactly one member.
+fn resolve_phase_safe(
+    name: Option<Multisig>,
+    role_holders: &[Member],
+    role: &str,
+    flag: &str,
+    network: &str,
+) -> Result<Address> {
+    match (name, role_holders) {
+        (Some(name), _) => member_address(role_holders, name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "{flag} {name} does not hold the {role} role on {network}; holders: {}",
+                member_names(role_holders),
+            )
+        }),
+        (None, []) => anyhow::bail!("no {role} in deployment-info for {network}"),
+        (None, [only]) => Ok(only.address),
+        (None, many) => anyhow::bail!(
+            "several {role}s for {network}: {}; pass {flag}",
+            member_names(many),
+        ),
+    }
+}
+
 /// Resolve schedule/execute Safe addresses and nonces, then compute all hashes.
 ///
 /// Fails loudly if the signer set is ambiguous or the nonce query fails; a
@@ -131,27 +160,35 @@ async fn resolve_toml_phases(
     provider: &impl Provider,
     params: &WriteProposalParams,
 ) -> Result<(PhaseToml, PhaseToml)> {
-    let (schedule_safe, execute_safe) = if let Some(safe) = params.safe_override {
-        (safe, safe)
-    } else {
-        let info = deployment_info(&params.network).with_context(|| {
-            format!(
-                "deployment-info unavailable for network {:?}",
-                params.network
-            )
-        })?;
-        let signers = &info.ops_timelock;
-        if signers.proposers.len() != 1 || signers.executors.len() != 1 {
-            anyhow::bail!(
-                "ambiguous signer set for network {:?}: {} proposer(s), {} executor(s); pass \
-                 --safe to override",
-                params.network,
-                signers.proposers.len(),
-                signers.executors.len(),
-            );
-        }
-        (signers.proposers[0], signers.executors[0])
-    };
+    let info = deployment_info(&params.network).with_context(|| {
+        format!(
+            "deployment-info unavailable for network {:?}",
+            params.network
+        )
+    })?;
+    let signers = &info.ops_timelock;
+    anyhow::ensure!(
+        params.timelock == signers.address,
+        "timelock {:#x} is not the {} ops timelock {:#x}; phase Safes would be resolved from the \
+         wrong role sets",
+        params.timelock,
+        params.network,
+        signers.address,
+    );
+    let schedule_safe = resolve_phase_safe(
+        params.schedule_safe,
+        &signers.proposers,
+        "proposer",
+        "--schedule-safe",
+        &params.network,
+    )?;
+    let execute_safe = resolve_phase_safe(
+        params.execute_safe,
+        &signers.executors,
+        "executor",
+        "--execute-safe",
+        &params.network,
+    )?;
 
     let schedule_nonce = safe_nonce(provider, schedule_safe).await?;
     let execute_nonce = if execute_safe == schedule_safe {
@@ -244,10 +281,115 @@ pub async fn write_stake_table_v3_proposal_dir(
 mod tests {
     use std::str::FromStr;
 
-    use alloy::{node_bindings::Anvil, providers::ProviderBuilder};
+    use alloy::{
+        node_bindings::Anvil,
+        providers::{ProviderBuilder, ext::AnvilApi},
+    };
 
     use super::*;
     use crate::proposals::proposal_toml::ProposalToml;
+
+    /// Runtime code for a `nonce()` stub returning `n`:
+    /// PUSH1 n, PUSH1 0, MSTORE, PUSH1 32, PUSH1 0, RETURN.
+    fn nonce_stub(n: u8) -> Bytes {
+        Bytes::from(vec![
+            0x60, n, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3,
+        ])
+    }
+
+    fn write_params(root: PathBuf, network: &str, timelock: Address) -> WriteProposalParams {
+        WriteProposalParams {
+            proposals_root: root,
+            network: network.to_owned(),
+            slug: "stake-table-v3".to_owned(),
+            chain_id: 1,
+            proxy: Address::from_str("0xcef474d372b5b09defe2af187bf17338dc704451").unwrap(),
+            new_impl: Address::from_str("0x5a6250dd35d875c0529573d9d934629a1b2778db").unwrap(),
+            timelock,
+            salt: B256::repeat_byte(0x11),
+            delay: U256::from(172800u64),
+            schedule_calldata: Bytes::from(vec![0xaa]),
+            execute_calldata: Bytes::from(vec![0xbb]),
+            schedule_safe: None,
+            execute_safe: None,
+        }
+    }
+
+    /// Split Safes: each phase records its own Safe and that Safe's own nonce.
+    #[tokio::test]
+    async fn test_write_proposal_dir_split_safes() {
+        let anvil = Anvil::new().spawn();
+        let provider = ProviderBuilder::new().connect_http(anvil.endpoint_url());
+
+        let ops = mainnet_ops_timelock();
+        let labs = member_address(&ops.proposers, Multisig::EspressoLabs).unwrap();
+        let serviceco = member_address(&ops.executors, Multisig::ServiceCo).unwrap();
+        provider.anvil_set_code(labs, nonce_stub(41)).await.unwrap();
+        provider
+            .anvil_set_code(serviceco, nonce_stub(7))
+            .await
+            .unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut params = write_params(tmp.path().to_path_buf(), "mainnet", ops.address);
+        params.schedule_safe = Some(Multisig::EspressoLabs);
+        params.execute_safe = Some(Multisig::ServiceCo);
+
+        let dir = write_stake_table_v3_proposal_dir(params, &provider)
+            .await
+            .unwrap();
+        let toml = ProposalToml::load(&dir).unwrap();
+        assert_eq!(toml.schedule.safe, labs);
+        assert_eq!(toml.schedule.nonce, 41);
+        assert_eq!(toml.execute.safe, serviceco);
+        assert_eq!(toml.execute.nonce, 7);
+        assert_ne!(toml.schedule.safe_tx, toml.execute.safe_tx);
+    }
+
+    /// One Safe for both phases: execute signs right after schedule, so nonce + 1.
+    #[tokio::test]
+    async fn test_write_proposal_dir_single_safe_nonce_increments() {
+        let anvil = Anvil::new().spawn();
+        let provider = ProviderBuilder::new().connect_http(anvil.endpoint_url());
+
+        let ops = deployment_info("decaf").unwrap().ops_timelock;
+        let labs = member_address(&ops.proposers, Multisig::EspressoLabs).unwrap();
+        provider.anvil_set_code(labs, nonce_stub(24)).await.unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = write_stake_table_v3_proposal_dir(
+            write_params(tmp.path().to_path_buf(), "decaf", ops.address),
+            &provider,
+        )
+        .await
+        .unwrap();
+
+        let toml = ProposalToml::load(&dir).unwrap();
+        assert_eq!(toml.schedule.safe, labs);
+        assert_eq!(toml.execute.safe, labs);
+        assert_eq!(toml.schedule.nonce, 24);
+        assert_eq!(toml.execute.nonce, 25);
+    }
+
+    /// A timelock that is not the network's ops timelock must not silently borrow its role sets.
+    #[tokio::test]
+    async fn test_write_proposal_dir_rejects_foreign_timelock() {
+        let anvil = Anvil::new().spawn();
+        let provider = ProviderBuilder::new().connect_http(anvil.endpoint_url());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let safe_exit = deployment_info("mainnet")
+            .unwrap()
+            .safe_exit_timelock
+            .address;
+        let err = write_stake_table_v3_proposal_dir(
+            write_params(tmp.path().to_path_buf(), "mainnet", safe_exit),
+            &provider,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("ops timelock"), "{err}");
+    }
 
     #[test]
     fn test_network_name_known() {
@@ -374,6 +516,77 @@ mod tests {
         assert_eq!(original, loaded);
     }
 
+    fn mainnet_ops_timelock() -> crate::proposals::deployment_info::TimelockInfo {
+        deployment_info("mainnet").unwrap().ops_timelock
+    }
+
+    #[test]
+    fn test_resolve_phase_safe_by_name() {
+        let ops = mainnet_ops_timelock();
+        let safe = resolve_phase_safe(
+            Some(Multisig::EspressoLabs),
+            &ops.proposers,
+            "proposer",
+            "--schedule-safe",
+            "mainnet",
+        )
+        .unwrap();
+        assert_eq!(
+            safe,
+            Address::from_str("0x34f5af5158171ffd2475d21db5fc3b311f221982").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_resolve_phase_safe_wrong_role_errors() {
+        let ops = mainnet_ops_timelock();
+        let err = resolve_phase_safe(
+            Some(Multisig::EspressoLabs),
+            &ops.executors,
+            "executor",
+            "--execute-safe",
+            "mainnet",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("does not hold the executor role"),
+            "{err}"
+        );
+        assert!(err.to_string().contains("serviceco"), "{err}");
+    }
+
+    #[test]
+    fn test_resolve_phase_safe_ambiguous_without_name() {
+        let ops = mainnet_ops_timelock();
+        let err = resolve_phase_safe(
+            None,
+            &ops.proposers,
+            "proposer",
+            "--schedule-safe",
+            "mainnet",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("several proposers"), "{err}");
+        assert!(err.to_string().contains("--schedule-safe"), "{err}");
+    }
+
+    #[test]
+    fn test_resolve_phase_safe_single_holder_needs_no_name() {
+        let ops = mainnet_ops_timelock();
+        let safe = resolve_phase_safe(
+            None,
+            &ops.executors,
+            "executor",
+            "--execute-safe",
+            "mainnet",
+        )
+        .unwrap();
+        assert_eq!(
+            safe,
+            Address::from_str("0x5e37b8038615ef3d75cf28b5982c4cbf065401fb").unwrap()
+        );
+    }
+
     /// The "already exists" guard fires before any on-chain call.
     #[tokio::test]
     async fn test_write_proposal_dir_rejects_existing() {
@@ -382,8 +595,6 @@ mod tests {
 
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path().to_path_buf();
-        let safe: Address =
-            Address::from_str("0xb76834e371b666feee48e5d7d9a97ca08b5a0620").unwrap();
 
         let make_params = |root: PathBuf| WriteProposalParams {
             proposals_root: root,
@@ -397,7 +608,8 @@ mod tests {
             delay: U256::from(300u64),
             schedule_calldata: Bytes::new(),
             execute_calldata: Bytes::new(),
-            safe_override: Some(safe),
+            schedule_safe: Some(Multisig::EspressoLabs),
+            execute_safe: Some(Multisig::EspressoLabs),
         };
 
         // Pre-create the dir and plant a schedule.json so the guard fires immediately.

--- a/crates/espresso/node/src/bin/deploy.rs
+++ b/crates/espresso/node/src/bin/deploy.rs
@@ -14,6 +14,7 @@ use espresso_contract_deployer::{
     builder::DeployerArgsBuilder,
     network_config::{light_client_genesis, light_client_genesis_from_stake_table},
     proposals::{
+        deployment_info::Multisig,
         timelock::TimelockOperationType,
         verify::{VerifyProposalArgs, run_verify_standalone},
     },
@@ -273,6 +274,16 @@ struct Options {
     /// Root directory for written proposals (default: "contracts/deployments/proposals" relative to CWD).
     #[clap(long, name = "PROPOSALS_ROOT")]
     pub proposals_root: Option<PathBuf>,
+
+    /// Multisig that submits the timelock `schedule` phase of a generated proposal.
+    /// Required when the timelock has more than one proposer.
+    #[clap(long, env = "ESPRESSO_PROPOSAL_SCHEDULE_SAFE", value_enum)]
+    pub schedule_safe: Option<Multisig>,
+
+    /// Multisig that submits the timelock `execute` phase of a generated proposal.
+    /// Required when the timelock has more than one executor.
+    #[clap(long, env = "ESPRESSO_PROPOSAL_EXECUTE_SAFE", value_enum)]
+    pub execute_safe: Option<Multisig>,
 
     /// Stake table capacity for the prover circuit
     #[clap(short, long, env = "ESPRESSO_STAKE_TABLE_CAPACITY", default_value_t = DEFAULT_STAKE_TABLE_CAPACITY)]
@@ -593,6 +604,12 @@ async fn async_main(migrated_envs: Vec<(&str, &str)>) -> anyhow::Result<()> {
     }
     if let Some(root) = opt.proposals_root {
         args_builder.proposals_root(root);
+    }
+    if let Some(safe) = opt.schedule_safe {
+        args_builder.schedule_safe(safe);
+    }
+    if let Some(safe) = opt.execute_safe {
+        args_builder.execute_safe(safe);
     }
     if let Some(multisig) = opt.multisig_address {
         args_builder.multisig(multisig);

--- a/doc/stake-table-fast-finality.md
+++ b/doc/stake-table-fast-finality.md
@@ -505,8 +505,13 @@ cargo run -p espresso-node --bin deploy -- \
     --use-timelock-owner \
     --timelock-operation-salt "0x$(openssl rand -hex 32)" \
     --timelock-operation-delay 172800 \
+    --schedule-safe espresso_labs \
+    --execute-safe serviceco \
     --calldata-out-dir ./tmp/st_v3_timelock/
 ```
+
+`--schedule-safe`/`--execute-safe` name the multisig submitting each phase; they are required when the timelock role has
+more than one holder, as on mainnet (proposers: `espresso_labs`, `serviceco`; executor: `serviceco`).
 
 ### Testing the Safe TX output against a mainnet fork
 
@@ -527,6 +532,8 @@ cargo run -p espresso-node --bin deploy -- \
     --use-timelock-owner \
     --timelock-operation-salt "0x$(openssl rand -hex 32)" \
     --timelock-operation-delay 172800 \
+    --schedule-safe espresso_labs \
+    --execute-safe serviceco \
     --calldata-out-dir ./tmp/st_v3_timelock_mainnet/
 ```
 


### PR DESCRIPTION
Mainnet's OpsTimelock has two proposers (espresso_labs, serviceco) and one executor (serviceco), so proposal generation aborted with "ambiguous signer set" and had no way to choose; espresso_labs must schedule and serviceco execute.

- deployment-info members keep their name as a `Multisig` enum, so an unknown name in a deployment TOML fails to parse instead of being discarded
- `deploy --schedule-safe/--execute-safe` pick the phase Safes; a named multisig must hold the role, and omitting the flag is only allowed when the role has a single holder
- writing a proposal now fails when the target timelock is not the network's ops timelock, which would resolve Safes from the wrong role sets
- `verify-proposal` asserts on chain that each phase Safe holds its role, rather than trusting the embedded deployment-info snapshot alone
