### PR TITLE
[Backport release-ff] feat(api): add status endpoint for node public keys (#4759)

### DIFF
--- a/crates/espresso/api/examples/test_api.rs
+++ b/crates/espresso/api/examples/test_api.rs
@@ -356,6 +356,8 @@ impl v1::FeeStateApi for TestApi {
 
 #[async_trait]
 impl v1::StatusApi for TestApi {
+    type Keys = serde_json::Value;
+
     async fn block_height(&self) -> Result<u64> {
         Ok(0)
     }
@@ -367,6 +369,9 @@ impl v1::StatusApi for TestApi {
     }
     async fn metrics(&self) -> Result<String> {
         Ok(String::new())
+    }
+    async fn keys(&self) -> Result<Self::Keys> {
+        Ok(serde_json::Value::Null)
     }
 }
 

--- a/crates/espresso/api/src/axum.rs
+++ b/crates/espresso/api/src/axum.rs
@@ -843,6 +843,12 @@ where
             Err(e) => Err(ApiError::Internal(e)),
         }
     };
+    let status_keys = |State(state): State<S>| async move {
+        <S as v1::StatusApi>::keys(&state)
+            .await
+            .map(Json)
+            .map_err(ApiError::Internal)
+    };
 
     let config_hotshot = |State(state): State<S>| async move {
         <S as v1::ConfigApi>::hotshot_config(&state)
@@ -1780,6 +1786,7 @@ where
             get(status_time_since_last_decide),
         )
         .route(routes::v1::STATUS_METRICS_ROUTE, get(status_metrics))
+        .route(routes::v1::STATUS_KEYS_ROUTE, get(status_keys))
         // Config routes
         .route(routes::v1::CONFIG_HOTSHOT_ROUTE, get(config_hotshot))
         .route(routes::v1::CONFIG_ENV_ROUTE, get(config_env))

--- a/crates/espresso/api/src/axum/routes.rs
+++ b/crates/espresso/api/src/axum/routes.rs
@@ -108,6 +108,7 @@ pub mod v1 {
     pub const STATUS_SUCCESS_RATE_ROUTE: &str = "/v1/status/success-rate";
     pub const STATUS_TIME_SINCE_LAST_DECIDE_ROUTE: &str = "/v1/status/time-since-last-decide";
     pub const STATUS_METRICS_ROUTE: &str = "/v1/status/metrics";
+    pub const STATUS_KEYS_ROUTE: &str = "/v1/status/keys";
 
     pub const CONFIG_HOTSHOT_ROUTE: &str = "/v1/config/hotshot";
     pub const CONFIG_ENV_ROUTE: &str = "/v1/config/env";

--- a/crates/espresso/api/src/v1/status.rs
+++ b/crates/espresso/api/src/v1/status.rs
@@ -3,12 +3,17 @@
 //! Mirrors the tide-disco endpoints defined in `hotshot-query-service/api/status.toml`.
 
 use async_trait::async_trait;
+use serde::Serialize;
 
 #[async_trait]
 pub trait StatusApi {
+    type Keys: Serialize + Send + Sync + 'static;
+
     async fn block_height(&self) -> anyhow::Result<u64>;
     async fn success_rate(&self) -> anyhow::Result<f64>;
     async fn time_since_last_decide(&self) -> anyhow::Result<u64>;
 
     async fn metrics(&self) -> anyhow::Result<String>;
+
+    async fn keys(&self) -> anyhow::Result<Self::Keys>;
 }

--- a/crates/espresso/node/api/status.toml
+++ b/crates/espresso/node/api/status.toml
@@ -1,0 +1,11 @@
+# Extensions to the status API defined in `hotshot-query-service/api/status.toml`.
+
+[route.keys]
+PATH = ["/keys"]
+DOC = """
+Get this node's public keys (Ethereum account, BLS, Schnorr, x25519).
+
+The BLS and Schnorr keys are formatted as in stake-table responses; the x25519 key is tagged
+base64. The Ethereum account is taken from the node's stake-table registration and is null if the
+node is not registered.
+"""

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -71,7 +71,10 @@ use tokio::time::timeout;
 use url::Url;
 use vbs::version::Version;
 
-use self::data_source::{HotShotConfigDataSource, NodeStateDataSource, StateSignatureDataSource};
+use self::data_source::{
+    HotShotConfigDataSource, NodeKeysDataSource, NodePublicKeys, NodeStateDataSource,
+    StateSignatureDataSource,
+};
 use crate::{
     SeqTypes, SequencerApiVersion, SequencerContext,
     api::data_source::TokenDataSource,
@@ -1268,6 +1271,34 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence> HotShotConfigDataSour
     }
 }
 
+impl<N: ConnectedNetwork<PubKey>, D: Sync, P: SequencerPersistence> NodeKeysDataSource
+    for StorageState<N, P, D>
+{
+    async fn node_public_keys(&self) -> NodePublicKeys {
+        self.as_ref().node_public_keys().await
+    }
+}
+
+impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence> NodeKeysDataSource for ApiState<N, P> {
+    async fn node_public_keys(&self) -> NodePublicKeys {
+        let ctx = self.sequencer_context.as_ref().get().await.get_ref();
+        let config = ctx.validator_config();
+        let consensus_key = config.public_key;
+        let eth_account = ctx
+            .consensus_handle()
+            .membership_coordinator()
+            .await
+            .membership()
+            .latest_account(&consensus_key);
+        NodePublicKeys {
+            eth_account,
+            consensus_key,
+            state_ver_key: config.state_public_key.clone(),
+            x25519_key: config.x25519_keypair.as_ref().map(|kp| kp.public_key()),
+        }
+    }
+}
+
 #[async_trait]
 impl<N: ConnectedNetwork<PubKey>, D: Sync, P: SequencerPersistence> StateSignatureDataSource<N>
     for StorageState<N, P, D>
@@ -2336,7 +2367,7 @@ pub mod test_helpers {
             .api_config(options)
             .network_config(network_config)
             .build();
-        let _network = TestNetwork::new(config, MOCK_SEQUENCER_VERSIONS).await;
+        let network = TestNetwork::new(config, MOCK_SEQUENCER_VERSIONS).await;
         client.connect(None).await;
 
         // The status API is well tested in the query service repo. Here we are just smoke testing
@@ -2361,6 +2392,31 @@ pub mod test_helpers {
         assert!(success_rate.is_finite(), "{success_rate}");
         // We know at least some views have been successful, since we finalized a block.
         assert!(success_rate > 0.0, "{success_rate}");
+
+        let keys: NodePublicKeys = client.get("status/keys").send().await.unwrap();
+        let expected = network.server.validator_config();
+        assert_eq!(keys.consensus_key, expected.public_key);
+        assert_eq!(keys.state_ver_key, expected.state_public_key);
+        assert_eq!(
+            keys.x25519_key,
+            expected.x25519_keypair.as_ref().map(|kp| kp.public_key())
+        );
+        assert_eq!(keys.eth_account, None);
+
+        // Request JSON explicitly: without an Accept header tide-disco responds with bincode,
+        // which cannot deserialize into `serde_json::Value`.
+        let json: serde_json::Value = client
+            .get("status/keys")
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .unwrap();
+        let bls = json["consensus_key"].as_str().unwrap();
+        assert!(bls.starts_with("BLS_VER_KEY~"), "{bls}");
+        let schnorr = json["state_ver_key"].as_str().unwrap();
+        assert!(schnorr.starts_with("SCHNORR_VER_KEY~"), "{schnorr}");
+        let x25519 = json["x25519_key"].as_str().unwrap();
+        assert!(x25519.starts_with("X25519_PK~"), "{x25519}");
     }
 
     /// Test the submit API with custom options.

--- a/crates/espresso/node/src/api/data_source.rs
+++ b/crates/espresso/node/src/api/data_source.rs
@@ -28,9 +28,10 @@ use hotshot_query_service::{
 use hotshot_types::{
     PeerConfig,
     data::{EpochNumber, VidShare, ViewNumber},
-    light_client::LCV3StateSignatureRequestBody,
+    light_client::{LCV3StateSignatureRequestBody, StateVerKey},
     simple_certificate::LightClientStateUpdateCertificateV2,
     traits::{network::ConnectedNetwork, node_implementation::NodeType},
+    x25519,
 };
 use indexmap::IndexMap;
 use light_client::{state::LightClientOptions, storage::LightClientSqliteOptions};
@@ -123,6 +124,40 @@ pub(crate) trait StateSignatureDataSource<N: ConnectedNetwork<PubKey>> {
 
 pub(crate) trait NodeStateDataSource {
     fn node_state(&self) -> impl Send + Future<Output = NodeState>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodePublicKeys {
+    pub eth_account: Option<Address>,
+    pub consensus_key: BLSPubKey,
+    pub state_ver_key: StateVerKey,
+    #[serde(with = "x25519_tagged")]
+    pub x25519_key: Option<x25519::PublicKey>,
+}
+
+mod x25519_tagged {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+
+    use super::x25519;
+
+    pub fn serialize<S: Serializer>(
+        key: &Option<x25519::PublicKey>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        key.as_ref().map(ToString::to_string).serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Option<x25519::PublicKey>, D::Error> {
+        Option::<String>::deserialize(d)?
+            .map(|s| s.parse().map_err(D::Error::custom))
+            .transpose()
+    }
+}
+
+pub(crate) trait NodeKeysDataSource {
+    fn node_public_keys(&self) -> impl Send + Future<Output = NodePublicKeys>;
 }
 
 pub(crate) trait TokenDataSource<T: NodeType> {
@@ -587,6 +622,49 @@ pub(crate) trait PruningDataSource {
     fn get_oldest_leaf(
         &self,
     ) -> impl Send + Future<Output = anyhow::Result<Option<LeafQueryData<SeqTypes>>>>;
+}
+
+#[cfg(test)]
+mod test {
+    use hotshot_types::{light_client::StateKeyPair, traits::signature_key::SignatureKey as _};
+
+    use super::*;
+
+    #[test]
+    fn test_node_public_keys_serialize_like_stake_table() {
+        let account = Address::random();
+        let consensus_key = BLSPubKey::generated_from_seed_indexed([1; 32], 0).0;
+        let state_ver_key = StateKeyPair::generate_from_seed_indexed([2; 32], 0).ver_key();
+        let x25519_key = x25519::Keypair::generated_from_seed_indexed([3; 32], 0)
+            .unwrap()
+            .public_key();
+
+        let validator = serde_json::to_value(RegisteredValidator::<BLSPubKey> {
+            account,
+            stake_table_key: Some(consensus_key),
+            state_ver_key: Some(state_ver_key.clone()),
+            stake: U256::from(1u64),
+            commission: 0,
+            delegators: HashMap::new(),
+            authenticated: true,
+            x25519_key: Some(x25519_key),
+            p2p_addr: None,
+        })
+        .unwrap();
+
+        let keys = serde_json::to_value(NodePublicKeys {
+            eth_account: Some(account),
+            consensus_key,
+            state_ver_key,
+            x25519_key: Some(x25519_key),
+        })
+        .unwrap();
+
+        assert_eq!(keys["eth_account"], validator["account"]);
+        assert_eq!(keys["consensus_key"], validator["stake_table_key"]);
+        assert_eq!(keys["state_ver_key"], validator["state_ver_key"]);
+        assert_eq!(keys["x25519_key"], x25519_key.to_string());
+    }
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/crates/espresso/node/src/api/endpoints.rs
+++ b/crates/espresso/node/src/api/endpoints.rs
@@ -33,6 +33,7 @@ use hotshot_query_service::{
         self, MerklizedState, MerklizedStateDataSource, MerklizedStateHeightPersistence, Snapshot,
     },
     node::{self, NodeDataSource},
+    status::{self, StatusDataSource},
 };
 use hotshot_types::{
     data::{EpochNumber, ViewNumber},
@@ -45,8 +46,9 @@ use tide_disco::{Api, Error as _, RequestParams, StatusCode, method::ReadState};
 use vbs::version::{StaticVersion, StaticVersionType};
 
 use super::data_source::{
-    CatchupDataSource, DatabaseMetadataSource, HotShotConfigDataSource, NodeStateDataSource,
-    PruningDataSource, StakeTableDataSource, StateSignatureDataSource, SubmitDataSource,
+    CatchupDataSource, DatabaseMetadataSource, HotShotConfigDataSource, NodeKeysDataSource,
+    NodeStateDataSource, PruningDataSource, StakeTableDataSource, StateSignatureDataSource,
+    SubmitDataSource,
 };
 use crate::{
     SeqTypes, SequencerApiVersion, SequencerPersistence, api::RewardMerkleTreeDataSource,
@@ -504,6 +506,29 @@ where
         total_supply_l1,
         total_reward_distributed,
     ))
+}
+
+pub(super) fn status<S>(
+    api_ver: semver::Version,
+) -> Result<Api<S, status::Error, StaticVersion<0, 1>>>
+where
+    S: 'static + Send + Sync + ReadState,
+    <S as ReadState>::State: Send + Sync + StatusDataSource + NodeKeysDataSource,
+{
+    // Extend the base API
+    let mut options = status::Options::default();
+    let extension = toml::from_str(include_str!("../../api/status.toml"))?;
+    options.extensions.push(extension);
+
+    // Create the base API with our extensions
+    let mut api = status::define_api::<S, _>(&options, SequencerApiVersion::instance(), api_ver)?;
+
+    // Tack on the application logic
+    api.get("keys", |_, state| {
+        async move { Ok(state.node_public_keys().await) }.boxed()
+    })?;
+
+    Ok(api)
 }
 
 pub(super) fn node<S>(api_ver: semver::Version) -> Result<Api<S, node::Error, StaticVersion<0, 1>>>

--- a/crates/espresso/node/src/api/options.rs
+++ b/crates/espresso/node/src/api/options.rs
@@ -19,7 +19,7 @@ use futures::{
 use hotshot_query_service::{
     ApiState as AppState, Error,
     data_source::{ExtensibleDataSource, MetricsDataSource},
-    status::{self, HasMetrics, UpdateStatusData},
+    status::{HasMetrics, UpdateStatusData},
 };
 use hotshot_types::traits::{
     metrics::{Metrics, NoMetrics},
@@ -232,8 +232,7 @@ impl Options {
 
             // Initialize v0 and v1 status API.
             register_api("status", &mut app, move |ver| {
-                status::define_api(&Default::default(), SequencerApiVersion::instance(), ver)
-                    .context("failed to define status api")
+                endpoints::status(ver).context("failed to define status api")
             })?;
 
             self.init_hotshot_modules(&mut app)?;
@@ -316,8 +315,7 @@ impl Options {
 
         // Initialize v0 and v1 status API.
         register_api("status", &mut app, move |ver| {
-            status::define_api(&Default::default(), SequencerApiVersion::instance(), ver)
-                .context("failed to define status api")
+            endpoints::status(ver).context("failed to define status api")
         })?;
 
         // Initialize availability and node APIs (these both use the same data source).

--- a/crates/espresso/node/src/api/state.rs
+++ b/crates/espresso/node/src/api/state.rs
@@ -51,8 +51,8 @@ use tagged_base64::TaggedBase64;
 use super::{
     RewardMerkleTreeDataSource, RewardMerkleTreeV2Data as InternalRewardTreeData,
     data_source::{
-        RequestResponseDataSource as _, StakeTableDataSource, StateCertDataSource,
-        StateCertFetchingDataSource, StateSignatureDataSource,
+        NodeKeysDataSource, NodePublicKeys, RequestResponseDataSource as _, StakeTableDataSource,
+        StateCertDataSource, StateCertFetchingDataSource, StateSignatureDataSource,
     },
 };
 
@@ -2155,8 +2155,10 @@ where
 impl<D> espresso_api::v1::StatusApi for NodeApiStateImpl<D>
 where
     D: std::ops::Deref + Clone + Send + Sync + 'static,
-    D::Target: hotshot_query_service::status::StatusDataSource + Send + Sync,
+    D::Target: hotshot_query_service::status::StatusDataSource + NodeKeysDataSource + Send + Sync,
 {
+    type Keys = NodePublicKeys;
+
     async fn block_height(&self) -> anyhow::Result<u64> {
         let ds = &*self.data_source;
         let h = hotshot_query_service::status::StatusDataSource::block_height(ds)
@@ -2184,6 +2186,10 @@ where
         use tide_disco::metrics::Metrics as _;
         let ds = &*self.data_source;
         ds.metrics().export().map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    async fn keys(&self) -> anyhow::Result<NodePublicKeys> {
+        Ok(self.data_source.node_public_keys().await)
     }
 }
 

--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -454,6 +454,10 @@ where
         self.consensus_handle.clone()
     }
 
+    pub fn validator_config(&self) -> &ValidatorConfig<SeqTypes> {
+        &self.validator_config
+    }
+
     pub async fn upgrade_lock(&self) -> UpgradeLock<SeqTypes> {
         self.consensus_handle.upgrade_lock().await
     }

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -205,6 +205,15 @@ impl EpochCommittees {
             .cloned()
     }
 
+    pub fn latest_account(&self, key: &PubKey) -> Option<Address> {
+        let inner = self.inner.read();
+        inner
+            .snapshots
+            .values()
+            .rev()
+            .find_map(|snap| snap.inner.committee.address_mapping.get(key).copied())
+    }
+
     /// Fetch the fixed block reward and update it if its None.
     /// We used a fixed block reward for version v3
     /// Version v4 uses the dynamic block reward


### PR DESCRIPTION
Backports #4759 (`status/keys` endpoint exposing the node's public keys) to `release-ff`.

### This PR:
* Cherry-picks eda7d5c1fc4 (#4759) with `-x`, resolving conflicts against release-ff's pre-tide-removal API stack:
  * `espresso-api`'s axum router on release-ff predates the aide/OpenAPI rework, so the `keys` handler and route are added in its plain `Router`/`Json` style.
  * `node/src/api/state.rs`: applied the `NodeKeysDataSource` bound, `type Keys = NodePublicKeys`, and `keys()` method onto release-ff's `StatusApi` impl.
* Adds the endpoint to the **tide-disco** status module as well, since release-ff still serves `status/…` via tide-disco on the main API port (on main, #4759 landed after the tide removal so only axum needed it):
  * New extension spec `crates/espresso/node/api/status.toml` following the existing `node.toml`/`fee.toml` pattern.
  * New `endpoints::status()` wraps `hotshot_query_service::status::define_api` with the `keys` route; both `register_api("status", …)` call sites use it.
* Test adaptation: the JSON-shape assertion in `status_test_helper` sends `Accept: application/json`, since tide-disco responds with bincode by default (main's axum always returns JSON).

The endpoint is served on both the tide port (`status/keys`, v0 and v1) and the axum port (`/v1/status/keys`).

### Key places to review:
* `crates/espresso/node/src/api/endpoints.rs`, `endpoints::status()` — the tide-side extension, which has no counterpart on main.
* `crates/espresso/api/src/axum.rs` — the handler adapted to release-ff's plain axum style.

### Things tested
* `cargo nextest run -p espresso-node`: `test_node_public_keys_serialize_like_stake_table`, `status_test_without_query_module`, and both `status_test_with_query_module` cases pass.
* `cargo check`/`clippy` clean on `espresso-node` and `espresso-api` (tests + examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)