### PR TITLE
[Backport release-ff] Consensus and new-protocol fixes (#4698, #4695, #4743, #4731, #4747, #4730, #4751, #4796)

### DIFF
--- a/crates/cliquenet/src/lib.rs
+++ b/crates/cliquenet/src/lib.rs
@@ -118,6 +118,10 @@ pub struct Config {
     #[builder(default = 6)]
     keep_alive_retries: u8,
 
+    /// Max. number of concurrent accept tasks.
+    #[builder(default = (3 * parties.len()).max(100))]
+    max_accept_tasks: usize,
+
     /// Optional metrics implementation.
     metrics: Option<Arc<dyn Metrics>>,
 }
@@ -156,6 +160,7 @@ impl fmt::Debug for Config {
             .field("keepalive_after", &self.keep_alive_after)
             .field("keepalive_interval", &self.keep_alive_interval)
             .field("keepalive_retries", &self.keep_alive_retries)
+            .field("max_accept_tasks", &self.max_accept_tasks)
             .finish()
     }
 }

--- a/crates/cliquenet/src/msg/hello.rs
+++ b/crates/cliquenet/src/msg/hello.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Hello {
     Ok,
     BackOff(Duration),
@@ -33,7 +33,7 @@ impl Hello {
         }
     }
 
-    pub fn to_bytes(&self) -> HelloBytes {
+    pub fn to_bytes(self) -> HelloBytes {
         match self {
             Self::Ok => HelloBytes::Ok([0]),
             Self::BackOff(d) => {

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -35,7 +35,8 @@ pub struct Server {
     obound: UnboundedReceiver<Command>,
     next_slot: watch::Receiver<Slot>,
     accept_tasks: JoinSet<Result<Connection, NetworkError>>,
-    hello_tasks: JoinMap<PublicKey, Result<(Hello, Connection, Hello), NetworkError>>,
+    #[allow(clippy::type_complexity)]
+    hello_tasks: JoinMap<PublicKey, Result<(Hello, Connection, Option<Hello>), NetworkError>>,
     connect_tasks: JoinMap<PublicKey, Connection>,
     peer_tasks: JoinMap<PublicKey, Peer>,
     metrics: Arc<dyn Metrics>,
@@ -138,25 +139,27 @@ impl Server {
 
         loop {
             select! {
-                x = listener.accept() => match x {
-                    Ok((stream, addr)) => {
-                        debug!(
-                            name = %self.conf.name,
-                            node = %self.key,
-                            %addr,
-                            "accepted new tcp connection"
-                        );
-                        self.spawn_accept(stream)
+                x = listener.accept(), if self.accept_tasks.len() < self.conf.max_accept_tasks => {
+                    match x {
+                        Ok((stream, addr)) => {
+                            debug!(
+                                name = %self.conf.name,
+                                node = %self.key,
+                                %addr,
+                                "accepted new tcp connection"
+                            );
+                            self.spawn_accept(stream)
+                        }
+                        Err(err) => {
+                            warn!(
+                                name = %self.conf.name,
+                                node = %self.key,
+                                %err,
+                                "error accepting tcp connection"
+                            )
+                        }
                     }
-                    Err(err) => {
-                        warn!(
-                            name = %self.conf.name,
-                            node = %self.key,
-                            %err,
-                            "error accepting tcp connection"
-                        )
-                    }
-                },
+                }
 
                 Some(h) = self.accept_tasks.join_next() => match h {
                     Ok(Ok(conn)) => {
@@ -231,7 +234,7 @@ impl Server {
                             );
                             continue
                         };
-                        if !(our_hello.is_ok() && their_hello.is_ok()) {
+                        if !(our_hello.is_ok() && their_hello.is_some_and(|h| h.is_ok())) {
                             warn!(
                                 name   = %self.conf.name,
                                 node   = %self.key,
@@ -681,12 +684,27 @@ impl Server {
 
         self.metrics.add(&conn.key, HELLOS, 1);
 
+        // Under normal circumstances we should never witness more hellos than parties.
+        // An adversary may nevertheless pass the accept stage and since we do not
+        // know the party we inform it to back off. If the remote does not send us
+        // their hello in due time this will occupy the hello task (and a file
+        // descriptor). To put a cap on that we make the reading of hellos contingent
+        // on how many ongoing hellos we already process. Under attack we do not
+        // bother with reading the remote's (unless it is a peer we want), but only
+        // send our hello and drop the connection. NB that this may cause the remote
+        // to see a connection reset.
+        let under_pressure = self.hello_tasks.len() > 2 * self.parties.len();
+
         self.hello_tasks.abort(&conn.key);
         self.hello_tasks.spawn(
             conn.key,
             until(self.conf.handshake_timeout, async move {
-                let theirs = conn.recv_hello().await?;
-                conn.send_hello(ours.clone()).await?;
+                let theirs = if ours.is_ok() || !under_pressure {
+                    Some(conn.recv_hello().await?)
+                } else {
+                    None
+                };
+                conn.send_hello(ours).await?;
                 Ok::<_, NetworkError>((ours, conn, theirs))
             }),
         );

--- a/crates/espresso/api/src/axum.rs
+++ b/crates/espresso/api/src/axum.rs
@@ -648,10 +648,13 @@ where
     };
 
     let get_cert2 = |State(state): State<S>, Path(height): Path<u64>| async move {
-        <S as v1::HotShotAvailabilityApi>::get_cert2(&state, height)
-            .await
-            .map(Json)
-            .map_err(ApiError::Internal)
+        match <S as v1::HotShotAvailabilityApi>::get_cert2(&state, height).await {
+            Ok(Some(cert2)) => Ok(Json(cert2)),
+            Ok(None) => Err(ApiError::NotFound(anyhow::anyhow!(
+                "no cert2 available for height {height}"
+            ))),
+            Err(err) => Err(ApiError::Internal(err)),
+        }
     };
 
     // WebSocket streaming handlers

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -8828,12 +8828,14 @@ mod test {
                 // Limits endpoint (static response)
                 compare_endpoints(&http, api_port, axum_port, "availability/limits").await?;
 
-                // Cert2 endpoint (returns null when no cert is available at this height)
-                compare_endpoints(
+                // Cert2 endpoint: `avail_block` is a mid-chain block with no cert2, so both APIs
+                // return 404. Compare status only, since the two error bodies differ by design.
+                compare_error_endpoints(
                     &http,
                     api_port,
                     axum_port,
                     &format!("availability/cert2/{avail_block}"),
+                    404,
                 )
                 .await?;
 

--- a/crates/espresso/node/src/api/state.rs
+++ b/crates/espresso/node/src/api/state.rs
@@ -1867,10 +1867,12 @@ where
     }
 
     async fn get_cert2(&self, height: u64) -> anyhow::Result<Option<Self::Cert2>> {
-        self.data_source
+        Ok(self
+            .data_source
             .get_cert2(height)
             .await
-            .map_err(|e| anyhow::anyhow!("{}", e))
+            .with_timeout(Duration::from_millis(500))
+            .await)
     }
 
     async fn stream_leaves(&self, from: usize) -> anyhow::Result<BoxStream<'static, Self::Leaf>> {

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -54,6 +54,7 @@ pub(crate) fn default_telemetry_endpoint(chain_id: ChainId) -> Option<&'static s
     }
 }
 
+pub use espresso_types::RECENT_STAKE_TABLES_LIMIT;
 use genesis::L1Finalized;
 pub use genesis::{Genesis, GenesisSource};
 use hotshot::{
@@ -97,8 +98,6 @@ use url::Url;
 use vbs::version::StaticVersion;
 
 use crate::request_response::data_source::Storage as RequestResponseStorage;
-
-pub const RECENT_STAKE_TABLES_LIMIT: u64 = 20;
 
 /// The Sequencer node is generic over the hotshot CommChannel.
 #[derive(Derivative, Serialize, Deserialize)]

--- a/crates/espresso/node/src/persistence.rs
+++ b/crates/espresso/node/src/persistence.rs
@@ -2396,6 +2396,64 @@ mod tests {
         Ok(())
     }
 
+    // Epoch data is stored piecemeal: `store_drb_result`, `store_epoch_root`
+    // and `store_stake` each write only their part (one row in SQL, separate
+    // files in FS). A loader must report data another writer created the
+    // epoch entry for as absent — regression test for `load_stake` panicking
+    // on a DRB-only row's NULL stake column.
+    #[rstest_reuse::apply(persistence_types)]
+    pub async fn test_load_partially_stored_epoch_data<P: TestablePersistence>(
+        _p: PhantomData<P>,
+    ) -> anyhow::Result<()> {
+        let tmp = P::tmp_storage().await;
+        let storage = P::connect(&tmp).await;
+
+        let instance_state = NodeState::mock();
+        let validated_state = hotshot_types::traits::ValidatedState::genesis(&instance_state).0;
+        let leaf: Leaf2 = Leaf::genesis(&validated_state, &instance_state, MOCK_UPGRADE.base)
+            .await
+            .into();
+        let header = leaf.block_header().clone();
+
+        let validator = AuthenticatedValidator::mock();
+        let mut stake = IndexMap::new();
+        stake.insert(validator.account, validator);
+
+        // Nothing stored yet.
+        let epoch = EpochNumber::new(1);
+        assert!(storage.load_stake(epoch).await?.is_none());
+        assert!(storage.load_drb_result(epoch).await?.is_none());
+        assert!(storage.load_epoch_root(epoch).await?.is_none());
+
+        // A DRB result alone; the other loaders report their data as absent.
+        storage.store_drb_result(epoch, [1; 32]).await?;
+        assert!(storage.load_stake(epoch).await?.is_none());
+        assert_eq!(storage.load_drb_result(epoch).await?, Some([1; 32]));
+        assert!(storage.load_epoch_root(epoch).await?.is_none());
+
+        // A stake table alone, likewise.
+        let epoch2 = EpochNumber::new(2);
+        storage
+            .store_stake(epoch2, stake.clone(), None, None)
+            .await?;
+        assert!(storage.load_stake(epoch2).await?.is_some());
+        assert!(storage.load_drb_result(epoch2).await?.is_none());
+        assert!(storage.load_epoch_root(epoch2).await?.is_none());
+
+        // With everything stored for one epoch, each loader returns its
+        // value and none has clobbered the others.
+        storage.store_epoch_root(epoch, header.clone()).await?;
+        storage
+            .store_stake(epoch, stake.clone(), None, None)
+            .await?;
+        let (table, ..) = storage.load_stake(epoch).await?.unwrap();
+        assert_eq!(stake, table);
+        assert_eq!(storage.load_drb_result(epoch).await?, Some([1; 32]));
+        assert_eq!(storage.load_epoch_root(epoch).await?, Some(header));
+
+        Ok(())
+    }
+
     #[rstest_reuse::apply(persistence_types)]
     pub async fn test_delete_stake_tables<P: TestablePersistence>(
         _p: PhantomData<P>,

--- a/crates/espresso/node/src/persistence/fs.rs
+++ b/crates/espresso/node/src/persistence/fs.rs
@@ -14,8 +14,8 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use clap::Parser;
 use espresso_types::{
-    AuthenticatedValidatorMap, Leaf, Leaf2, NetworkConfig, Payload, PubKey, RegisteredValidatorMap,
-    SeqTypes, StakeTableHash,
+    AuthenticatedValidatorMap, Header, Leaf, Leaf2, NetworkConfig, Payload, PubKey,
+    RegisteredValidatorMap, SeqTypes, StakeTableHash,
     traits::{EventsPersistenceRead, MembershipPersistence, StakeTuple},
     v0::traits::{EventConsumer, PersistenceOptions, SequencerPersistence},
     v0_3::{
@@ -2032,6 +2032,46 @@ impl MembershipPersistence for Persistence {
             )
         })?;
         Ok(Some(stake))
+    }
+
+    async fn load_drb_result(&self, epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+        let inner = self.inner.read().await;
+        let file_path = inner
+            .epoch_drb_result_dir_path()
+            .join(epoch.to_string())
+            .with_extension("txt");
+
+        if !file_path.is_file() {
+            return Ok(None);
+        }
+
+        let bytes = fs::read(&file_path)
+            .context(format!("reading epoch drb result {}", file_path.display()))?;
+        let drb_result = bincode::deserialize::<DrbResult>(&bytes)
+            .context(format!("parsing epoch drb result {}", file_path.display()))?;
+        Ok(Some(drb_result))
+    }
+
+    async fn load_epoch_root(&self, epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
+        let inner = self.inner.read().await;
+        let file_path = inner
+            .epoch_root_block_header_dir_path()
+            .join(epoch.to_string())
+            .with_extension("txt");
+
+        if !file_path.is_file() {
+            return Ok(None);
+        }
+
+        let bytes = fs::read(&file_path).context(format!(
+            "reading epoch root block header {}",
+            file_path.display()
+        ))?;
+        let header = bincode::deserialize::<Header>(&bytes).context(format!(
+            "parsing epoch root block header {}",
+            file_path.display()
+        ))?;
+        Ok(Some(header))
     }
 
     async fn load_latest_stake(&self, limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>> {

--- a/crates/espresso/node/src/persistence/no_storage.rs
+++ b/crates/espresso/node/src/persistence/no_storage.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use anyhow::bail;
 use async_trait::async_trait;
 use espresso_types::{
-    AuthenticatedValidatorMap, Leaf2, NetworkConfig, PubKey, RegisteredValidatorMap,
+    AuthenticatedValidatorMap, Header, Leaf2, NetworkConfig, PubKey, RegisteredValidatorMap,
     StakeTableHash,
     traits::{EventsPersistenceRead, MembershipPersistence, StakeTuple},
     v0::traits::{EventConsumer, PersistenceOptions, SequencerPersistence},
@@ -311,6 +311,14 @@ impl MembershipPersistence for NoStorage {
     }
 
     async fn load_latest_stake(&self, _limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>> {
+        Ok(None)
+    }
+
+    async fn load_drb_result(&self, _epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+        Ok(None)
+    }
+
+    async fn load_epoch_root(&self, _epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
         Ok(None)
     }
 

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -15,7 +15,7 @@ use committable::Committable;
 use derivative::Derivative;
 use derive_more::derive::{From, Into};
 use espresso_types::{
-    AuthenticatedValidatorMap, BackoffParams, BlockMerkleTree, FeeMerkleTree, Leaf, Leaf2,
+    AuthenticatedValidatorMap, BackoffParams, BlockMerkleTree, FeeMerkleTree, Header, Leaf, Leaf2,
     NetworkConfig, Payload, PubKey, Ratio, RegisteredValidatorMap, StakeTableHash, parse_duration,
     parse_size,
     traits::{EventsPersistenceRead, MembershipPersistence, StakeTuple},
@@ -3153,7 +3153,7 @@ impl MembershipPersistence for Persistence {
             .fetch_optional(
                 query(
                     "SELECT stake, block_reward, stake_table_hash FROM epoch_drb_and_root WHERE \
-                     epoch = $1",
+                     epoch = $1 AND stake IS NOT NULL",
                 )
                 .bind(epoch.u64() as i64),
             )
@@ -3173,6 +3173,50 @@ impl MembershipPersistence for Persistence {
                     .transpose()?;
 
                 Ok((stake_table, reward, stake_table_hash))
+            })
+            .transpose()
+    }
+
+    async fn load_drb_result(&self, epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+        let result = self
+            .db
+            .read()
+            .await?
+            .fetch_optional(
+                query(
+                    "SELECT drb_result FROM epoch_drb_and_root WHERE epoch = $1 AND drb_result IS \
+                     NOT NULL",
+                )
+                .bind(epoch.u64() as i64),
+            )
+            .await?;
+
+        result
+            .map(|row| {
+                let bytes: Vec<u8> = row.get("drb_result");
+                bytes.try_into().or_else(|_| bail!("invalid drb result"))
+            })
+            .transpose()
+    }
+
+    async fn load_epoch_root(&self, epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
+        let result = self
+            .db
+            .read()
+            .await?
+            .fetch_optional(
+                query(
+                    "SELECT block_header FROM epoch_drb_and_root WHERE epoch = $1 AND \
+                     block_header IS NOT NULL",
+                )
+                .bind(epoch.u64() as i64),
+            )
+            .await?;
+
+        result
+            .map(|row| {
+                let bytes: Vec<u8> = row.get("block_header");
+                bincode::deserialize(&bytes).context("deserializing block header")
             })
             .transpose()
     }

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -44,6 +44,15 @@ use crate::{
     v0_3::{ASSUMED_BLOCK_TIME_SECONDS, AuthenticatedValidator, Fetcher, RewardAmount},
 };
 
+/// Number of recent per-epoch stake tables kept in memory.
+///
+/// `reload_stake` loads this many epochs from persistence on startup and
+/// `prune_epochs` evicts anything older as the tip advances, so a
+/// long-running node holds the same window as a freshly restarted one.
+/// Evicted epochs are recovered on demand via the membership coordinator's
+/// catchup.
+pub const RECENT_STAKE_TABLES_LIMIT: u64 = 20;
+
 /// Type to describe DA and Stake memberships.
 #[derive(Clone, Debug)]
 pub struct EpochCommittees {
@@ -51,6 +60,7 @@ pub struct EpochCommittees {
     fetcher: Arc<Fetcher>,
     #[cfg_attr(not(feature = "node"), allow(dead_code))]
     update_fixed_block_reward_lock: Arc<AsyncMutex<()>>,
+    load_from_storage_lock: Arc<AsyncMutex<()>>,
     epoch_height: BlockNumber,
 }
 
@@ -75,6 +85,11 @@ struct Inner {
     ///
     /// Kept separate from `snapshots` because the lookup is a range query.
     da_committees: BTreeMap<EpochNumber, Arc<DaCommittee>>,
+
+    /// Epochs below this have been evicted by `prune_epochs`.
+    ///
+    /// Only ever moves forward.
+    prune_cutoff: EpochNumber,
 
     first_epoch: Option<EpochNumber>,
 
@@ -485,11 +500,13 @@ impl EpochCommittees {
                 da_committees: BTreeMap::new(),
                 snapshots,
                 all_validators: BTreeMap::new(),
+                prune_cutoff: EpochNumber::genesis(),
                 first_epoch: None,
                 fixed_block_reward,
             })),
             fetcher: Arc::new(fetcher),
             update_fixed_block_reward_lock: Arc::new(AsyncMutex::new(())),
+            load_from_storage_lock: Arc::new(AsyncMutex::new(())),
             epoch_height: epoch_height.into(),
         }
     }
@@ -506,7 +523,7 @@ impl EpochCommittees {
             },
         }
 
-        // Load the 50 latest stored stake tables
+        // Load the `limit` latest stored stake tables
         let loaded_stake = match self
             .fetcher
             .persistence
@@ -674,6 +691,74 @@ impl Membership<SeqTypes> for EpochCommittees {
         self.inner.read().snapshots.get(&epoch).cloned()
     }
 
+    /// Load the committee for `epoch` from storage.
+    ///
+    /// Everything persisted for the epoch is restored: the stake table, the
+    /// epoch root header, and the randomized committee (rebuilt from the DRB
+    /// result).
+    async fn load_stake_table(&self, epoch: EpochNumber) -> bool {
+        if self.inner.read().snapshots.contains_key(&epoch) {
+            return true;
+        }
+        // Ensure there is only one `load_stake_table` at a time:
+        let _guard = self.load_from_storage_lock.lock().await;
+        // Check if someone else won the race:
+        if self.inner.read().snapshots.contains_key(&epoch) {
+            return true;
+        }
+        let persistence = self.fetcher.persistence.lock().await;
+        let stake_table = persistence.load_stake(epoch).await;
+        let (validators, block_reward, stake_table_hash) = match stake_table {
+            Ok(Some(stake)) => stake,
+            Ok(None) => return false,
+            Err(err) => {
+                warn!(%err, "failed to load stake table for epoch {epoch} from persistence");
+                return false;
+            },
+        };
+        let drb = match persistence.load_drb_result(epoch).await {
+            Ok(drb) => drb,
+            Err(err) => {
+                warn!(%err, "failed to load drb result for epoch {epoch} from persistence");
+                None
+            },
+        };
+        let header = match persistence.load_epoch_root(epoch).await {
+            Ok(header) => header,
+            Err(err) => {
+                warn!(%err, "failed to load epoch root for epoch {epoch} from persistence");
+                None
+            },
+        };
+        drop(persistence);
+        info!(
+            %epoch,
+            has_drb = drb.is_some(),
+            has_header = header.is_some(),
+            "stake table loaded from persistence"
+        );
+        let committee = Arc::new(EpochCommittee::new(
+            validators,
+            block_reward,
+            stake_table_hash,
+            header,
+        ));
+        let randomized = drb.map(|drb| {
+            let leaders = committee
+                .eligible_leaders
+                .iter()
+                .map(|peer_config| peer_config.stake_table_entry.clone())
+                .collect();
+            Arc::new(generate_stake_cdf(leaders, drb))
+        });
+        let mut inner = self.inner.write();
+        inner.put_epoch_committee(epoch, committee);
+        if let Some(randomized) = randomized {
+            inner.put_randomized_committee(epoch, randomized);
+        }
+        true
+    }
+
     fn non_epoch_snapshot(&self) -> Self::NonEpochSnapshot {
         self.inner.read().non_epoch_snapshot.clone()
     }
@@ -733,6 +818,8 @@ impl Membership<SeqTypes> for EpochCommittees {
                 .map_err(Self::Error::Fetcher)?;
             block_reward = Some(reward);
         }
+
+        self.load_stake_table(epoch).await;
 
         let epoch_committee = self.inner.read().epoch_committee(epoch).cloned();
 
@@ -840,6 +927,7 @@ impl Membership<SeqTypes> for EpochCommittees {
             // extract `all_validators` for the previous epoch
             previous_validators = inner.all_validators.remove(&previous_epoch);
             inner.all_validators.insert(epoch, all_validators.clone());
+            inner.prune_epochs(epoch);
         }
 
         let persistence_lock = self.fetcher.persistence.lock().await;
@@ -1169,6 +1257,30 @@ impl Inner {
             ),
         );
     }
+
+    /// Evict snapshots more than [`RECENT_STAKE_TABLES_LIMIT`] epochs below
+    /// `added`.
+    ///
+    /// The cutoff only ever moves forward: `add_epoch_root` also runs for old
+    /// epochs during catchup, and a lagging insert must neither evict newer
+    /// state nor evict itself before its readers had a chance to observe it.
+    ///
+    /// `da_committees` is exempt: it holds one entry per configured DA
+    /// committee (seeded from config at startup and on upgrade certificates),
+    /// so it is bounded, and `resolve_da_committee`'s greatest-key-below
+    /// lookup needs the full history for re-inserted old epochs.
+    #[cfg_attr(not(feature = "node"), allow(dead_code))]
+    fn prune_epochs(&mut self, added: EpochNumber) {
+        let cutoff = EpochNumber::new(added.saturating_sub(RECENT_STAKE_TABLES_LIMIT));
+        if cutoff <= self.prune_cutoff {
+            return;
+        }
+        self.prune_cutoff = cutoff;
+        // The snapshots for `first_epoch` and `first_epoch + 1` (seeded by
+        // `set_first_epoch`) are never evicted:
+        let keep = self.first_epoch.unwrap_or_else(EpochNumber::genesis) + 1u64;
+        self.snapshots.retain(|e, _| *e <= keep || *e >= cutoff);
+    }
 }
 
 /// A consistent per-epoch view of `EpochCommittees`.
@@ -1437,6 +1549,10 @@ mod tests {
     const TEST_DURATION: Duration = Duration::from_secs(5);
 
     fn build_committees(num_peers: u64) -> EpochCommittees {
+        build_committees_with_fetcher(num_peers, Fetcher::mock())
+    }
+
+    fn build_committees_with_fetcher(num_peers: u64, fetcher: Fetcher) -> EpochCommittees {
         let peers: Vec<PeerConfig<SeqTypes>> = (0..num_peers)
             .map(|i| {
                 ValidatorConfig::<SeqTypes>::generated_from_seed_indexed(
@@ -1448,7 +1564,166 @@ mod tests {
                 .public_config()
             })
             .collect();
-        EpochCommittees::new_stake(peers.clone(), peers, None, Fetcher::mock(), 100u64)
+        EpochCommittees::new_stake(peers.clone(), peers, None, fetcher, 100u64)
+    }
+
+    /// Persistence stub holding stake tables for epochs 7 and 8, plus a DRB
+    /// result and an epoch root header for epoch 7 only.
+    #[derive(Debug)]
+    struct MockStakeStore {
+        header: Header,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::traits::MembershipPersistence for MockStakeStore {
+        async fn load_stake(
+            &self,
+            epoch: EpochNumber,
+        ) -> anyhow::Result<Option<crate::traits::StakeTuple>> {
+            Ok((*epoch == 7 || *epoch == 8).then(|| (Default::default(), None, None)))
+        }
+
+        async fn load_latest_stake(
+            &self,
+            _limit: u64,
+        ) -> anyhow::Result<Option<Vec<crate::v0_3::IndexedStake>>> {
+            Ok(None)
+        }
+
+        async fn load_drb_result(&self, epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+            Ok((*epoch == 7).then_some([7; 32]))
+        }
+
+        async fn load_epoch_root(&self, epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
+            Ok((*epoch == 7).then(|| self.header.clone()))
+        }
+
+        async fn store_stake(
+            &self,
+            _epoch: EpochNumber,
+            _stake: AuthenticatedValidatorMap,
+            _block_reward: Option<RewardAmount>,
+            _stake_table_hash: Option<StakeTableHash>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn store_events(
+            &self,
+            _l1_finalized: u64,
+            _events: Vec<(crate::v0_3::EventKey, crate::v0_3::StakeTableEvent)>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn load_events(
+            &self,
+            _from_l1_block: u64,
+            _l1_finalized: u64,
+        ) -> anyhow::Result<(
+            Option<crate::traits::EventsPersistenceRead>,
+            Vec<(crate::v0_3::EventKey, crate::v0_3::StakeTableEvent)>,
+        )> {
+            Ok((None, vec![]))
+        }
+
+        async fn delete_stake_tables(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn store_all_validators(
+            &self,
+            _epoch: EpochNumber,
+            _all_validators: IndexMap<Address, crate::v0_3::RegisteredValidator<PubKey>>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn load_all_validators(
+            &self,
+            _epoch: EpochNumber,
+            _offset: u64,
+            _limit: u64,
+        ) -> anyhow::Result<Vec<crate::v0_3::RegisteredValidator<PubKey>>> {
+            Ok(vec![])
+        }
+    }
+
+    // `load_stake_table` materializes a snapshot from the persisted stake
+    // table (e.g. after eviction by `prune_epochs`) without network catchup,
+    // including the randomized committee and the epoch root header when
+    // they are persisted.
+    #[tokio::test]
+    async fn restore_stake_table_from_persistence() {
+        let store = MockStakeStore {
+            header: build_epoch_root_header().await,
+        };
+        let fetcher = Fetcher::new(
+            Arc::new(crate::mock::MockStateCatchup::default()),
+            Arc::new(AsyncMutex::new(store)),
+            crate::L1Client::new(vec!["http://localhost:3331".parse().unwrap()])
+                .expect("Failed to create L1 client"),
+            crate::ChainConfig::default(),
+        );
+        let committees = build_committees_with_fetcher(4, fetcher);
+
+        // Epoch 7 has a stake table, a DRB result and a root header in storage.
+        let seven = EpochNumber::new(7);
+        assert!(committees.snapshot(seven).is_none());
+        assert!(committees.load_stake_table(seven).await);
+        let snapshot = committees.snapshot(seven).unwrap();
+        assert!(snapshot.has_drb());
+        assert!(snapshot.inner.committee.header.is_some());
+        // A second call is satisfied by the in-memory snapshot.
+        assert!(committees.load_stake_table(seven).await);
+        // Epoch 8 has a stake table but no DRB result and no root header.
+        let eight = EpochNumber::new(8);
+        assert!(committees.load_stake_table(eight).await);
+        let snapshot = committees.snapshot(eight).unwrap();
+        assert!(!snapshot.has_drb());
+        assert!(snapshot.inner.committee.header.is_none());
+        // Nothing persisted for epoch 9.
+        assert!(!committees.load_stake_table(EpochNumber::new(9)).await);
+    }
+
+    // `prune_epochs` keeps a bounded window behind the newest decided epoch
+    // plus the first-epoch seeds (catchup anchors), and its cutoff never
+    // regresses when an older epoch is (re-)inserted during catchup.
+    #[test]
+    fn prune_epochs_keeps_recent_window() {
+        let committees = build_committees(4);
+        let mut inner = committees.inner.write();
+        inner.first_epoch = Some(EpochNumber::new(1));
+        let template = inner
+            .epoch_committee(EpochNumber::genesis())
+            .expect("genesis committee exists")
+            .clone();
+
+        for e in 2..=50 {
+            inner.put_epoch_committee(EpochNumber::new(e), template.clone());
+            inner.prune_epochs(EpochNumber::new(e));
+        }
+
+        // The seeds for `first_epoch` and `first_epoch + 1` survive, then
+        // nothing until the cutoff.
+        let cutoff = EpochNumber::new(50 - RECENT_STAKE_TABLES_LIMIT);
+        let expected: Vec<EpochNumber> = [1, 2]
+            .into_iter()
+            .chain(*cutoff..=50)
+            .map(EpochNumber::new)
+            .collect();
+        assert_eq!(
+            inner.snapshots.keys().copied().collect::<Vec<_>>(),
+            expected
+        );
+
+        // A catchup insert below the cutoff is not evicted by its own
+        // insertion; it goes once the tip advances past it.
+        inner.put_epoch_committee(EpochNumber::new(5), template);
+        inner.prune_epochs(EpochNumber::new(5));
+        assert!(inner.snapshots.contains_key(&EpochNumber::new(5)));
+        inner.prune_epochs(EpochNumber::new(51));
+        assert!(!inner.snapshots.contains_key(&EpochNumber::new(5)));
     }
 
     // Concurrent reads must not panic or deadlock while a writer drives

--- a/crates/espresso/types/src/v0/impls/instance_state.rs
+++ b/crates/espresso/types/src/v0/impls/instance_state.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 #[cfg(feature = "node")]
 use hotshot_contract_adapter::sol_types::{LightClientV3, StakeTableV3};
 use hotshot_types::{
-    HotShotConfig, data::EpochNumber, epoch_membership::EpochMembershipCoordinator,
+    HotShotConfig, data::EpochNumber, drb::DrbResult, epoch_membership::EpochMembershipCoordinator,
     traits::states::InstanceState,
 };
 use moka::future::Cache;
@@ -25,7 +25,7 @@ use super::{
 #[cfg(feature = "node")]
 use crate::v0::L1Client;
 use crate::{
-    AuthenticatedValidatorMap, PubKey, RegisteredValidatorMap,
+    AuthenticatedValidatorMap, Header, PubKey, RegisteredValidatorMap,
     v0::{
         GenesisHeader, L1BlockInfo, Timestamp, Upgrade, UpgradeMode,
         impls::{StakeTableHash, fetch_and_calculate_block_reward, reward::EpochRewardsCalculator},
@@ -175,6 +175,14 @@ impl MembershipPersistence for NoStorage {
     }
 
     async fn load_latest_stake(&self, _limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>> {
+        Ok(None)
+    }
+
+    async fn load_drb_result(&self, _epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+        Ok(None)
+    }
+
+    async fn load_epoch_root(&self, _epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
         Ok(None)
     }
 

--- a/crates/espresso/types/src/v0/impls/mod.rs
+++ b/crates/espresso/types/src/v0/impls/mod.rs
@@ -13,7 +13,8 @@ mod state;
 mod transaction;
 
 pub use committee::{
-    EpochCommittees, EpochCommitteesError, EpochSnapshot, fetch_and_calculate_block_reward,
+    EpochCommittees, EpochCommitteesError, EpochSnapshot, RECENT_STAKE_TABLES_LIMIT,
+    fetch_and_calculate_block_reward,
 };
 pub use fee_info::{FeeError, retain_accounts};
 #[cfg(any(test, feature = "testing"))]

--- a/crates/espresso/types/src/v0/mod.rs
+++ b/crates/espresso/types/src/v0/mod.rs
@@ -27,8 +27,8 @@ pub use impls::reward::{
 pub use impls::testing;
 pub use impls::{
     BuilderValidationError, EpochCommittees, EpochCommitteesError, EpochSnapshot, FeeError,
-    ProposalValidationError, StateValidationError, ValidatorSet, get_l1_deposits, retain_accounts,
-    validators_from_l1_events,
+    ProposalValidationError, RECENT_STAKE_TABLES_LIMIT, StateValidationError, ValidatorSet,
+    get_l1_deposits, retain_accounts, validators_from_l1_events,
 };
 pub use nsproof::*;
 pub use txproof::*;

--- a/crates/espresso/types/src/v0/traits.rs
+++ b/crates/espresso/types/src/v0/traits.rs
@@ -24,7 +24,7 @@ use hotshot_types::{
         DaProposal, DaProposal2, QuorumProposal, QuorumProposal2, QuorumProposalWrapper,
         VidCommitment, VidDisperseShare,
     },
-    drb::{DrbInput, DrbResult},
+    drb::DrbInput,
     event::{HotShotAction, LeafInfo},
     message::{Proposal, convert_proposal},
     simple_certificate::{
@@ -40,6 +40,7 @@ use hotshot_types::{
 };
 use hotshot_types::{
     data::{EpochNumber, ViewNumber},
+    drb::DrbResult,
     epoch_membership::EpochMembershipCoordinator,
     new_protocol::CoordinatorEvent,
     simple_certificate::LightClientStateUpdateCertificateV2,
@@ -56,7 +57,7 @@ use super::{
 };
 use crate::{
     AuthenticatedValidatorMap, BlockMerkleTree, FeeAccount, FeeAccountProof, FeeMerkleCommitment,
-    Leaf2, PubKey, SeqTypes,
+    Header, Leaf2, PubKey, SeqTypes,
     v0::impls::StakeTableHash,
     v0_3::{
         ChainConfig, RegisteredValidator, RewardAccountProofV1, RewardAccountV1, RewardAmount,
@@ -520,6 +521,12 @@ pub trait MembershipPersistence: Send + Sync + 'static {
 
     /// Load stake tables for storage for latest `n` known epochs
     async fn load_latest_stake(&self, limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>>;
+
+    /// Load the DRB result for `epoch`.
+    async fn load_drb_result(&self, epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>>;
+
+    /// Load the epoch root block header for `epoch`.
+    async fn load_epoch_root(&self, epoch: EpochNumber) -> anyhow::Result<Option<Header>>;
 
     /// Store stake table at `epoch` in the persistence layer
     async fn store_stake(

--- a/crates/hotshot/example-types/src/membership/strict_membership.rs
+++ b/crates/hotshot/example-types/src/membership/strict_membership.rs
@@ -294,6 +294,10 @@ where
             committee.into_iter().map(Into::into).collect(),
         );
     }
+
+    async fn load_stake_table(&self, _: EpochNumber) -> bool {
+        false
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/hotshot/new-protocol/bench/src/metrics.rs
+++ b/crates/hotshot/new-protocol/bench/src/metrics.rs
@@ -70,7 +70,7 @@ impl MetricsCollector {
                 self.view_mut(v).vid_disperse_ns = Some(ts);
             },
             // Replica: proposal processing
-            ConsensusInput::ProposalWithVidShare(_sender, p, _) => {
+            ConsensusInput::Proposal(_sender, p) => {
                 let v = *p.view_number();
                 self.view_mut(v).proposal_recv_ns = Some(ts);
             },

--- a/crates/hotshot/new-protocol/bench/src/node.rs
+++ b/crates/hotshot/new-protocol/bench/src/node.rs
@@ -10,6 +10,7 @@ use hotshot_example_types::{
 };
 use hotshot_new_protocol::{
     block::{BlockBuilder, BlockBuilderConfig},
+    cert_verifier::CertVerifiers,
     client::CoordinatorClient,
     consensus::{Consensus, ConsensusInput, ConsensusOutput},
     coordinator::{Coordinator, timer::Timer},
@@ -201,6 +202,7 @@ async fn build_coordinator(
         .timeout_collector(timeout_collector)
         .timeout_one_honest_collector(timeout_one_honest_collector)
         .epoch_root_collector(epoch_root_collector)
+        .cert_verifiers(CertVerifiers::new(membership.clone(), upgrade_lock.clone()))
         .vid_disperser(vid_disperser)
         .vid_reconstructor(vid_reconstructor)
         .epoch_manager(epoch_manager)

--- a/crates/hotshot/new-protocol/src/cert_verifier.rs
+++ b/crates/hotshot/new-protocol/src/cert_verifier.rs
@@ -1,0 +1,500 @@
+use std::{
+    any::type_name,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::Display,
+    hash::Hash,
+    mem,
+    ops::Deref,
+};
+
+use alloy::primitives::U256;
+use hotshot_types::{
+    data::{EpochNumber, ViewNumber},
+    epoch_membership::EpochMembershipCoordinator,
+    message::UpgradeLock,
+    simple_certificate::{
+        Certificate1, Certificate2, SimpleCertificate, Threshold, TimeoutCertificate2,
+    },
+    simple_vote::{HasEpoch, Voteable},
+    stake_table::StakeTableEntries,
+    traits::{node_implementation::NodeType, signature_key::SignatureKey},
+    vote::{Certificate, HasViewNumber},
+};
+use hotshot_utils::anytrace::Result;
+use tokio_util::task::JoinMap;
+use tracing::{error, warn};
+
+use crate::message::{EpochChangeMessage, Unchecked, Validated};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ValidCert<C> {
+    cert: C,
+    epoch: EpochNumber,
+}
+
+impl<C> ValidCert<C> {
+    pub(crate) fn new(cert: C, epoch: EpochNumber) -> Self {
+        Self { cert, epoch }
+    }
+
+    pub fn cert(&self) -> &C {
+        &self.cert
+    }
+
+    pub fn epoch(&self) -> EpochNumber {
+        self.epoch
+    }
+
+    pub fn into_cert(self) -> C {
+        self.cert
+    }
+}
+
+impl<C> Deref for ValidCert<C> {
+    type Target = C;
+
+    fn deref(&self) -> &Self::Target {
+        self.cert()
+    }
+}
+
+impl<C: HasViewNumber> HasViewNumber for ValidCert<C> {
+    fn view_number(&self) -> ViewNumber {
+        self.cert.view_number()
+    }
+}
+
+pub trait Verifiable<T: NodeType>: HasViewNumber + HasEpoch + Sized {
+    /// Identifies the `Verifiable`, e.g. `ViewNumber` or `EpochNumber`.
+    type Key: Copy + Ord + Hash + Display + Send + Sync + 'static;
+
+    type Output: Send + 'static;
+
+    fn key(&self) -> Option<Self::Key>;
+
+    fn check(
+        self,
+        stake_table: &[<T::SignatureKey as SignatureKey>::StakeTableEntry],
+        threshold: U256,
+        upgrade_lock: &UpgradeLock<T>,
+    ) -> Result<Self::Output>;
+}
+
+impl<T, D, V> Verifiable<T> for SimpleCertificate<T, D, V>
+where
+    T: NodeType,
+    D: Voteable<T> + HasEpoch + 'static,
+    V: Threshold<T>,
+    Self: Certificate<T, D> + Send + 'static,
+{
+    type Key = ViewNumber;
+    type Output = Self;
+
+    fn key(&self) -> Option<ViewNumber> {
+        Some(self.view_number())
+    }
+
+    fn check(
+        self,
+        stake_table: &[<T::SignatureKey as SignatureKey>::StakeTableEntry],
+        threshold: U256,
+        upgrade_lock: &UpgradeLock<T>,
+    ) -> Result<Self> {
+        self.is_valid_cert(stake_table, threshold, upgrade_lock)?;
+        Ok(self)
+    }
+}
+
+impl<T: NodeType> Verifiable<T> for EpochChangeMessage<T, Unchecked> {
+    type Key = EpochNumber;
+    type Output = EpochChangeMessage<T, Validated>;
+
+    fn key(&self) -> Option<EpochNumber> {
+        self.epoch()
+    }
+
+    fn check(
+        self,
+        stake_table: &[<T::SignatureKey as SignatureKey>::StakeTableEntry],
+        threshold: U256,
+        upgrade_lock: &UpgradeLock<T>,
+    ) -> Result<Self::Output> {
+        self.cert1
+            .is_valid_cert(stake_table, threshold, upgrade_lock)?;
+        self.cert2
+            .is_valid_cert(stake_table, threshold, upgrade_lock)?;
+        Ok(self.into_validated())
+    }
+}
+
+/// Verifies certificates off the main coordinator thread.
+///
+/// The threshold-signature check is slow (> 1ms), so running it inline would
+/// stall the consensus loop. Each item's check runs in a `spawn_blocking`
+/// task; `next()` yields only those that pass. An item whose epoch
+/// membership isn't known yet is held in `pending_membership` and retried on
+/// [`Self::retry_pending`].
+///
+/// Items are deduplicated per ([`Verifiable::Key`], sender) and verified one
+/// at a time per key, trying the next sender's item if one proves invalid; a
+/// faulty sender can neither shadow a key nor hold more than one slot per
+/// key. Since intake bounds the key space, memory is bounded by (admissible
+/// keys * committee size).
+pub struct CertVerifier<T: NodeType, C: Verifiable<T>> {
+    tasks: JoinMap<C::Key, Option<ValidCert<C::Output>>>,
+    pending_task: BTreeMap<C::Key, HashMap<T::SignatureKey, C>>,
+    pending_membership: BTreeMap<C::Key, HashMap<T::SignatureKey, C>>,
+    completed: BTreeSet<C::Key>,
+    lower_bound: Option<C::Key>,
+    membership: EpochMembershipCoordinator<T>,
+    upgrade_lock: UpgradeLock<T>,
+    invalid_certs: u64,
+}
+
+impl<T: NodeType, C: Verifiable<T> + Send + 'static> CertVerifier<T, C> {
+    pub fn new(membership: EpochMembershipCoordinator<T>, upgrade_lock: UpgradeLock<T>) -> Self {
+        Self {
+            tasks: JoinMap::new(),
+            pending_task: BTreeMap::new(),
+            pending_membership: BTreeMap::new(),
+            completed: BTreeSet::new(),
+            lower_bound: None,
+            membership,
+            upgrade_lock,
+            invalid_certs: 0,
+        }
+    }
+
+    /// Submit an item received from the network for verification. If the
+    /// epoch's membership isn't ready the item is held and its epoch returned
+    /// so the caller can drive that epoch's catchup. Duplicates are dropped.
+    pub fn verify(&mut self, sender: T::SignatureKey, cert: C) -> Option<EpochNumber> {
+        let Some(key) = cert.key() else {
+            warn!(cert = type_name::<C>(), "certificate has no key");
+            return None;
+        };
+
+        let Some(epoch) = cert.epoch() else {
+            warn!(%key, cert = type_name::<C>(), "certificate has no epoch number");
+            return None;
+        };
+
+        if self.is_stale(key) || self.completed.contains(&key) {
+            return None;
+        }
+
+        if let Some(senders) = self.pending_task.get(&key)
+            && senders.contains_key(&sender)
+        {
+            return None;
+        }
+
+        if let Some(senders) = self.pending_membership.get(&key)
+            && senders.contains_key(&sender)
+        {
+            return None;
+        }
+
+        if self.tasks.contains_key(&key) {
+            self.pending_task
+                .entry(key)
+                .or_default()
+                .insert(sender, cert);
+            return None;
+        }
+
+        let Ok(membership) = self.membership.membership_for_epoch(Some(epoch)) else {
+            self.pending_membership
+                .entry(key)
+                .or_default()
+                .insert(sender, cert);
+            return Some(epoch);
+        };
+
+        let lock = self.upgrade_lock.clone();
+
+        self.tasks.spawn_blocking(key, move || {
+            let entries = StakeTableEntries::from_iter(membership.stake_table()).0;
+            let threshold = membership.success_threshold();
+            match cert.check(&entries, threshold, &lock) {
+                Ok(valid) => Some(ValidCert::new(valid, epoch)),
+                Err(err) => {
+                    warn!(%key, %epoch, %err, cert = type_name::<C>(), "invalid certificate");
+                    None
+                },
+            }
+        });
+
+        None
+    }
+
+    /// Record that this key's item was completed by other means.
+    ///
+    /// This can happen locally from votes for example.
+    pub fn mark_completed(&mut self, key: C::Key) {
+        if self.is_stale(key) {
+            return;
+        }
+        self.completed.insert(key);
+        self.pending_task.remove(&key);
+        self.pending_membership.remove(&key);
+        self.tasks.abort(&key);
+    }
+
+    /// Re-attempt any items deferred because their epoch stake table wasn't
+    /// available. Called when new epoch data arrives. Returns the epochs
+    /// whose stake table is still missing so the caller can keep driving their
+    /// catchup.
+    pub fn retry_pending(&mut self) -> Vec<EpochNumber> {
+        mem::take(&mut self.pending_membership)
+            .into_values()
+            .flatten()
+            .filter_map(|(sender, cert)| self.verify(sender, cert))
+            .collect()
+    }
+
+    pub async fn next(&mut self) -> Option<ValidCert<C::Output>> {
+        loop {
+            match self.tasks.join_next().await? {
+                (key, Ok(Some(cert))) => {
+                    if !self.is_stale(key) {
+                        self.completed.insert(key);
+                        self.pending_task.remove(&key);
+                        self.pending_membership.remove(&key);
+                        return Some(cert);
+                    }
+                },
+                (key, Ok(None)) => {
+                    self.invalid_certs += 1;
+                    if !self.is_stale(key)
+                        && let Some((sender, cert)) = self.next_pending_sender(key)
+                    {
+                        self.verify(sender, cert);
+                    }
+                },
+                (key, Err(err)) => {
+                    if err.is_panic() {
+                        error!(%key, %err, cert = type_name::<C>(), "cert verification task panic");
+                    }
+                    if !self.is_stale(key)
+                        && let Some((sender, cert)) = self.next_pending_sender(key)
+                    {
+                        self.verify(sender, cert);
+                    }
+                },
+            }
+        }
+    }
+
+    pub fn gc(&mut self, key: C::Key) {
+        self.completed = self.completed.split_off(&key);
+        self.pending_task = self.pending_task.split_off(&key);
+        self.pending_membership = self.pending_membership.split_off(&key);
+        self.lower_bound = Some(key);
+        self.tasks.abort_matching(|k| *k < key);
+    }
+
+    pub fn num_invalid_certs(&self) -> u64 {
+        self.invalid_certs
+    }
+
+    fn next_pending_sender(&mut self, k: C::Key) -> Option<(T::SignatureKey, C)> {
+        let map = self.pending_task.get_mut(&k)?;
+        let sender = map.keys().next().cloned()?;
+        let cert = map.remove(&sender)?;
+        if map.is_empty() {
+            self.pending_task.remove(&k);
+        }
+        Some((sender, cert))
+    }
+
+    fn is_stale(&self, key: C::Key) -> bool {
+        self.lower_bound.is_some_and(|lb| key < lb)
+    }
+}
+
+/// Verifies certificates off the main coordinator thread.
+///
+/// Unlike [`CertVerifier`], these certificates are keyed by sender key
+/// instead of view/epoch, helping a lagging node jump to the frontier. While a
+/// certificate is verified, subsequent requests are dropped which bounds each
+/// peer to one verification at a time.
+pub struct CertBySenderVerifier<T: NodeType, C: Verifiable<T>> {
+    tasks: JoinMap<T::SignatureKey, Option<ValidCert<C::Output>>>,
+    pending: HashMap<T::SignatureKey, C>,
+    completed: BTreeSet<ViewNumber>,
+    lower_bound: ViewNumber,
+    membership: EpochMembershipCoordinator<T>,
+    upgrade_lock: UpgradeLock<T>,
+    invalid_certs: u64,
+}
+
+impl<T: NodeType, C: Verifiable<T> + Send + 'static> CertBySenderVerifier<T, C>
+where
+    C::Output: HasViewNumber,
+{
+    pub fn new(membership: EpochMembershipCoordinator<T>, upgrade_lock: UpgradeLock<T>) -> Self {
+        Self {
+            tasks: JoinMap::new(),
+            pending: HashMap::new(),
+            completed: BTreeSet::new(),
+            lower_bound: ViewNumber::genesis(),
+            membership,
+            upgrade_lock,
+            invalid_certs: 0,
+        }
+    }
+
+    /// Submit an item received from `sender` for verification.
+    ///
+    /// Dropped if the sender's previous submission is still being verified. If
+    /// the epoch's membership isn't ready the item is held and its epoch
+    /// returned so the caller can drive that epoch's catchup.
+    pub fn verify(&mut self, sender: T::SignatureKey, cert: C) -> Option<EpochNumber> {
+        let view = cert.view_number();
+
+        if view < self.lower_bound
+            || self.completed.contains(&view)
+            || self.tasks.contains_key(&sender)
+        {
+            return None;
+        }
+
+        let Some(epoch) = cert.epoch() else {
+            warn!(%view, cert = type_name::<C>(), "received certificate has no epoch number");
+            return None;
+        };
+
+        let Ok(membership) = self.membership.membership_for_epoch(Some(epoch)) else {
+            self.pending.insert(sender, cert);
+            return Some(epoch);
+        };
+
+        let lock = self.upgrade_lock.clone();
+
+        self.tasks.spawn_blocking(sender, move || {
+            let entries = StakeTableEntries::from_iter(membership.stake_table()).0;
+            let threshold = membership.success_threshold();
+            match cert.check(&entries, threshold, &lock) {
+                Ok(valid) => Some(ValidCert::new(valid, epoch)),
+                Err(err) => {
+                    warn!(%view, %epoch, %err, cert = type_name::<C>(), "invalid certificate");
+                    None
+                },
+            }
+        });
+
+        None
+    }
+
+    /// Record that this view's item was completed by other means.
+    ///
+    /// This can happen locally from votes for example.
+    pub fn mark_completed(&mut self, view: ViewNumber) {
+        if view < self.lower_bound {
+            return;
+        }
+        self.completed.insert(view);
+        self.pending.retain(|_, c| c.view_number() != view);
+    }
+
+    /// Re-attempt any items deferred because their epoch stake table wasn't
+    /// available. Returns the epochs whose stake table is still missing so
+    /// the caller can keep driving their catchup.
+    pub fn retry_pending(&mut self) -> Vec<EpochNumber> {
+        mem::take(&mut self.pending)
+            .into_iter()
+            .filter_map(|(sender, cert)| self.verify(sender, cert))
+            .collect()
+    }
+
+    pub async fn next(&mut self) -> Option<ValidCert<C::Output>> {
+        loop {
+            match self.tasks.join_next().await? {
+                (_, Ok(Some(cert))) => {
+                    let view = cert.view_number();
+                    if view >= self.lower_bound && self.completed.insert(view) {
+                        return Some(cert);
+                    }
+                },
+                (_, Ok(None)) => {
+                    self.invalid_certs += 1;
+                },
+                (sender, Err(err)) => {
+                    if err.is_panic() {
+                        error!(?sender, %err, cert = type_name::<C>(), "cert verification task panic");
+                    }
+                },
+            }
+        }
+    }
+
+    pub fn gc(&mut self, view: ViewNumber) {
+        self.completed = self.completed.split_off(&view);
+        self.pending.retain(|_, c| c.view_number() >= view);
+        self.lower_bound = view;
+    }
+
+    pub fn num_invalid_certs(&self) -> u64 {
+        self.invalid_certs
+    }
+}
+
+/// The coordinator's network-certificate verifiers, one per certificate type.
+pub struct CertVerifiers<T: NodeType> {
+    pub cert1: CertVerifier<T, Certificate1<T>>,
+    pub cert2: CertVerifier<T, Certificate2<T>>,
+    pub timeout: CertBySenderVerifier<T, TimeoutCertificate2<T>>,
+    pub advance: CertBySenderVerifier<T, Certificate1<T>>,
+    pub epoch_change: CertVerifier<T, EpochChangeMessage<T, Unchecked>>,
+}
+
+impl<T: NodeType> CertVerifiers<T> {
+    pub fn new(membership: EpochMembershipCoordinator<T>, upgrade_lock: UpgradeLock<T>) -> Self {
+        Self {
+            cert1: CertVerifier::new(membership.clone(), upgrade_lock.clone()),
+            cert2: CertVerifier::new(membership.clone(), upgrade_lock.clone()),
+            timeout: CertBySenderVerifier::new(membership.clone(), upgrade_lock.clone()),
+            advance: CertBySenderVerifier::new(membership.clone(), upgrade_lock.clone()),
+            epoch_change: CertVerifier::new(membership, upgrade_lock),
+        }
+    }
+
+    pub fn retry_pending<F>(&mut self, mut request: F)
+    where
+        F: FnMut(EpochNumber),
+    {
+        for epoch in self.cert1.retry_pending() {
+            request(epoch);
+        }
+        for epoch in self.cert2.retry_pending() {
+            request(epoch);
+        }
+        for epoch in self.timeout.retry_pending() {
+            request(epoch);
+        }
+        for epoch in self.advance.retry_pending() {
+            request(epoch);
+        }
+        for epoch in self.epoch_change.retry_pending() {
+            request(epoch);
+        }
+    }
+
+    pub fn gc(&mut self, view: ViewNumber, epoch: EpochNumber) {
+        self.cert1.gc(view);
+        self.cert2.gc(view);
+        self.timeout.gc(view);
+        self.advance.gc(view);
+        self.epoch_change.gc(epoch);
+    }
+
+    pub fn num_invalid_certs(&self) -> u64 {
+        self.cert1
+            .num_invalid_certs()
+            .saturating_add(self.cert2.num_invalid_certs())
+            .saturating_add(self.timeout.num_invalid_certs())
+            .saturating_add(self.advance.num_invalid_certs())
+            .saturating_add(self.epoch_change.num_invalid_certs())
+    }
+}

--- a/crates/hotshot/new-protocol/src/cert_verifier.rs
+++ b/crates/hotshot/new-protocol/src/cert_verifier.rs
@@ -20,7 +20,7 @@ use hotshot_types::{
     traits::{node_implementation::NodeType, signature_key::SignatureKey},
     vote::{Certificate, HasViewNumber},
 };
-use hotshot_utils::anytrace::Result;
+use hotshot_utils::anytrace::{Result, Wrap};
 use tokio_util::task::JoinMap;
 use tracing::{error, warn};
 
@@ -76,6 +76,7 @@ pub trait Verifiable<T: NodeType>: HasViewNumber + HasEpoch + Sized {
         self,
         stake_table: &[<T::SignatureKey as SignatureKey>::StakeTableEntry],
         threshold: U256,
+        epoch_height: u64,
         upgrade_lock: &UpgradeLock<T>,
     ) -> Result<Self::Output>;
 }
@@ -98,6 +99,7 @@ where
         self,
         stake_table: &[<T::SignatureKey as SignatureKey>::StakeTableEntry],
         threshold: U256,
+        _epoch_height: u64,
         upgrade_lock: &UpgradeLock<T>,
     ) -> Result<Self> {
         self.is_valid_cert(stake_table, threshold, upgrade_lock)?;
@@ -117,8 +119,10 @@ impl<T: NodeType> Verifiable<T> for EpochChangeMessage<T, Unchecked> {
         self,
         stake_table: &[<T::SignatureKey as SignatureKey>::StakeTableEntry],
         threshold: U256,
+        epoch_height: u64,
         upgrade_lock: &UpgradeLock<T>,
     ) -> Result<Self::Output> {
+        self.well_formed(epoch_height).wrap()?;
         self.cert1
             .is_valid_cert(stake_table, threshold, upgrade_lock)?;
         self.cert2
@@ -212,11 +216,12 @@ impl<T: NodeType, C: Verifiable<T> + Send + 'static> CertVerifier<T, C> {
         };
 
         let lock = self.upgrade_lock.clone();
+        let epoch_height = *self.membership.epoch_height();
 
         self.tasks.spawn_blocking(key, move || {
             let entries = StakeTableEntries::from_iter(membership.stake_table()).0;
             let threshold = membership.success_threshold();
-            match cert.check(&entries, threshold, &lock) {
+            match cert.check(&entries, threshold, epoch_height, &lock) {
                 Ok(valid) => Some(ValidCert::new(valid, epoch)),
                 Err(err) => {
                     warn!(%key, %epoch, %err, cert = type_name::<C>(), "invalid certificate");
@@ -371,11 +376,12 @@ where
         };
 
         let lock = self.upgrade_lock.clone();
+        let epoch_height = *self.membership.epoch_height();
 
         self.tasks.spawn_blocking(sender, move || {
             let entries = StakeTableEntries::from_iter(membership.stake_table()).0;
             let threshold = membership.success_threshold();
-            match cert.check(&entries, threshold, &lock) {
+            match cert.check(&entries, threshold, epoch_height, &lock) {
                 Ok(valid) => Some(ValidCert::new(valid, epoch)),
                 Err(err) => {
                     warn!(%view, %epoch, %err, cert = type_name::<C>(), "invalid certificate");

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -102,11 +102,12 @@ pub enum ConsensusInput<T: NodeType> {
     },
     EpochChange(EpochChangeMessage<T>),
     HeaderCreated(ViewNumber, Commitment<Leaf2<T>>, T::BlockHeader),
-    ProposalWithVidShare(
-        T::SignatureKey,
-        ProposalMessage<T, Validated>,
-        VidDisperseShare2<T>,
-    ),
+    /// A validated proposal. Consensus parks it until this node's VID share
+    /// for the same payload arrives ([`ConsensusInput::VidShare`]) and only
+    /// processes the two together.
+    Proposal(T::SignatureKey, ProposalMessage<T, Validated>),
+    /// This node's validated VID share.
+    VidShare(VidDisperseShare2<T>),
     FetchedProposal(ProposalMessage<T, Validated>),
     StateValidated(StateResponse<T>),
     StateValidationFailed(StateResponse<T>),
@@ -156,6 +157,11 @@ pub enum ConsensusOutput<T: NodeType> {
     ViewChanged(ViewNumber, EpochNumber),
     /// A view timed out with a timeout certificate.
     ViewTimedOut(ViewNumber),
+    /// A validated proposal met this node's VID share.
+    ProposalPaired {
+        proposal: SignedProposal<T, Proposal<T>>,
+        vid_share: VidDisperseShare2<T>,
+    },
     ProposalValidated {
         proposal: SignedProposal<T, Proposal<T>>,
         sender: T::SignatureKey,
@@ -178,6 +184,13 @@ pub enum ConsensusOutput<T: NodeType> {
     BroadcastVidShare(VidDisperseShare2<T>),
 }
 
+type UnpairedProposals<T> = BTreeMap<
+    (ViewNumber, VidCommitment2),
+    (<T as NodeType>::SignatureKey, ProposalMessage<T, Validated>),
+>;
+
+type UnpairedVidShares<T> = BTreeMap<(ViewNumber, VidCommitment2), VidDisperseShare2<T>>;
+
 /// Views to retain decide inputs (`proposals`, `certs`, `certs2`) behind the
 /// decided view, letting a late-broadcast Cert2 decide an older gap view.
 pub(crate) const DECIDE_BUFFER: u64 = 20;
@@ -190,6 +203,8 @@ pub struct Consensus<T: NodeType> {
     signed_proposals: BTreeMap<ViewNumber, SignedProposal<T, Proposal<T>>>,
     proposed_views: BTreeSet<ViewNumber>,
     vid_shares: BTreeMap<ViewNumber, VidDisperseShare2<T>>,
+    unpaired_proposals: UnpairedProposals<T>,
+    unpaired_vid_shares: UnpairedVidShares<T>,
     states_verified: BTreeMap<ViewNumber, Commitment<Leaf2<T>>>,
     blocks_reconstructed: BTreeSet<(ViewNumber, VidCommitment2)>,
     blocks: BTreeMap<(ViewNumber, VidCommitment2), T::BlockPayload>,
@@ -369,6 +384,8 @@ impl<T: NodeType> Consensus<T> {
             state_certs: BTreeMap::new(),
             upgrade_lock,
             vid_shares: BTreeMap::new(),
+            unpaired_proposals: BTreeMap::new(),
+            unpaired_vid_shares: BTreeMap::new(),
             epoch_height: epoch_height.into(),
         }
     }
@@ -659,14 +676,18 @@ impl<T: NodeType> Consensus<T> {
             input.view_number()
         };
         let proto = match input {
-            ConsensusInput::ProposalWithVidShare(sender, proposal, vid_share) => {
+            ConsensusInput::Proposal(sender, proposal) => {
                 debug!(
                     sender = %KeyPrefix::from(&sender),
                     block = %proposal.proposal.data.block_header.block_number(),
                     epoch = %proposal.proposal.data.epoch,
-                    "apply: proposal+vid share"
+                    "apply: proposal"
                 );
-                self.handle_proposal_with_vid_share(sender, proposal, vid_share, outbox)
+                self.pair_proposal(sender, proposal, outbox)
+            },
+            ConsensusInput::VidShare(vid_share) => {
+                debug!("apply: vid share");
+                self.pair_vid_share(vid_share, outbox)
             },
             ConsensusInput::FetchedProposal(message) => {
                 debug!(
@@ -946,7 +967,10 @@ impl<T: NodeType> Consensus<T> {
         match scope {
             GcScope::Local(view) => {
                 let c = Commitment::default_commitment_no_preimage();
+                let vc = VidCommitment2::default();
                 self.headers = self.headers.split_off(&(view, c));
+                self.unpaired_proposals = self.unpaired_proposals.split_off(&(view, vc));
+                self.unpaired_vid_shares = self.unpaired_vid_shares.split_off(&(view, vc));
                 self.proposed_views = self.proposed_views.split_off(&view);
                 self.states_verified = self.states_verified.split_off(&view);
                 self.timeout_certs = self.timeout_certs.split_off(&view);
@@ -1007,6 +1031,64 @@ impl<T: NodeType> Consensus<T> {
     #[cfg(test)]
     pub(crate) fn force_set_proposal(&mut self, view: ViewNumber, proposal: Proposal<T>) {
         self.proposals.insert(view, proposal);
+    }
+
+    /// Pair a validated proposal with this node's VID share for the same payload.
+    ///
+    /// The half arriving first is parked, keyed by (view, payload commitment).
+    fn pair_proposal(
+        &mut self,
+        sender: T::SignatureKey,
+        proposal: ProposalMessage<T, Validated>,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) -> Protocol {
+        let view = proposal.view_number();
+        let VidCommitment::V2(commit) = proposal.proposal.data.block_header.payload_commitment()
+        else {
+            warn!(%view, "proposal payload commitment is not V2, discarding");
+            return Protocol::Abort;
+        };
+        let Some(vid_share) = self.unpaired_vid_shares.remove(&(view, commit)) else {
+            self.unpaired_proposals
+                .insert((view, commit), (sender, proposal));
+            return Protocol::Abort;
+        };
+        self.on_proposal_paired(sender, proposal, vid_share, outbox)
+    }
+
+    /// Pair this node's VID share with a validated proposal for the same payload.
+    ///
+    /// The half arriving first is parked, keyed by (view, payload commitment).
+    fn pair_vid_share(
+        &mut self,
+        vid_share: VidDisperseShare2<T>,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) -> Protocol {
+        let key = (vid_share.view_number(), vid_share.payload_commitment);
+        let Some((sender, proposal)) = self.unpaired_proposals.remove(&key) else {
+            self.unpaired_vid_shares.insert(key, vid_share);
+            return Protocol::Abort;
+        };
+        self.on_proposal_paired(sender, proposal, vid_share, outbox)
+    }
+
+    fn on_proposal_paired(
+        &mut self,
+        sender: T::SignatureKey,
+        proposal: ProposalMessage<T, Validated>,
+        vid_share: VidDisperseShare2<T>,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) -> Protocol {
+        // Parked halves for this and older views can no longer pair.
+        let view = proposal.view_number();
+        let vc = VidCommitment2::default();
+        self.unpaired_proposals = self.unpaired_proposals.split_off(&(view + 1, vc));
+        self.unpaired_vid_shares = self.unpaired_vid_shares.split_off(&(view + 1, vc));
+        outbox.push_back(ConsensusOutput::ProposalPaired {
+            proposal: proposal.proposal.clone(),
+            vid_share: vid_share.clone(),
+        });
+        self.handle_proposal_with_vid_share(sender, proposal, vid_share, outbox)
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -2645,7 +2727,8 @@ impl<T: NodeType> ConsensusInput<T> {
             ConsensusInput::AdvanceView(cert) => cert.view_number() + 1,
             ConsensusInput::EpochRootCertificates { cert1, .. } => cert1.view_number(),
             ConsensusInput::HeaderCreated(view, ..) => *view,
-            ConsensusInput::ProposalWithVidShare(_, prop, _) => prop.view_number(),
+            ConsensusInput::Proposal(_, prop) => prop.view_number(),
+            ConsensusInput::VidShare(share) => share.view_number(),
             ConsensusInput::FetchedProposal(prop) => prop.view_number(),
             ConsensusInput::StateValidated(response) => response.view,
             ConsensusInput::StateValidationFailed(request) => request.view,

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -1518,28 +1518,6 @@ impl<T: NodeType> Consensus<T> {
             warn!("locked certificate is newer than epoch change certificate1");
             return Protocol::Abort;
         }
-        // Check if the certificates match
-        if cert1.view_number() != cert2.view_number()
-            || cert1.epoch() != cert2.epoch()
-            || cert1.data.leaf_commit != cert2.data.leaf_commit
-        {
-            warn!("epoch change certificates do not match");
-            return Protocol::Abort;
-        }
-        // check if it's the last block for the correct epoch
-        if !is_last_block(cert2.data.block_number, *self.epoch_height) {
-            warn!("epoch change certificate2 is not the last block of the epoch");
-            return Protocol::Abort;
-        }
-        if cert2.data.block_number / *self.epoch_height != *cert2.data.epoch {
-            warn!("epoch change certificate2 is not for the correct epoch");
-            return Protocol::Abort;
-        }
-        // Check if the proposal matches the certificate1
-        if proposal_commitment(&proposal) != cert1.data.leaf_commit {
-            warn!("epoch change proposal commitment does not match certificate1 leaf commitment");
-            return Protocol::Abort;
-        }
         let next_view = cert2.view_number() + 1;
         let next_epoch = cert2.data.epoch + 1;
         // Change view to the first view of the next epoch

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -24,7 +24,7 @@ use hotshot_types::{
         HasEpoch, LightClientStateUpdateVote2, QuorumData2, SimpleVote, TimeoutData2, TimeoutVote2,
         Vote2Data,
     },
-    stake_table::{HSStakeTable, StakeTableEntries},
+    stake_table::HSStakeTable,
     traits::{
         block_contents::BlockHeader,
         node_implementation::NodeType,
@@ -33,13 +33,14 @@ use hotshot_types::{
         },
     },
     utils::{epoch_from_block_number, is_epoch_root, is_epoch_transition, is_last_block},
-    vote::{self, Certificate, HasViewNumber},
+    vote::{Certificate, HasViewNumber},
 };
 use hotshot_utils::anytrace;
 use tracing::{debug, info, instrument, warn};
 
 use crate::{
     block::BlockAndHeaderRequest,
+    cert_verifier::ValidCert,
     coordinator::{GcScope, VID_RECONSTRUCT_GC_MARGIN},
     helpers::proposal_commitment,
     logging::KeyPrefix,
@@ -87,20 +88,20 @@ pub enum ConsensusInput<T: NodeType> {
         payload_commitment: VidCommitment,
     },
     BlockReconstructed(ViewNumber, VidCommitment2),
-    Certificate1(Certificate1<T>),
-    Certificate2(Certificate2<T>),
+    Certificate1(ValidCert<Certificate1<T>>),
+    Certificate2(ValidCert<Certificate2<T>>),
     /// A quorum certificate allows us to advance our view.
     ///
     /// Used to help divergent nodes re-converge on restart.
-    AdvanceView(Certificate1<T>),
+    AdvanceView(ValidCert<Certificate1<T>>),
     /// Atomic pair emitted by the `EpochRootTally` for epoch-root views:
     /// a `Certificate1` and its matching `LightClientStateUpdateCertificateV2`.
     /// Consensus never sees an epoch-root Cert1 without the matching state_cert.
     EpochRootCertificates {
-        cert1: Certificate1<T>,
+        cert1: ValidCert<Certificate1<T>>,
         state_cert: LightClientStateUpdateCertificateV2<T>,
     },
-    EpochChange(EpochChangeMessage<T>),
+    EpochChange(EpochChangeMessage<T, Validated>),
     HeaderCreated(ViewNumber, Commitment<Leaf2<T>>, T::BlockHeader),
     /// A validated proposal. Consensus parks it until this node's VID share
     /// for the same payload arrives ([`ConsensusInput::VidShare`]) and only
@@ -113,7 +114,7 @@ pub enum ConsensusInput<T: NodeType> {
     StateValidationFailed(StateResponse<T>),
     Stored(StorageOutput<T>),
     Timeout(ViewNumber, EpochNumber),
-    TimeoutCertificate(TimeoutCertificate2<T>),
+    TimeoutCertificate(ValidCert<TimeoutCertificate2<T>>),
     TimeoutOneHonest(ViewNumber, EpochNumber),
     VidDisperseCreated(ViewNumber, VidCommitment2),
     DrbResult(EpochNumber, DrbResult),
@@ -137,7 +138,7 @@ pub enum ConsensusOutput<T: NodeType> {
     /// Broadcast a first-obtained Cert2 so peers that could not assemble it
     /// from votes can still decide. Mirrors `SendCertificate1`.
     SendCertificate2(Certificate2<T>),
-    SendEpochChange(EpochChangeMessage<T>),
+    SendEpochChange(EpochChangeMessage<T, Validated>),
     RequestVidDisperse {
         view: ViewNumber,
         epoch: EpochNumber,
@@ -221,7 +222,6 @@ pub struct Consensus<T: NodeType> {
     /// `decided_views` is not persisted, so a replayed certificate pair could
     /// otherwise re-decide pre-anchor views.
     decide_floor_view: ViewNumber,
-    invalid_certs: u64,
     last_decided_view: ViewNumber,
     last_decided_leaf: Leaf2<T>,
     drb_results: BTreeMap<EpochNumber, DrbResult>,
@@ -246,14 +246,6 @@ pub struct Consensus<T: NodeType> {
 
     /// Skipped by `maybe_vote_2_and_update_lock` (V1 AvidM dispersal).
     pre_cutover_views: BTreeSet<ViewNumber>,
-
-    /// Certificates whose epoch membership was not yet available when they
-    /// arrived.  They are retried when new epoch data becomes available.
-    pending_certs1: BTreeMap<ViewNumber, Certificate1<T>>,
-    pending_certs2: BTreeMap<ViewNumber, Certificate2<T>>,
-    /// Timeout certificates deferred for the same reason, keyed by the view
-    /// they certify as timed out.
-    pending_timeout_certs: BTreeMap<ViewNumber, TimeoutCertificate2<T>>,
 
     timeout_view: ViewNumber,
     /// Highest view this node may have acted in before a restart (from the
@@ -284,16 +276,6 @@ enum Protocol {
     Abort,
     /// Continue with protocol.
     Continue,
-}
-
-/// Result of attempting to verify a certificate's epoch membership.
-enum CertVerification {
-    /// Certificate is cryptographically valid.
-    Valid,
-    /// Certificate is cryptographically invalid (bad signature).
-    Invalid,
-    /// The epoch's stake table is not yet available (catchup in progress).
-    EpochUnavailable,
 }
 
 /// Reason a proposal failed the safety/liveness rule.
@@ -352,7 +334,6 @@ impl<T: NodeType> Consensus<T> {
             leaves: BTreeMap::new(),
             decided_views: BTreeSet::from([last_decided_view]),
             decide_floor_view: ViewNumber::genesis(),
-            invalid_certs: 0,
             last_decided_view,
             last_decided_leaf: genesis_leaf,
             headers: BTreeMap::new(),
@@ -375,9 +356,6 @@ impl<T: NodeType> Consensus<T> {
             pending_vote2: BTreeMap::new(),
             pending_proposal: BTreeMap::new(),
             pre_cutover_views: BTreeSet::new(),
-            pending_certs1: BTreeMap::new(),
-            pending_certs2: BTreeMap::new(),
-            pending_timeout_certs: BTreeMap::new(),
             private_key,
             state_private_key,
             stake_table_capacity,
@@ -644,10 +622,6 @@ impl<T: NodeType> Consensus<T> {
         self.locked_cert.as_ref().map(|c| c.view_number())
     }
 
-    pub(crate) fn invalid_certs(&self) -> u64 {
-        self.invalid_certs
-    }
-
     /// Newest view that can no longer be decided (and below which decide
     /// inputs are dropped): slides [`DECIDE_BUFFER`] behind the watermark,
     /// pinned at the restart/cutover anchor.
@@ -661,10 +635,6 @@ impl<T: NodeType> Consensus<T> {
     /// Apply consensus to the given input and collect protocol outputs.
     #[instrument(level = "debug", skip_all, fields(node = %self.node_id, view = %input.view_number()))]
     pub fn apply(&mut self, input: ConsensusInput<T>, outbox: &mut Outbox<ConsensusOutput<T>>) {
-        let drb_epoch = match &input {
-            ConsensusInput::DrbResult(epoch, _) => Some(*epoch),
-            _ => None,
-        };
         // DRB results arrive asynchronously with no specific view attached.
         // Use `current_view` so that the post-apply retries (`maybe_propose`,
         // `maybe_vote_*`) target the view the node is actually on — in
@@ -714,23 +684,17 @@ impl<T: NodeType> Consensus<T> {
                 return;
             },
             ConsensusInput::Certificate1(certificate) => {
-                debug!(
-                    epoch = ?certificate.epoch().map(|e| *e),
-                    "apply: certificate1"
-                );
-                self.handle_certificate1(certificate, outbox)
+                debug!(epoch = %certificate.epoch(), "apply: certificate1");
+                self.handle_certificate1(certificate)
             },
             ConsensusInput::Certificate2(certificate) => {
-                debug!(
-                    epoch = ?certificate.epoch().map(|e| *e),
-                    "apply: certificate2"
-                );
+                debug!(epoch = %certificate.epoch(), "apply: certificate2");
                 self.handle_certificate2(certificate, outbox)
             },
             ConsensusInput::AdvanceView(certificate) => {
                 debug!(
                     view  = %certificate.view_number(),
-                    epoch = ?certificate.epoch().map(|e| *e),
+                    epoch = %certificate.epoch(),
                     "apply: advance view"
                 );
                 self.handle_advance_view(certificate, outbox)
@@ -744,17 +708,14 @@ impl<T: NodeType> Consensus<T> {
                 // proposer has it on hand. Atomicity invariant: this pair always
                 // arrives together; Consensus never sees the Cert1 alone.
                 self.state_certs.insert(state_cert.epoch, state_cert);
-                self.handle_certificate1(cert1, outbox)
+                self.handle_certificate1(cert1)
             },
             ConsensusInput::TimeoutCertificate(certificate) => {
                 let timed_out_view = certificate.view_number();
-                let cert_epoch = certificate.epoch();
-                let leader = cert_epoch
-                    .map(|e| self.leader_label(timed_out_view, e))
-                    .unwrap_or_else(|| "unknown".to_string());
+                let leader = self.leader_label(timed_out_view, certificate.epoch());
                 warn!(
                     view = %timed_out_view,
-                    epoch = ?cert_epoch.map(|e| *e),
+                    epoch = %certificate.epoch(),
                     %leader,
                     "apply: timeout certificate"
                 );
@@ -871,13 +832,6 @@ impl<T: NodeType> Consensus<T> {
         self.maybe_propose(view, outbox);
         // An event from the current view or the previous view can trigger a propose
         self.maybe_propose(view + 1, outbox);
-
-        // When new epoch data arrives (DRB result or epoch change), retry
-        // any pending certificates that were deferred because their epoch
-        // membership wasn't available yet.
-        if drb_epoch.is_some() {
-            self.retry_pending_certs(outbox);
-        }
     }
 
     pub fn last_decided_view(&self) -> ViewNumber {
@@ -960,9 +914,11 @@ impl<T: NodeType> Consensus<T> {
         self.signed_proposals.get(view)
     }
 
-    /// Garbage-collect per-view state. The decide inputs (`proposals`,
-    /// `certs`, `certs2`, deferred certs, `decided_views`) survive down to
-    /// [`Self::decide_floor`] so a late Cert2 can still decide a gap view.
+    /// Garbage-collect per-view state.
+    ///
+    /// The decide inputs (`proposals`, `certs`, `certs2`, deferred certs,
+    /// `decided_views`) survive down to [`Self::decide_floor`] so a late
+    /// Cert2 can still decide a gap view.
     pub fn gc(&mut self, scope: GcScope) {
         match scope {
             GcScope::Local(view) => {
@@ -985,13 +941,10 @@ impl<T: NodeType> Consensus<T> {
                 self.certs = self.certs.split_off(&keep_from);
                 self.certs2 = self.certs2.split_off(&keep_from);
                 self.decided_views = self.decided_views.split_off(&keep_from);
-                self.pending_certs1 = self.pending_certs1.split_off(&keep_from);
-                self.pending_certs2 = self.pending_certs2.split_off(&keep_from);
                 self.proposals = self.proposals.split_off(&keep_from);
                 self.leaves = self.leaves.split_off(&view);
                 self.signed_proposals = self.signed_proposals.split_off(&view);
                 self.vid_shares = self.vid_shares.split_off(&view);
-                self.pending_timeout_certs = self.pending_timeout_certs.split_off(&view);
                 self.stored_proposals = self.stored_proposals.split_off(&view);
                 self.stored_vids = self.stored_vids.split_off(&view);
                 self.stored_actions = self.stored_actions.split_off(&(view, ActionKind::Vote));
@@ -1133,31 +1086,6 @@ impl<T: NodeType> Consensus<T> {
             return Protocol::Abort;
         }
 
-        // if the previous block is the last block of the epoch, this proposal is the first proposal of the new epoch
-        if is_last_block(block_number.saturating_sub(1), *self.epoch_height) {
-            let Some(cert2) = &proposal.next_epoch_justify_qc else {
-                warn!(
-                    %view, %proposer, block = %block_number, %epoch, %qc_view, %qc_epoch,
-                    "no next epoch justify QC"
-                );
-                return Protocol::Abort;
-            };
-            if cert2.data.leaf_commit != proposal.justify_qc.data().leaf_commit {
-                warn!(
-                    %view, %proposer, block = %block_number, %epoch, %qc_view, %qc_epoch,
-                    "next epoch justify QC does not match proposal"
-                );
-                return Protocol::Abort;
-            }
-            if !self.verify_cert(cert2, qc_epoch) {
-                warn!(
-                    %view, %proposer, block = %block_number, %epoch, %qc_view, %qc_epoch,
-                    "next epoch justify QC not verified"
-                );
-                return Protocol::Abort;
-            }
-        }
-
         let payload_size = vid_share.payload_byte_len();
 
         // Store the proposal before the DRB check so it is not lost when
@@ -1168,6 +1096,7 @@ impl<T: NodeType> Consensus<T> {
         self.signed_proposals.insert(view, signed_proposal.clone());
         self.leaves.insert(view, proposal.clone().into());
         self.vid_shares.insert(view, vid_share);
+        self.adopt_certified_drb(view);
 
         self.request_parent_proposal_if_missing(&proposal, outbox);
 
@@ -1258,7 +1187,9 @@ impl<T: NodeType> Consensus<T> {
         self.signed_proposals.insert(view, signed_proposal);
         self.request_parent_proposal_if_missing(&proposal, outbox);
         self.proposals.insert(view, proposal);
+        self.adopt_certified_drb(view);
     }
+
     fn request_parent_proposal_if_missing(
         &self,
         proposal: &Proposal<T>,
@@ -1279,81 +1210,36 @@ impl<T: NodeType> Consensus<T> {
     }
 
     #[instrument(level = "debug", skip_all)]
-    fn handle_certificate1(
-        &mut self,
-        certificate: Certificate1<T>,
-        outbox: &mut Outbox<ConsensusOutput<T>>,
-    ) -> Protocol {
+    fn handle_certificate1(&mut self, certificate: ValidCert<Certificate1<T>>) -> Protocol {
         let view = certificate.view_number();
-        // Below the decide floor the certificate is useless and its per-view
-        // state was GC'd; drop it before paying for signature verification.
         if view <= self.decide_floor() {
             return Protocol::Continue;
         }
-        if self.certs.contains_key(&view) {
-            return Protocol::Continue;
-        }
-        let Some(certificate_epoch) = certificate.epoch() else {
-            warn!(%view, "certificate1 has no epoch number");
-            return Protocol::Abort;
-        };
-        // TODO: This signature check is slow (> 1ms).  We should consider
-        // if this should be done off the main thread.
-        match self.try_verify_cert(&certificate, certificate_epoch) {
-            CertVerification::Valid => {},
-            CertVerification::Invalid => {
-                warn!(%view, "certificate1 not verified");
-                return Protocol::Abort;
-            },
-            CertVerification::EpochUnavailable => {
-                debug!(%view, %certificate_epoch, "certificate1 deferred (epoch unavailable)");
-                self.pending_certs1.insert(view, certificate);
-                outbox.push_back(ConsensusOutput::RequestDrbResult(certificate_epoch));
-                return Protocol::Continue;
-            },
-        }
-        self.certs.insert(view, certificate);
+        self.certs.entry(view).or_insert(certificate.into_cert());
+        self.adopt_certified_drb(view);
         Protocol::Continue
     }
 
     #[instrument(level = "debug", skip_all)]
     fn handle_certificate2(
         &mut self,
-        certificate: Certificate2<T>,
+        certificate: ValidCert<Certificate2<T>>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) -> Protocol {
         let view = certificate.view_number();
-        // Same intake floor as `handle_certificate1`.
         if view <= self.decide_floor() {
             return Protocol::Continue;
         }
         if self.certs2.contains_key(&view) {
             return Protocol::Continue;
         }
-        let Some(certificate_epoch) = certificate.epoch() else {
-            warn!(%view, "certificate2 has no epoch number");
-            return Protocol::Abort;
-        };
-        // TODO: This signature check is slow (> 1ms).  We should consider
-        // if this should be done off the main thread.
-        match self.try_verify_cert(&certificate, certificate_epoch) {
-            CertVerification::Valid => {},
-            CertVerification::Invalid => {
-                warn!(%view, "certificate2 not verified");
-                return Protocol::Abort;
-            },
-            CertVerification::EpochUnavailable => {
-                debug!(%view, %certificate_epoch, "certificate2 deferred (epoch unavailable)");
-                self.pending_certs2.insert(view, certificate);
-                outbox.push_back(ConsensusOutput::RequestDrbResult(certificate_epoch));
-                return Protocol::Continue;
-            },
-        }
         // Relay a first-obtained Cert2 so peers that missed the vote2s can
         // still decide. Skip decided views so a GC'd-then-re-received Cert2
         // cannot ping-pong between nodes forever.
         if !self.decided_views.contains(&view) {
-            outbox.push_back(ConsensusOutput::SendCertificate2(certificate.clone()));
+            outbox.push_back(ConsensusOutput::SendCertificate2(
+                certificate.cert().clone(),
+            ));
         }
         if view > self.last_decided_view && !self.proposals.contains_key(&view) {
             warn!(%view, "have certificate2 but no proposal; requesting fetch");
@@ -1362,15 +1248,47 @@ impl<T: NodeType> Consensus<T> {
                 leaf_commit: certificate.data.leaf_commit,
             });
         }
-        self.certs2.insert(view, certificate);
+        self.certs2.insert(view, certificate.into_cert());
         Protocol::Continue
+    }
+
+    /// Adopt the successor-epoch DRB carried by the transition leaf at `view`,
+    /// once we hold both its proposal and a QC certifying it. A Cert1 over the
+    /// leaf is a quorum's endorsement of its `next_drb_result`, so a catching-up
+    /// node can use it without waiting on a separate successor-epoch catchup.
+    fn adopt_certified_drb(&mut self, view: ViewNumber) {
+        let Some(proposal) = self.proposals.get(&view) else {
+            return;
+        };
+        // Only transition leaves in epoch >= 1 carry the next epoch's DRB.
+        if proposal.epoch <= EpochNumber::genesis()
+            || !is_epoch_transition(proposal.block_header.block_number(), *self.epoch_height)
+        {
+            return;
+        }
+        let Some(drb) = proposal.next_drb_result else {
+            return;
+        };
+        let next_epoch = proposal.epoch + 1;
+        if self.drb_results.contains_key(&next_epoch) {
+            return;
+        }
+        // Adopt only from the exact leaf the QC certified (hashes the leaf).
+        let Some(cert) = self.certs.get(&view) else {
+            return;
+        };
+        if proposal_commitment(proposal) != cert.data.leaf_commit {
+            return;
+        }
+        self.drb_results.insert(next_epoch, drb);
+        debug!(%view, %next_epoch, "adopted quorum-certified next_drb_result");
     }
 
     /// Advance our view based on a quorum certificate.
     #[instrument(level = "debug", skip_all)]
     fn handle_advance_view(
         &mut self,
-        cert1: Certificate1<T>,
+        cert1: ValidCert<Certificate1<T>>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) -> Protocol {
         let view = cert1.view_number();
@@ -1379,25 +1297,10 @@ impl<T: NodeType> Consensus<T> {
             return Protocol::Continue;
         }
 
-        let Some(epoch) = cert1.epoch() else {
-            warn!(%view, "cert1 has no epoch number");
-            return Protocol::Abort;
-        };
+        let epoch = cert1.epoch();
 
-        match self.try_verify_cert(&cert1, epoch) {
-            CertVerification::Valid => {},
-            CertVerification::Invalid => {
-                warn!(%view, "cert1 is invalid");
-                return Protocol::Abort;
-            },
-            CertVerification::EpochUnavailable => {
-                debug!(%view, %epoch, "missing epoch to verify cert1");
-                outbox.push_back(ConsensusOutput::RequestDrbResult(epoch));
-                return Protocol::Continue;
-            },
-        }
-
-        self.certs.entry(view).or_insert(cert1);
+        self.certs.entry(view).or_insert(cert1.into_cert());
+        self.adopt_certified_drb(view);
 
         // Ensure we submit a vote2 if we can:
         self.maybe_vote_2_and_update_lock(view, outbox);
@@ -1527,7 +1430,7 @@ impl<T: NodeType> Consensus<T> {
     #[instrument(level = "debug", skip_all)]
     fn handle_timeout_certificate(
         &mut self,
-        certificate: TimeoutCertificate2<T>,
+        certificate: ValidCert<TimeoutCertificate2<T>>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) -> Protocol {
         let view = certificate.view_number() + 1;
@@ -1542,33 +1445,14 @@ impl<T: NodeType> Consensus<T> {
         if self.timeout_certs.contains_key(&view) {
             return Protocol::Continue;
         }
-        let Some(epoch) = certificate.epoch() else {
-            warn!(view = %certificate.view_number(), "timeout certificate has no epoch number");
-            return Protocol::Abort;
-        };
-        // Verify the threshold signature before acting on the certificate.
-        // Matches `handle_certificate1`/`handle_certificate2`.
-        match self.try_verify_cert(&certificate, epoch) {
-            CertVerification::Valid => {},
-            CertVerification::Invalid => {
-                warn!(%view, %epoch, "timeout certificate not verified");
-                return Protocol::Abort;
-            },
-            CertVerification::EpochUnavailable => {
-                debug!(%view, %epoch, "timeout certificate deferred (epoch unavailable)");
-                self.pending_timeout_certs
-                    .insert(certificate.view_number(), certificate);
-                outbox.push_back(ConsensusOutput::RequestDrbResult(epoch));
-                return Protocol::Continue;
-            },
-        }
-        self.timeout_certs.insert(view, certificate.clone());
+        let epoch = certificate.epoch();
+        self.timeout_certs.insert(view, certificate.cert().clone());
         self.current_view = self.current_view.max(view);
         self.current_epoch = Some(epoch);
         outbox.push_back(ConsensusOutput::ViewChanged(view, epoch));
         outbox.push_back(ConsensusOutput::ViewTimedOut(certificate.view_number()));
         outbox.push_back(ConsensusOutput::SendTimeoutCertificate(
-            certificate,
+            certificate.into_cert(),
             view,
             epoch,
         ));
@@ -1602,13 +1486,14 @@ impl<T: NodeType> Consensus<T> {
     #[instrument(level = "debug", skip_all)]
     fn handle_epoch_change(
         &mut self,
-        epoch_change: EpochChangeMessage<T>,
+        epoch_change: EpochChangeMessage<T, Validated>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) -> Protocol {
         let EpochChangeMessage {
             cert1,
             cert2,
             proposal,
+            ..
         } = epoch_change;
         // Compare epochs (not views) so a node that timed out past a boundary
         // it never saw can still recover via a genuinely new epoch change.
@@ -1655,19 +1540,6 @@ impl<T: NodeType> Consensus<T> {
             warn!("epoch change proposal commitment does not match certificate1 leaf commitment");
             return Protocol::Abort;
         }
-        // Verify the certificates
-        let Some(cert1_epoch) = cert1.epoch() else {
-            warn!("epoch change certificate1 has no epoch number");
-            return Protocol::Abort;
-        };
-        if !self.verify_cert(&cert1, cert1_epoch) {
-            warn!("epoch change certificate not verified");
-            return Protocol::Abort;
-        }
-        if !self.verify_cert(&cert2, cert2.data.epoch) {
-            warn!("epoch change certificate not verified");
-            return Protocol::Abort;
-        }
         let next_view = cert2.view_number() + 1;
         let next_epoch = cert2.data.epoch + 1;
         // Change view to the first view of the next epoch
@@ -1686,9 +1558,11 @@ impl<T: NodeType> Consensus<T> {
             ));
         }
 
-        self.proposals.insert(cert2.view_number(), proposal);
+        let boundary_view = cert2.view_number();
+        self.proposals.insert(boundary_view, proposal);
         self.certs.insert(cert1.view_number(), cert1);
-        self.certs2.insert(cert2.view_number(), cert2);
+        self.certs2.insert(boundary_view, cert2);
+        self.adopt_certified_drb(boundary_view);
         Protocol::Continue
     }
 
@@ -1923,11 +1797,8 @@ impl<T: NodeType> Consensus<T> {
         if is_last_block(proposal.block_header.block_number(), *self.epoch_height)
             && cert1.data.leaf_commit == proposal_commit
         {
-            let epoch_change = EpochChangeMessage {
-                cert1: cert1.clone(),
-                cert2: cert2.clone(),
-                proposal: proposal.clone(),
-            };
+            let epoch_change =
+                EpochChangeMessage::validated(cert1.clone(), cert2.clone(), proposal.clone());
             outbox.push_back(ConsensusOutput::SendEpochChange(epoch_change));
         }
         // we have a second certificate, and matching proposal, it is decided.
@@ -2461,86 +2332,6 @@ impl<T: NodeType> Consensus<T> {
             parent_commit: parent_commit.to_string(),
             locked_commit: locked_commit.to_string(),
         })
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    fn verify_cert<A, C>(&self, cert: &C, epoch: EpochNumber) -> bool
-    where
-        C: vote::Certificate<T, A>,
-    {
-        match self
-            .stake_table_coordinator
-            .membership_for_epoch(Some(epoch))
-        {
-            Ok(stake_table) => {
-                let entries = StakeTableEntries::from_iter(stake_table.stake_table()).0;
-                let threshold = stake_table.success_threshold();
-                match cert.is_valid_cert(&entries, threshold, &self.upgrade_lock) {
-                    Ok(()) => true,
-                    Err(err) => {
-                        warn!(%epoch, %err, "invalid threshold signature");
-                        false
-                    },
-                }
-            },
-            Err(err) => {
-                warn!(%epoch, %err, "failed to get stake table");
-                false
-            },
-        }
-    }
-
-    /// Try to verify a certificate, distinguishing between "epoch not available"
-    /// and "cryptographically invalid".
-    #[instrument(level = "trace", skip_all)]
-    fn try_verify_cert<A, C>(&mut self, cert: &C, epoch: EpochNumber) -> CertVerification
-    where
-        C: vote::Certificate<T, A>,
-    {
-        match self
-            .stake_table_coordinator
-            .membership_for_epoch(Some(epoch))
-        {
-            Ok(stake_table) => {
-                let entries = StakeTableEntries::from_iter(stake_table.stake_table()).0;
-                let threshold = stake_table.success_threshold();
-                match cert.is_valid_cert(&entries, threshold, &self.upgrade_lock) {
-                    Ok(()) => CertVerification::Valid,
-                    Err(err) => {
-                        warn!(%epoch, %err, "invalid threshold signature");
-                        self.invalid_certs += 1;
-                        CertVerification::Invalid
-                    },
-                }
-            },
-            Err(_) => CertVerification::EpochUnavailable,
-        }
-    }
-
-    /// Retry verification of pending certificates whose epoch may now be available.
-    fn retry_pending_certs(&mut self, outbox: &mut Outbox<ConsensusOutput<T>>) {
-        // Retry pending cert1s.
-        let pending = std::mem::take(&mut self.pending_certs1);
-        for (view, cert) in pending {
-            self.handle_certificate1(cert.clone(), outbox);
-            self.maybe_vote_2_and_update_lock(view, outbox);
-            // The deferred Cert1 can be the last missing decide ingredient.
-            self.maybe_decide(view, outbox);
-            self.maybe_propose(view, outbox);
-        }
-
-        // Retry pending cert2s.
-        let pending = std::mem::take(&mut self.pending_certs2);
-        for (view, cert) in pending {
-            self.handle_certificate2(cert.clone(), outbox);
-            self.maybe_decide(view, outbox);
-            self.maybe_propose(view, outbox);
-        }
-
-        let pending = std::mem::take(&mut self.pending_timeout_certs);
-        for (_view, cert) in pending {
-            self.handle_timeout_certificate(cert, outbox);
-        }
     }
 
     /// Format the leader's key prefix for the given view/epoch, or `"unknown"`

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -229,6 +229,9 @@ pub struct Consensus<T: NodeType> {
     voted_1_views: BTreeSet<ViewNumber>,
     voted_2_views: BTreeSet<ViewNumber>,
 
+    /// For each view this node cast a vote1 in, the view its proposal was justified at.
+    vote1_parent: BTreeMap<ViewNumber, ViewNumber>,
+
     /// Storage confirmations; sends are gated on these facts.
     stored_proposals: BTreeMap<ViewNumber, Vec<Commitment<Leaf2<T>>>>,
     stored_vids: BTreeSet<ViewNumber>,
@@ -347,6 +350,7 @@ impl<T: NodeType> Consensus<T> {
             stake_table_coordinator: membership_coordinator,
             voted_1_views: BTreeSet::new(),
             voted_2_views: BTreeSet::new(),
+            vote1_parent: BTreeMap::new(),
             stored_proposals: BTreeMap::new(),
             stored_vids: BTreeSet::new(),
             stored_actions: BTreeSet::new(),
@@ -490,6 +494,7 @@ impl<T: NodeType> Consensus<T> {
         for leaf in seed.undecided {
             let view = leaf.view_number();
             let justify_qc = leaf.justify_qc().clone();
+            let parent_view = justify_qc.view_number();
             self.register_legacy_qc(&justify_qc);
 
             let block_number = leaf.block_header().block_number();
@@ -521,6 +526,7 @@ impl<T: NodeType> Consensus<T> {
             self.proposed_views.insert(view);
             self.voted_1_views.insert(view);
             self.voted_2_views.insert(view);
+            self.vote1_parent.insert(view, parent_view);
         }
 
         if let Some(high_qc) = &seed.high_qc {
@@ -887,6 +893,16 @@ impl<T: NodeType> Consensus<T> {
         if anchor_view > self.decide_floor_view {
             self.decide_floor_view = anchor_view;
         }
+        // Which views this node submitted its vote1 in is not persisted, only how far
+        // it acted. A vote1 needs its proposal stored, so treat every seeded proposal
+        // at or below the bar as one, this node may have voted for. Without that, a
+        // vote2 re-cast after the restart could land in a view whose branch this node
+        // had already left behind.
+        for (&view, proposal) in self.proposals.range(..=last_barred) {
+            self.vote1_parent
+                .entry(view)
+                .or_insert(proposal.justify_qc.view_number());
+        }
         // `Coordinator::start` enters `current_view + 1`, so parking the cursor
         // at the high QC makes the node re-enter at `high_qc + 1`.
         let resume_view = self.stored_high_qc.unwrap_or(anchor_view + 1);
@@ -942,6 +958,7 @@ impl<T: NodeType> Consensus<T> {
                 self.certs2 = self.certs2.split_off(&keep_from);
                 self.decided_views = self.decided_views.split_off(&keep_from);
                 self.proposals = self.proposals.split_off(&keep_from);
+                self.vote1_parent = self.vote1_parent.split_off(&keep_from);
                 self.leaves = self.leaves.split_off(&view);
                 self.signed_proposals = self.signed_proposals.split_off(&view);
                 self.vid_shares = self.vid_shares.split_off(&view);
@@ -1946,6 +1963,10 @@ impl<T: NodeType> Consensus<T> {
             return;
         }
         let (vote2, _) = self.pending_vote2.remove(&view).expect("checked above");
+        if self.voted_for_branch_excluding(view) {
+            warn!(%view, "dropping pending vote2 for a view a later vote1 skips");
+            return;
+        }
         outbox.push_back(ConsensusOutput::SendVote2(vote2));
     }
 
@@ -1956,6 +1977,22 @@ impl<T: NodeType> Consensus<T> {
         view <= self.restart_barred_view
             || (self.stored_actions.contains(&(view, ActionKind::Vote))
                 && self.stored_vids.contains(&view))
+    }
+
+    /// Whether a vote1 in a later view endorsed a branch with no block at `view`.
+    ///
+    /// This is what keeps one node out of two conflicting quorums. A vote2 certifies
+    /// `view` for good, but the certificate and the reconstructed block it waits on
+    /// can arrive after the node has submitted vote1 elsewhere. Casting it anyway
+    /// would count the node towards a quorum committing `view` and towards one
+    /// certifying a branch without it.
+    ///
+    /// This covers the order vote1-then-vote2. The reverse is the `is_safe`
+    /// re-check in `maybe_vote_1`; neither alone is enough.
+    fn voted_for_branch_excluding(&self, view: ViewNumber) -> bool {
+        self.vote1_parent
+            .range(view + 1..)
+            .any(|(_, justified_at)| *justified_at < view)
     }
 
     fn release_proposal(&mut self, view: ViewNumber, outbox: &mut Outbox<ConsensusOutput<T>>) {
@@ -2015,6 +2052,20 @@ impl<T: NodeType> Consensus<T> {
         let epoch = proposal.epoch;
         let qc_view = proposal.justify_qc.view_number();
         let qc_epoch = proposal.justify_qc.epoch();
+
+        // The counterpart of `voted_for_branch_excluding`, for the other order.
+        // `handle_proposal_with_vid_share` checked this proposal against the lock
+        // as it stood on arrival, and state validation can complete after that.
+        // A vote2 in the meantime locks this node on a view the proposal's
+        // branch may skip, and voting here would then count it towards a quorum
+        // certifying that branch and towards the one committing the view.
+        if let Err(err) = self.is_safe(proposal) {
+            warn!(
+                %view, block = %block_number, %epoch, %qc_view, ?qc_epoch, %err,
+                "proposal no longer safe against the current lock; refusing to vote1"
+            );
+            return;
+        }
 
         // Don't vote for epoch-transition proposals until we can verify
         // the attached DRB result.  Same guard as `maybe_propose`:
@@ -2146,6 +2197,7 @@ impl<T: NodeType> Consensus<T> {
             && self.is_proposal_stored(view, &proposal_commit);
         let vid_share = can_send.then(|| vid_share.clone());
         self.voted_1_views.insert(view);
+        self.vote1_parent.insert(view, qc_view);
         if let Some(vid_share) = vid_share {
             outbox.push_back(ConsensusOutput::SendVote1(vote));
             outbox.push_back(ConsensusOutput::BroadcastVidShare(vid_share));
@@ -2231,6 +2283,11 @@ impl<T: NodeType> Consensus<T> {
             || self.decided_views.contains(&view)
             || view <= self.decide_floor()
         {
+            return;
+        }
+
+        if self.voted_for_branch_excluding(view) {
+            warn!(%view, %qc_view, %block, "a later vote1 skips this view; refusing to vote2");
             return;
         }
 

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -35,6 +35,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     block::{BlockAndHeaderRequest, BlockBuilder, BlockBuilderConfig},
+    cert_verifier::CertVerifiers,
     client::{ClientApi, ClientRequest, CoordinatorClient, QueryError},
     consensus::{Consensus, ConsensusInput, ConsensusOutput, PreCutoverSeed},
     coordinator::{
@@ -77,6 +78,16 @@ pub(crate) const VID_RECONSTRUCT_GC_MARGIN: u64 = 5;
 /// storage writes for recent views aren't aborted before they persist.
 const STORAGE_GC_MARGIN: u64 = 5;
 
+/// Epoch changes claiming an epoch further ahead than this are dropped at
+/// intake. We could not verify them anyway: an epoch's stake table only
+/// materializes by walking the DRB chain, so parking such a message and
+/// driving catchup for an arbitrary claimed epoch just burns resources.
+/// Within the ceiling, deferred changes verify progressively as catchup
+/// advances ([`CertVerifiers::retry_pending`] runs on every DRB arrival).
+const EPOCH_CHANGE_LOOKAHEAD: u64 = 3;
+
+pub(crate) const MAX_VIEWS_AHEAD: ViewNumber = ViewNumber::new(30);
+
 #[derive(Builder)]
 pub struct Coordinator<T: NodeType, S> {
     membership_coordinator: EpochMembershipCoordinator<T>,
@@ -95,6 +106,7 @@ pub struct Coordinator<T: NodeType, S> {
     timeout_one_honest_collector:
         VoteCollector<T, SimpleTally<T, TimeoutVote2<T>, TimeoutOneHonest<T>>>,
     epoch_root_collector: VoteCollector<T, EpochRootTally<T>>,
+    cert_verifiers: CertVerifiers<T>,
     epoch_manager: EpochManager<T>,
     block_builder: BlockBuilder<T>,
     proposal_validator: ProposalValidator<T>,
@@ -299,7 +311,14 @@ where
                 membership_coordinator.clone(),
                 lock.clone(),
             ))
-            .epoch_root_collector(VoteCollector::new(membership_coordinator.clone(), lock))
+            .epoch_root_collector(VoteCollector::new(
+                membership_coordinator.clone(),
+                lock.clone(),
+            ))
+            .cert_verifiers(CertVerifiers::new(
+                membership_coordinator.clone(),
+                lock.clone(),
+            ))
             .epoch_manager(EpochManager::new(
                 initializer.epoch_height,
                 membership_coordinator.clone(),
@@ -460,6 +479,7 @@ where
                     }
                 }
                 Some(tcert) = self.timeout_collector.next() => {
+                    self.cert_verifiers.timeout.mark_completed(tcert.view_number());
                     return Ok(ConsensusInput::TimeoutCertificate(tcert))
                 }
                 Some(out) = self.timeout_one_honest_collector.next() => {
@@ -470,12 +490,30 @@ where
                     return Ok(ConsensusInput::TimeoutOneHonest(out.view_number(), epoch))
                 }
                 Some(cert1) = self.vote1_collector.next() => {
+                    self.cert_verifiers.cert1.mark_completed(cert1.view_number());
                     return Ok(ConsensusInput::Certificate1(cert1))
                 }
                 Some(cert2) = self.vote2_collector.next() => {
+                    self.cert_verifiers.cert2.mark_completed(cert2.view_number());
                     return Ok(ConsensusInput::Certificate2(cert2))
                 }
+                Some(cert1) = self.cert_verifiers.cert1.next() => {
+                    return Ok(ConsensusInput::Certificate1(cert1))
+                }
+                Some(cert2) = self.cert_verifiers.cert2.next() => {
+                    return Ok(ConsensusInput::Certificate2(cert2))
+                }
+                Some(tc) = self.cert_verifiers.timeout.next() => {
+                    return Ok(ConsensusInput::TimeoutCertificate(tc))
+                }
+                Some(cert1) = self.cert_verifiers.advance.next() => {
+                    return Ok(ConsensusInput::AdvanceView(cert1))
+                }
+                Some(epoch_change) = self.cert_verifiers.epoch_change.next() => {
+                    return Ok(ConsensusInput::EpochChange(epoch_change.into_cert()))
+                }
                 Some((cert1, state_cert)) = self.epoch_root_collector.next() => {
+                    self.cert_verifiers.cert1.mark_completed(cert1.view_number());
                     self.storage.append_state_cert(
                         ViewNumber::new(state_cert.light_client_state.view_number),
                         state_cert.clone(),
@@ -586,13 +624,12 @@ where
                 },
                 Some(result) = self.epoch_manager.next() => match result {
                     Ok(EpochRootResult::DrbResult(epoch, drb_result)) => {
-                        // New epoch data available — retry votes that were
-                        // buffered because their membership wasn't ready.
                         self.vote1_collector.retry_pending_votes();
                         self.vote2_collector.retry_pending_votes();
                         self.timeout_collector.retry_pending_votes();
                         self.timeout_one_honest_collector.retry_pending_votes();
                         self.epoch_root_collector.retry_pending_votes();
+                        self.cert_verifiers.retry_pending(|e| self.epoch_manager.request_drb_result(e));
                         return Ok(ConsensusInput::DrbResult(epoch, drb_result))
                     }
                     Err(failure) => {
@@ -1006,7 +1043,7 @@ where
                     let epoch = p.proposal.data.epoch;
                     let block = p.proposal.data.block_header.block_number();
                     debug!(%node, %sender, %view, %epoch, %block, "recv proposal");
-                    if !self.is_too_far_ahead(view)
+                    if !self.is_view_too_far_ahead(view)
                         && self.proposal_received_at.is_none_or(|(v, _)| v < view)
                     {
                         self.proposal_received_at = Some((view, Instant::now()));
@@ -1062,7 +1099,7 @@ where
                 },
                 ConsensusMessage::Vote1(vote1) => {
                     let view = vote1.vote.view_number();
-                    if self.is_too_far_ahead(view) {
+                    if self.is_view_too_far_ahead(view) {
                         warn!(%node, %sender, %view, "vote1 is too far ahead");
                         return None;
                     }
@@ -1091,7 +1128,7 @@ where
                 },
                 ConsensusMessage::VidShareBroadcast(share) => {
                     let view = share.view_number();
-                    if self.is_too_far_ahead(view) {
+                    if self.is_view_too_far_ahead(view) {
                         warn!(%node, %sender, %view, "vid share broadcast is too far ahead");
                         return None;
                     }
@@ -1105,7 +1142,7 @@ where
                 },
                 ConsensusMessage::Vote2(vote2) => {
                     let view = vote2.view_number();
-                    if self.is_too_far_ahead(view) {
+                    if self.is_view_too_far_ahead(view) {
                         warn!(%node, %sender, %view, "vote2 is too far ahead");
                         return None;
                     }
@@ -1118,22 +1155,52 @@ where
                     None
                 },
                 ConsensusMessage::Certificate1(certificate1, _key) => {
+                    let view = certificate1.view_number();
                     debug!(
-                        %node, %sender,
-                        view = %certificate1.view_number(),
+                        %node, %sender, %view,
                         epoch = ?certificate1.epoch().map(|e| *e),
                         "recv certificate1"
                     );
-                    Some(ConsensusInput::Certificate1(certificate1))
+                    if self.is_view_too_far_ahead(view) {
+                        warn!(%node, %sender, %view, "certificate1 is too far ahead");
+                        return None;
+                    }
+                    if self.is_epoch_too_far_ahead(certificate1.epoch()) {
+                        warn!(%node, %sender, %view, "certificate1 epoch is too far ahead");
+                        return None;
+                    }
+                    if let Some(epoch) = self
+                        .cert_verifiers
+                        .cert1
+                        .verify(message.sender, certificate1)
+                    {
+                        self.epoch_manager.request_drb_result(epoch);
+                    }
+                    None
                 },
                 ConsensusMessage::Certificate2(certificate2, _key) => {
+                    let view = certificate2.view_number();
                     debug!(
-                        %node, %sender,
-                        view = %certificate2.view_number(),
+                        %node, %sender, %view,
                         epoch = ?certificate2.epoch().map(|e| *e),
                         "recv certificate2"
                     );
-                    Some(ConsensusInput::Certificate2(certificate2))
+                    if self.is_view_too_far_ahead(view) {
+                        warn!(%node, %sender, %view, "certificate2 is too far ahead");
+                        return None;
+                    }
+                    if self.is_epoch_too_far_ahead(certificate2.epoch()) {
+                        warn!(%node, %sender, %view, "certificate2 epoch is too far ahead");
+                        return None;
+                    }
+                    if let Some(epoch) = self
+                        .cert_verifiers
+                        .cert2
+                        .verify(message.sender, certificate2)
+                    {
+                        self.epoch_manager.request_drb_result(epoch);
+                    }
+                    None
                 },
                 ConsensusMessage::TimeoutVote(timeout_msg) => {
                     let view = timeout_msg.vote.view_number();
@@ -1147,37 +1214,55 @@ where
                     // If a peer times out in a view at or ahead of us we adopt its
                     // highest certificate. Evidence takes precedence over
                     // the vote being too far ahead, and a valid certificate proves
-                    // the network reached that view, and consensus verifies it
-                    // before acting on it.
-                    //
-                    // TODO: Make verification asynchronous
-                    let evidence = timeout_msg
+                    // the network reached that view.
+                    if let Some(e) = timeout_msg
                         .evidence
                         .filter(|e| e.view_number() >= current_view)
-                        .map(|e| match e {
-                            CatchupEvidence::Qc(qc) => ConsensusInput::AdvanceView(qc),
-                            CatchupEvidence::Tc(tc) => ConsensusInput::TimeoutCertificate(tc),
-                        });
-
-                    if self.is_too_far_ahead(view) {
-                        warn!(%node, %sender, %view, "timeout vote is too far ahead");
-                        return evidence;
+                    {
+                        match e {
+                            CatchupEvidence::Qc(qc) => {
+                                if let Some(epoch) = self
+                                    .cert_verifiers
+                                    .advance
+                                    .verify(message.sender.clone(), qc)
+                                {
+                                    self.epoch_manager.request_drb_result(epoch);
+                                }
+                            },
+                            CatchupEvidence::Tc(tc) => {
+                                if let Some(epoch) = self
+                                    .cert_verifiers
+                                    .timeout
+                                    .verify(message.sender.clone(), tc)
+                                {
+                                    self.epoch_manager.request_drb_result(epoch);
+                                }
+                            },
+                        }
                     }
+
+                    if self.is_view_too_far_ahead(view) {
+                        warn!(%node, %sender, %view, "timeout vote is too far ahead");
+                        return None;
+                    }
+
                     if view < current_view {
                         debug!(
                             %node, %sender, %view, %current_view,
                             "timeout vote for stale view; replying with catchup evidence"
                         );
                         self.send_catchup_evidence(&message.sender, view);
-                        return evidence;
+                        return None;
                     }
+
                     debug!(%node, %sender, %view, has_evidence, "recv timeout vote");
+
                     self.timeout_collector
                         .accumulate_vote(timeout_msg.vote.clone());
                     self.timeout_one_honest_collector
                         .accumulate_vote(timeout_msg.vote);
 
-                    evidence
+                    None
                 },
                 ConsensusMessage::TimeoutCertificate(tc) => {
                     debug!(
@@ -1186,7 +1271,14 @@ where
                         epoch = ?tc.epoch().map(|e| *e),
                         "recv timeout certificate"
                     );
-                    Some(ConsensusInput::TimeoutCertificate(tc))
+                    if let Some(epoch) = self
+                        .cert_verifiers
+                        .timeout
+                        .verify(message.sender.clone(), tc)
+                    {
+                        self.epoch_manager.request_drb_result(epoch);
+                    }
+                    None
                 },
                 ConsensusMessage::HighQc(qc) => {
                     debug!(
@@ -1195,16 +1287,31 @@ where
                         epoch = ?qc.epoch().map(|e| *e),
                         "recv high qc"
                     );
-                    Some(ConsensusInput::AdvanceView(qc))
+                    if let Some(epoch) = self
+                        .cert_verifiers
+                        .advance
+                        .verify(message.sender.clone(), qc)
+                    {
+                        self.epoch_manager.request_drb_result(epoch);
+                    }
+                    None
                 },
                 ConsensusMessage::EpochChange(epoch_change) => {
-                    debug!(
-                        %node, %sender,
-                        view = %epoch_change.cert1.view_number(),
-                        epoch = ?epoch_change.cert1.epoch().map(|e| *e),
-                        "recv epoch change"
-                    );
-                    Some(ConsensusInput::EpochChange(epoch_change))
+                    let view = epoch_change.cert1.view_number();
+                    let epoch = epoch_change.cert1.epoch();
+                    debug!(%node, %sender, %view, epoch = ?epoch.map(|e| *e), "recv epoch change");
+                    if self.is_epoch_too_far_ahead(epoch) {
+                        warn!(%node, %sender, %view, ?epoch, "epoch change is too far ahead");
+                        return None;
+                    }
+                    if let Some(epoch) = self
+                        .cert_verifiers
+                        .epoch_change
+                        .verify(message.sender, epoch_change)
+                    {
+                        self.epoch_manager.request_drb_result(epoch);
+                    }
+                    None
                 },
             },
             MessageType::Block(msg) => {
@@ -1226,7 +1333,7 @@ where
                             hashes = manifest.hashes.len(),
                             "recv dedup manifest"
                         );
-                        if !self.is_too_far_ahead(manifest.view)
+                        if !self.is_view_too_far_ahead(manifest.view)
                             && let Some(view_leader) = self.leader(manifest.view, manifest.epoch)
                             && view_leader == message.sender
                         {
@@ -1559,8 +1666,8 @@ where
         let consensus = &m.consensus;
         consensus.current_view.set(*view as usize);
         let invalid_certs = self
-            .consensus
-            .invalid_certs()
+            .cert_verifiers
+            .num_invalid_certs()
             .saturating_sub(self.invalid_certs_at_decide);
         consensus.invalid_qc.set(invalid_certs as usize);
         let last_decided_view = self.consensus.last_decided_view();
@@ -1588,7 +1695,7 @@ where
         // a gap-fill decide of older views must not regress the gauges.
         let advanced = newest.view_number() == self.consensus.last_decided_view();
         if advanced {
-            self.invalid_certs_at_decide = self.consensus.invalid_certs();
+            self.invalid_certs_at_decide = self.cert_verifiers.num_invalid_certs();
         }
         let Some(m) = &self.metrics else { return };
         let consensus = &m.consensus;
@@ -1695,8 +1802,10 @@ where
                 self.vote2_collector.gc(view);
             },
             GcScope::Decided(view) => {
+                let decide_floor = self.consensus.decide_floor();
                 self.epoch_manager.gc(epoch);
                 self.epoch_root_collector.gc(view);
+                self.cert_verifiers.gc(decide_floor, epoch);
                 self.pending_proposal_fetches.gc(view);
                 self.requested_missing_proposals
                     .retain(|key| key.view > view);
@@ -1707,9 +1816,7 @@ where
                     .gc(view.saturating_sub(VID_RECONSTRUCT_GC_MARGIN).into());
                 let vc = VidCommitment2::default();
                 self.da_payloads = self.da_payloads.split_off(&(view, vc));
-                self.payload_txn_bytes = self
-                    .payload_txn_bytes
-                    .split_off(&(self.consensus.decide_floor() + 1));
+                self.payload_txn_bytes = self.payload_txn_bytes.split_off(&(decide_floor + 1));
             },
             GcScope::Timeout(view) => {
                 self.vid_reconstructor.retire_view(view);
@@ -1802,9 +1909,18 @@ where
         false
     }
 
-    /// We ignore votes more that 30 views ahead of our current view.
-    fn is_too_far_ahead(&self, v: ViewNumber) -> bool {
-        v > self.consensus.current_view() + 30
+    /// We ignore votes more than `MAX_VIEWS_AHEAD` ahead of ours.
+    fn is_view_too_far_ahead(&self, v: ViewNumber) -> bool {
+        v > self.consensus.current_view() + *MAX_VIEWS_AHEAD
+    }
+
+    /// We ignore certificates more than `EPOCH_CHANGE_LOOKAHEAD` ahead of ours.
+    fn is_epoch_too_far_ahead(&self, epoch: Option<EpochNumber>) -> bool {
+        let current = self
+            .consensus
+            .current_epoch()
+            .unwrap_or(EpochNumber::genesis());
+        epoch.is_some_and(|e| e > current + EPOCH_CHANGE_LOOKAHEAD)
     }
 
     pub(crate) fn catchup_evidence(&self) -> Option<ConsensusMessage<T, Validated>> {

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -14,7 +14,7 @@ use hotshot::{HotShotInitializer, traits::BlockPayload, types::SignatureKey};
 use hotshot_types::{
     consensus::{ConsensusMetricsValue, ParticipationTracker},
     data::{
-        EpochNumber, Leaf2, VidCommitment, VidCommitment2, VidDisperseShare2, ViewNumber,
+        EpochNumber, Leaf2, VidCommitment, VidCommitment2, ViewNumber,
         vid_disperse::vid_total_weight,
     },
     epoch_membership::EpochMembershipCoordinator,
@@ -51,7 +51,7 @@ use crate::{
     },
     network::Cliquenet,
     outbox::Outbox,
-    proposal::{ProposalValidator, ValidatedProposal, VidShareValidator},
+    proposal::{ProposalValidator, VidShareValidator},
     state::{HeaderRequest, StateEntry, StateManager, StateManagerOutput},
     storage::{NewProtocolStorage, Storage},
     vid::{VidDisperseRequest, VidDisperser, VidFragmentAccumulator, VidReconstructor},
@@ -112,10 +112,6 @@ pub struct Coordinator<T: NodeType, S> {
     pending_proposal_fetches: PendingProposalFetches<T>,
     #[builder(skip)]
     requested_missing_proposals: HashSet<ProposalFetchKey<T>>,
-    #[builder(default)]
-    cached_validated_proposals: BTreeMap<(ViewNumber, VidCommitment2), ValidatedProposal<T>>,
-    #[builder(default)]
-    cached_vid_shares: BTreeMap<(ViewNumber, VidCommitment2), VidDisperseShare2<T>>,
     #[builder(skip)]
     da_payloads: BTreeMap<(ViewNumber, VidCommitment2), PendingDa<T>>,
     metrics: Option<metrics::Metrics>,
@@ -488,14 +484,7 @@ where
                 }
                 Some(item) = self.share_validator.next() => match item {
                     Ok(vid_share) => {
-                        let view = vid_share.view_number();
-                        let key = (view, vid_share.payload_commitment);
-                        let Some(validated) = self.cached_validated_proposals.remove(&key) else {
-                            // Wait for the proposal
-                            self.cached_vid_shares.insert(key, vid_share);
-                            continue;
-                        };
-                        return self.on_proposal_and_vid_share(validated, vid_share)
+                        return Ok(ConsensusInput::VidShare(vid_share))
                     },
                     Err(e) => {
                         return Err(CoordinatorError::regular(e).context("vid share validation"))
@@ -509,21 +498,7 @@ where
                         // Refresh the network's peer set when a proposal is validated.
                         let epoch = validated.message.proposal.data.epoch;
                         self.bump_network_epoch(epoch);
-
-                        let view = validated.message.proposal.data.view_number();
-                        let VidCommitment::V2(commit) =
-                            validated.message.proposal.data.block_header.payload_commitment()
-                        else {
-                            warn!(%view, "proposal payload commitment is not V2, discarding");
-                            continue;
-                        };
-                        let key = (view, commit);
-                        let Some(vid_share) = self.cached_vid_shares.remove(&key) else {
-                            // Wait for the vid share describing this payload.
-                            self.cached_validated_proposals.insert(key, validated);
-                            continue;
-                        };
-                        return self.on_proposal_and_vid_share(validated, vid_share)
+                        return Ok(ConsensusInput::Proposal(validated.sender, validated.message))
                     }
                     Err(e) => {
                         return Err(CoordinatorError::regular(e).context("proposal validation"))
@@ -758,6 +733,31 @@ where
                         warn!(%node, %view, "no payload for proposed block");
                     }
                 }
+            },
+            ConsensusOutput::ProposalPaired {
+                proposal,
+                vid_share,
+            } => {
+                let view = proposal.data.view_number;
+                debug!(%node, %view, "proposal paired with vid share");
+                self.storage.append_vid(vid_share.clone());
+                self.storage.append_proposal(proposal.data.clone());
+                if let Some(state_cert) = &proposal.data.state_cert {
+                    self.storage.append_state_cert(
+                        ViewNumber::new(state_cert.light_client_state.view_number),
+                        state_cert.clone(),
+                    );
+                }
+                let expected_param = self.expected_vid_param(vid_share.target_epoch);
+                self.vid_reconstructor.handle_proposal(
+                    view,
+                    vid_share.payload_commitment,
+                    proposal.data.block_header.metadata().clone(),
+                    proposal.data.epoch,
+                    expected_param,
+                );
+                self.vid_reconstructor
+                    .handle_vid_share(self.public_key.clone(), vid_share);
             },
             ConsensusOutput::SendProposal(proposal) => {
                 let view = proposal.data.view_number;
@@ -1331,52 +1331,6 @@ where
         init_avidm_gf2_param(total_weight).ok()
     }
 
-    fn on_proposal_and_vid_share(
-        &mut self,
-        validated: ValidatedProposal<T>,
-        vid_share: VidDisperseShare2<T>,
-    ) -> Result<ConsensusInput<T>, CoordinatorError> {
-        self.storage.append_vid(vid_share.clone());
-        self.storage
-            .append_proposal(validated.message.proposal.data.clone());
-
-        if let Some(state_cert) = &validated.message.proposal.data.state_cert {
-            self.storage.append_state_cert(
-                ViewNumber::new(state_cert.light_client_state.view_number),
-                state_cert.clone(),
-            );
-        }
-
-        let expected_param = self.expected_vid_param(vid_share.target_epoch);
-        let proposal = &validated.message.proposal.data;
-        self.vid_reconstructor.handle_proposal(
-            proposal.view_number(),
-            vid_share.payload_commitment,
-            proposal.block_header.metadata().clone(),
-            proposal.epoch,
-            expected_param,
-        );
-        // This is our own share, addressed to us by the leader and already
-        // verified by the share validator.
-        self.vid_reconstructor
-            .handle_vid_share(self.public_key.clone(), vid_share.clone());
-
-        // GC for the cache
-        let view = validated.message.proposal.data.view_number();
-        self.cached_vid_shares = self
-            .cached_vid_shares
-            .split_off(&(view + 1, VidCommitment2::default()));
-        self.cached_validated_proposals = self
-            .cached_validated_proposals
-            .split_off(&(view + 1, VidCommitment2::default()));
-
-        Ok(ConsensusInput::ProposalWithVidShare(
-            validated.sender,
-            validated.message,
-            vid_share,
-        ))
-    }
-
     fn broadcast(
         &self,
         message_type: ConsensusMessage<T, Validated>,
@@ -1728,11 +1682,7 @@ where
         self.consensus.gc(scope);
         match scope {
             GcScope::Local(view) => {
-                let vc = VidCommitment2::default();
                 self.block_builder.gc(view);
-                self.cached_validated_proposals =
-                    self.cached_validated_proposals.split_off(&(view, vc));
-                self.cached_vid_shares = self.cached_vid_shares.split_off(&(view, vc));
                 self.vid_disperser.gc(view);
                 self.vid_fragment_accumulator.gc(view);
                 // When we enter a new view, we do not want to GC certain data

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -637,7 +637,7 @@ where
                         // the pending guard; consensus's `maybe_propose`
                         // will re-request the DRB when it next tries to
                         // build a transition proposal and finds it missing.
-                        warn!(%failure.error, epoch = %failure.epoch, "DRB request failed");
+                        warn!(err = %failure.error, epoch = %failure.epoch, "DRB request failed");
                         continue;
                     }
                 },

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -510,7 +510,14 @@ where
                     return Ok(ConsensusInput::AdvanceView(cert1))
                 }
                 Some(epoch_change) = self.cert_verifiers.epoch_change.next() => {
-                    return Ok(ConsensusInput::EpochChange(epoch_change.into_cert()))
+                    let epoch_change = epoch_change.into_cert();
+                    // The boundary leaf is final (Cert1 + Cert2), so seed a
+                    // commitment-only state for it: a validator whose
+                    // membership starts at this boundary can then build and
+                    // validate the new epoch's first proposals via catchup.
+                    self.state_manager
+                        .seed_from_header(epoch_change.proposal.clone());
+                    return Ok(ConsensusInput::EpochChange(epoch_change))
                 }
                 Some((cert1, state_cert)) = self.epoch_root_collector.next() => {
                     self.cert_verifiers.cert1.mark_completed(cert1.view_number());
@@ -899,6 +906,11 @@ where
                     epoch = ?epoch_change.cert1.epoch().map(|e| *e),
                     "send epoch change"
                 );
+                // A node that decided the boundary from broadcast Cert2s needs
+                // the boundary state seeded just like a receiver of an
+                // EpochChangeMessage; for members this is a no-op.
+                self.state_manager
+                    .seed_from_header(epoch_change.proposal.clone());
                 self.broadcast(
                     ConsensusMessage::EpochChange(epoch_change),
                     "broadcast epoch change",

--- a/crates/hotshot/new-protocol/src/lib.rs
+++ b/crates/hotshot/new-protocol/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod block;
+pub mod cert_verifier;
 pub mod client;
 pub mod consensus;
 pub mod coordinator;

--- a/crates/hotshot/new-protocol/src/message.rs
+++ b/crates/hotshot/new-protocol/src/message.rs
@@ -11,7 +11,8 @@ use hotshot_types::{
         OneHonestThreshold, SimpleCertificate, SuccessThreshold, TimeoutCertificate2,
     },
     simple_vote::{
-        LightClientStateUpdateVote2, QuorumVote2, SimpleVote, TimeoutData2, TimeoutVote2, Vote2Data,
+        HasEpoch, LightClientStateUpdateVote2, QuorumVote2, SimpleVote, TimeoutData2, TimeoutVote2,
+        Vote2Data,
     },
     traits::{node_implementation::NodeType, signature_key::SignatureKey},
     vote::HasViewNumber,
@@ -142,11 +143,65 @@ impl<T: NodeType> HasViewNumber for CatchupEvidence<T> {
 /// We include the proposal because the new leader in the next epoch
 /// will need it to build a header for the first block of the next epoch.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash, Eq)]
-#[serde(bound(deserialize = ""))]
-pub struct EpochChangeMessage<T: NodeType> {
+#[serde(bound(deserialize = "S: Deserialize<'de>"))]
+pub struct EpochChangeMessage<T: NodeType, S> {
     pub cert1: Certificate1<T>,
     pub cert2: Certificate2<T>,
     pub proposal: Proposal<T>,
+    #[serde(skip)]
+    _marker: PhantomData<fn() -> S>,
+}
+
+impl<T: NodeType> EpochChangeMessage<T, Validated> {
+    /// Wrap certificates this node has verified (or formed itself).
+    pub fn validated(
+        cert1: Certificate1<T>,
+        cert2: Certificate2<T>,
+        proposal: Proposal<T>,
+    ) -> Self {
+        Self {
+            cert1,
+            cert2,
+            proposal,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: NodeType> EpochChangeMessage<T, Unchecked> {
+    /// Mark this message's certificates as verified.
+    pub(crate) fn into_validated(self) -> EpochChangeMessage<T, Validated> {
+        EpochChangeMessage {
+            cert1: self.cert1,
+            cert2: self.cert2,
+            proposal: self.proposal,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: NodeType, S> EpochChangeMessage<T, S> {
+    #[cfg(test)]
+    pub fn into_unchecked(self) -> EpochChangeMessage<T, Unchecked> {
+        EpochChangeMessage {
+            cert1: self.cert1,
+            cert2: self.cert2,
+            proposal: self.proposal,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: NodeType, S> HasViewNumber for EpochChangeMessage<T, S> {
+    fn view_number(&self) -> ViewNumber {
+        self.cert1.view_number()
+    }
+}
+
+impl<T: NodeType, S> HasEpoch for EpochChangeMessage<T, S> {
+    fn epoch(&self) -> Option<EpochNumber> {
+        self.cert1.epoch()
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash, Eq)]
@@ -193,7 +248,7 @@ pub enum ConsensusMessage<T: NodeType, S> {
     Certificate2(Certificate2<T>, T::SignatureKey),
     TimeoutVote(TimeoutVoteMessage<T>),
     TimeoutCertificate(TimeoutCertificate2<T>),
-    EpochChange(EpochChangeMessage<T>),
+    EpochChange(EpochChangeMessage<T, S>),
     /// The leader's unicast of a per-namespace VID share fragment.
     VidShareFragment(VidShareFragmentMessage<T>),
     /// A node's own VID share, broadcast independently of Vote1.
@@ -212,7 +267,7 @@ impl<T: NodeType, S> ConsensusMessage<T, S> {
             Self::Certificate2(c, k) => ConsensusMessage::Certificate2(c, k),
             Self::TimeoutVote(v) => ConsensusMessage::TimeoutVote(v),
             Self::TimeoutCertificate(c) => ConsensusMessage::TimeoutCertificate(c),
-            Self::EpochChange(c) => ConsensusMessage::EpochChange(c),
+            Self::EpochChange(c) => ConsensusMessage::EpochChange(c.into_unchecked()),
             Self::VidShareFragment(v) => ConsensusMessage::VidShareFragment(v),
             Self::VidShareBroadcast(v) => ConsensusMessage::VidShareBroadcast(v),
             Self::HighQc(c) => ConsensusMessage::HighQc(c),

--- a/crates/hotshot/new-protocol/src/message.rs
+++ b/crates/hotshot/new-protocol/src/message.rs
@@ -15,6 +15,7 @@ use hotshot_types::{
         Vote2Data,
     },
     traits::{node_implementation::NodeType, signature_key::SignatureKey},
+    utils::is_last_block,
     vote::HasViewNumber,
 };
 pub use hotshot_types::{
@@ -22,6 +23,8 @@ pub use hotshot_types::{
     simple_certificate::{Certificate1, Certificate2},
 };
 use serde::{Deserialize, Serialize};
+
+use crate::helpers::proposal_commitment;
 
 pub type Vote2<T> = SimpleVote<T, Vote2Data<T>>;
 pub type TimeoutCertificate<T> = SimpleCertificate<T, TimeoutData2, SuccessThreshold>;
@@ -181,6 +184,26 @@ impl<T: NodeType> EpochChangeMessage<T, Unchecked> {
 }
 
 impl<T: NodeType, S> EpochChangeMessage<T, S> {
+    /// Structural validity of the message, independent of signatures.
+    pub fn well_formed(&self, epoch_height: u64) -> Result<(), EpochChangeError> {
+        if self.cert1.view_number() != self.cert2.view_number()
+            || self.cert1.epoch() != self.cert2.epoch()
+            || self.cert1.data.leaf_commit != self.cert2.data.leaf_commit
+        {
+            return Err(EpochChangeError::CertificateMismatch);
+        }
+        if !is_last_block(self.cert2.data.block_number, epoch_height) {
+            return Err(EpochChangeError::NotLastBlock);
+        }
+        if self.cert2.data.block_number / epoch_height != *self.cert2.data.epoch {
+            return Err(EpochChangeError::WrongEpoch);
+        }
+        if proposal_commitment(&self.proposal) != self.cert1.data.leaf_commit {
+            return Err(EpochChangeError::ProposalMismatch);
+        }
+        Ok(())
+    }
+
     #[cfg(test)]
     pub fn into_unchecked(self) -> EpochChangeMessage<T, Unchecked> {
         EpochChangeMessage {
@@ -190,6 +213,19 @@ impl<T: NodeType, S> EpochChangeMessage<T, S> {
             _marker: PhantomData,
         }
     }
+}
+
+/// Reason an [`EpochChangeMessage`] is not [well-formed](EpochChangeMessage::well_formed).
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+pub enum EpochChangeError {
+    #[error("certificates differ in view, epoch or leaf commitment")]
+    CertificateMismatch,
+    #[error("certificate2 is not for the last block of an epoch")]
+    NotLastBlock,
+    #[error("certificate2's block number does not match its epoch")]
+    WrongEpoch,
+    #[error("proposal commitment does not match certificate1's leaf commitment")]
+    ProposalMismatch,
 }
 
 impl<T: NodeType, S> HasViewNumber for EpochChangeMessage<T, S> {

--- a/crates/hotshot/new-protocol/src/proposal.rs
+++ b/crates/hotshot/new-protocol/src/proposal.rs
@@ -10,8 +10,8 @@ use hotshot_types::{
     simple_certificate::check_qc_state_cert_correspondence,
     simple_vote::HasEpoch,
     stake_table::StakeTableEntries,
-    traits::node_implementation::NodeType,
-    utils::is_epoch_root,
+    traits::{block_contents::BlockHeader, node_implementation::NodeType},
+    utils::{is_epoch_root, is_last_block},
     vote::{Certificate, HasViewNumber},
 };
 use hotshot_utils::anytrace;
@@ -90,6 +90,7 @@ impl<T: NodeType> ProposalValidator<T> {
         self.tasks.spawn(async move {
             let sender = v.signature(&p.proposal).await?;
             v.justify_qc(&p.proposal.data).await?;
+            v.next_epoch_justify_qc(&p.proposal.data).await?;
             v.view_change_evidence(&p.proposal.data).await?;
             v.state_cert(&p.proposal.data).await?;
             let validated_proposal = ValidatedProposal {
@@ -222,6 +223,36 @@ impl<T: NodeType> Validator<T> {
         }
     }
 
+    /// Verify the next-epoch justify QC on the first proposal of an epoch.
+    ///
+    /// If the previous block is the last block of an epoch, this proposal is
+    /// the first of the new epoch and must carry a `next_epoch_justify_qc`
+    /// over the same leaf as its justify QC.
+    async fn next_epoch_justify_qc(&self, proposal: &Proposal<T>) -> Result<()> {
+        let block_number = proposal.block_header.block_number();
+        if !is_last_block(block_number.saturating_sub(1), self.epoch_height) {
+            return Ok(());
+        }
+        let Some(cert2) = proposal.next_epoch_justify_qc.as_ref() else {
+            return Err(ValidationError::MissingNextEpochJustifyQc);
+        };
+        if cert2.data.leaf_commit != proposal.justify_qc.data.leaf_commit {
+            return Err(ValidationError::NextEpochJustifyQcMismatch);
+        }
+        let Some(epoch) = proposal.justify_qc.epoch() else {
+            return Err(ValidationError::MissingEpoch(
+                proposal.view_number,
+                "justify_qc",
+            ));
+        };
+        let membership = self.membership(epoch).await?;
+        let entries = StakeTableEntries::from_iter(membership.stake_table()).0;
+        let threshold = membership.success_threshold();
+        cert2
+            .is_valid_cert(&entries, threshold, &self.upgrade_lock)
+            .map_err(ValidationError::InvalidNextEpochJustifyQc)
+    }
+
     /// Validate the proposal's view-change evidence (timeout certificate).
     async fn view_change_evidence(&self, proposal: &Proposal<T>) -> Result<()> {
         let view = proposal.view_number();
@@ -303,6 +334,15 @@ pub enum ValidationError {
 
     #[error("invalid proposal justify qc: {0}")]
     InvalidJustifyQc(#[source] anytrace::Error),
+
+    #[error("first proposal of an epoch is missing next_epoch_justify_qc")]
+    MissingNextEpochJustifyQc,
+
+    #[error("next_epoch_justify_qc does not match the justify qc leaf commitment")]
+    NextEpochJustifyQcMismatch,
+
+    #[error("invalid next_epoch_justify_qc: {0}")]
+    InvalidNextEpochJustifyQc(#[source] anytrace::Error),
 
     #[error("vid share does not match proposal")]
     VidCommitmentDoesNotMatchProposal,

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -175,8 +175,15 @@ impl<T: NodeType> StateManager<T> {
 
     /// Seed a commitment-only (`from_header`) state so a child proposal can be
     /// validated against this leaf via catchup instead of being dropped.
+    ///
+    /// A real (validated) state for the leaf is never displaced, and any
+    /// header/state requests already queued on this leaf are restarted.
     pub(crate) fn seed_from_header(&mut self, proposal: Proposal<T>) {
-        self.insert_empty_state(proposal);
+        let commitment = proposal_commitment(&proposal);
+        if !self.validated_states.contains_key(&commitment) {
+            self.insert_empty_state(proposal);
+        }
+        self.start_pending(commitment);
     }
 
     pub fn request_state(&mut self, request: StateRequest<T>) {
@@ -204,10 +211,20 @@ impl<T: NodeType> StateManager<T> {
                 epoch = %request.epoch,
                 block = %request.block,
                 parent_commitment = %request.parent_commitment,
-                "parent state unavailable; deferring state validation (from_header stub inserted). \
-                 If this persists, the node cannot vote until the parent state is recovered."
+                "parent state unavailable; queued on parent for retry (from_header stub inserted). \
+                 If this persists, the parent state never arrived and the node cannot vote."
             );
-            self.insert_empty_state(request.proposal);
+            self.insert_empty_state(request.proposal.clone());
+            let queued = self
+                .pending_requests
+                .entry(request.parent_commitment)
+                .or_default();
+            if !queued
+                .iter()
+                .any(|p| matches!(p, Pending::State(r) if r.view == request.view))
+            {
+                queued.push(Pending::State(request));
+            }
             self.start_pending(commitment);
             return;
         };

--- a/crates/hotshot/new-protocol/src/tests.rs
+++ b/crates/hotshot/new-protocol/src/tests.rs
@@ -9,6 +9,7 @@ mod failures;
 mod integration;
 mod legacy_cutover;
 mod restarts;
+mod safety;
 mod stake_table_changes;
 mod state;
 mod storage;

--- a/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
@@ -21,6 +21,7 @@ use hotshot_types::{
 use super::utils::reconstructed_blocks;
 use crate::{
     block::{BlockBuilder, BlockBuilderConfig},
+    cert_verifier::CertVerifiers,
     client::CoordinatorClient,
     consensus::{Consensus, PreCutoverSeed},
     coordinator::{Coordinator, timer::Timer},
@@ -248,6 +249,7 @@ pub async fn build_test_coordinator(
         .timeout_collector(timeout_collector)
         .timeout_one_honest_collector(timeout_one_honest_collector)
         .epoch_root_collector(epoch_root_collector)
+        .cert_verifiers(CertVerifiers::new(membership.clone(), upgrade_lock.clone()))
         .vid_disperser(vid_disperser)
         .vid_reconstructor(vid_reconstructor)
         .epoch_manager(epoch_manager)

--- a/crates/hotshot/new-protocol/src/tests/common/harness.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/harness.rs
@@ -13,6 +13,7 @@ use hotshot_types::{
 use super::utils::mock_membership_with_num_nodes;
 use crate::{
     block::{BlockBuilder, BlockBuilderConfig},
+    cert_verifier::CertVerifiers,
     consensus::{Consensus, ConsensusInput, ConsensusOutput},
     coordinator::{error::Severity, timer::Timer},
     epoch::EpochManager,
@@ -138,6 +139,7 @@ impl TestHarness {
             .timeout_collector(timeout_collector)
             .timeout_one_honest_collector(timeout_one_honest_collector)
             .epoch_root_collector(epoch_root_collector)
+            .cert_verifiers(CertVerifiers::new(membership.clone(), upgrade_lock.clone()))
             .vid_disperser(vid_disperse_task)
             .vid_reconstructor(vid_reconstruction_task)
             .epoch_manager(epoch_manager)

--- a/crates/hotshot/new-protocol/src/tests/common/runner.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/runner.rs
@@ -17,6 +17,7 @@ use hotshot_types::{
     epoch_membership::EpochMembershipCoordinator,
     message::UpgradeLock,
     simple_certificate::TimeoutCertificate2,
+    simple_vote::HasEpoch,
     traits::{metrics::NoMetrics, signature_key::SignatureKey},
     vote::HasViewNumber,
     x25519::Keypair,
@@ -33,6 +34,7 @@ use tokio::{
 use tracing::{debug, info};
 
 use crate::{
+    cert_verifier::ValidCert,
     client::CoordinatorClient,
     consensus::{ConsensusInput, ConsensusOutput, PreCutoverSeed},
     coordinator::{Coordinator, error::Severity},
@@ -372,7 +374,9 @@ impl TestRunner {
 
             if let Some(certs) = self.initial_timeout_certs.get(&i) {
                 for tc in certs {
-                    coord.apply_consensus(ConsensusInput::TimeoutCertificate(tc.clone()));
+                    let epoch = tc.epoch().expect("seeded timeout cert has an epoch");
+                    let tc = ValidCert::new(tc.clone(), epoch);
+                    coord.apply_consensus(ConsensusInput::TimeoutCertificate(tc));
                     for output in coord.outbox_mut().take() {
                         // Keep the seeded certs local to this node; the
                         // real network never delivered them to the others.

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -53,6 +53,7 @@ use hotshot_types::{
 };
 
 use crate::{
+    cert_verifier::ValidCert,
     client::{ClientLeafFetcherNetwork, CoordinatorClient},
     consensus::{Consensus, ConsensusInput, ConsensusOutput},
     helpers::{proposal_commitment, test_upgrade_lock},
@@ -168,12 +169,12 @@ impl TestView {
 
     /// Build an Event for Certificate1.
     pub fn cert1_input(&self) -> ConsensusInput<TestTypes> {
-        ConsensusInput::Certificate1(self.cert1.clone())
+        ConsensusInput::Certificate1(ValidCert::new(self.cert1.clone(), self.epoch_number))
     }
 
     /// Build an Event for Certificate2.
     pub fn cert2_input(&self) -> ConsensusInput<TestTypes> {
-        ConsensusInput::Certificate2(self.cert2.clone())
+        ConsensusInput::Certificate2(ValidCert::new(self.cert2.clone(), self.epoch_number))
     }
 
     /// Build a Vote1 Event from a specific validator, carrying that validator's
@@ -284,9 +285,11 @@ impl TestView {
     }
 
     /// Build an Event for a timeout certificate.
-    #[allow(dead_code)]
     pub fn timeout_cert_input(&self) -> ConsensusInput<TestTypes> {
-        ConsensusInput::TimeoutCertificate(self.timeout_cert.clone())
+        ConsensusInput::TimeoutCertificate(ValidCert::new(
+            self.timeout_cert.clone(),
+            self.epoch_number,
+        ))
     }
 }
 

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -147,11 +147,17 @@ impl TestView {
             )),
         }
     }
-    pub fn proposal_input_consensus(&self, recipient_key: &BLSPubKey) -> ConsensusInput<TestTypes> {
-        ConsensusInput::ProposalWithVidShare(
-            self.leader_public_key,
-            self.proposal_message(),
-            self.vid_share_for(recipient_key),
+    /// Build the proposal and VID share inputs a node receives for this view.
+    ///
+    /// Consensus pairs the two internally, so both must be applied
+    /// (cf. [`ConsensusHarness::apply_pair`]).
+    pub fn proposal_input_consensus(
+        &self,
+        recipient_key: &BLSPubKey,
+    ) -> (ConsensusInput<TestTypes>, ConsensusInput<TestTypes>) {
+        (
+            ConsensusInput::Proposal(self.leader_public_key, self.proposal_message()),
+            ConsensusInput::VidShare(self.vid_share_for(recipient_key)),
         )
     }
 
@@ -1067,22 +1073,18 @@ impl ConsensusHarness {
     /// actions that consensus expects feedback for.
     pub async fn apply(&mut self, input: ConsensusInput<TestTypes>) {
         let mut outbox = Outbox::new();
-        // The coordinator persists incoming proposals and VID shares before
-        // consensus sees them; simulate those storage confirmations.
-        if let ConsensusInput::ProposalWithVidShare(_, msg, vid_share) = &input {
-            let view = msg.proposal.data.view_number;
-            let commitment = proposal_commitment(&msg.proposal.data);
-            self.consensus.apply(
-                ConsensusInput::Stored(StorageOutput::Proposal(view, commitment)),
-                &mut outbox,
-            );
-            self.consensus.apply(
-                ConsensusInput::Stored(StorageOutput::Vid(vid_share.view_number)),
-                &mut outbox,
-            );
-        }
         self.consensus.apply(input, &mut outbox);
         self.drain_outbox(&mut outbox).await;
+    }
+
+    /// Apply a proposal/VID-share input pair
+    /// (cf. `TestView::proposal_input_consensus`).
+    pub async fn apply_pair(
+        &mut self,
+        (proposal, vid_share): (ConsensusInput<TestTypes>, ConsensusInput<TestTypes>),
+    ) {
+        self.apply(proposal).await;
+        self.apply(vid_share).await;
     }
 
     async fn drain_outbox(&mut self, outbox: &mut Outbox<ConsensusOutput<TestTypes>>) {
@@ -1119,6 +1121,23 @@ impl ConsensusHarness {
                 let commitment = proposal_commitment(&proposal.data);
                 self.consensus.apply(
                     ConsensusInput::Stored(StorageOutput::Proposal(view, commitment)),
+                    outbox,
+                );
+            },
+            // The coordinator persists a paired proposal and VID share;
+            // simulate the storage confirmations.
+            ConsensusOutput::ProposalPaired {
+                proposal,
+                vid_share,
+            } => {
+                let view = proposal.data.view_number;
+                let commitment = proposal_commitment(&proposal.data);
+                self.consensus.apply(
+                    ConsensusInput::Stored(StorageOutput::Proposal(view, commitment)),
+                    outbox,
+                );
+                self.consensus.apply(
+                    ConsensusInput::Stored(StorageOutput::Vid(vid_share.view_number)),
                     outbox,
                 );
             },

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
 };
 
@@ -985,6 +985,8 @@ pub(crate) struct ConsensusHarness {
     pub consensus: Consensus<TestTypes>,
     pub membership_coordinator: EpochMembershipCoordinator<TestTypes>,
     pub collected: Outbox<ConsensusOutput<TestTypes>>,
+    deferred_states: BTreeMap<ViewNumber, ConsensusInput<TestTypes>>,
+    defer_state_for: BTreeSet<ViewNumber>,
 }
 
 impl ConsensusHarness {
@@ -1020,6 +1022,8 @@ impl ConsensusHarness {
             consensus,
             membership_coordinator: membership,
             collected: Outbox::new(),
+            deferred_states: BTreeMap::new(),
+            defer_state_for: BTreeSet::new(),
         }
     }
 
@@ -1069,7 +1073,29 @@ impl ConsensusHarness {
             consensus,
             membership_coordinator: membership,
             collected: Outbox::new(),
+            deferred_states: BTreeMap::new(),
+            defer_state_for: BTreeSet::new(),
         }
+    }
+
+    /// Withhold `view`'s state-validation response until [`Self::release_state`].
+    ///
+    /// The harness answers `RequestState` inline, which a real node cannot do:
+    /// validation runs asynchronously and may finish long after the proposal
+    /// was admitted. Tests that turn on that delay need to place it themselves.
+    /// Must be called before the proposal for `view` is applied.
+    pub fn defer_state(&mut self, view: ViewNumber) {
+        self.defer_state_for.insert(view);
+    }
+
+    /// Deliver the response withheld by [`Self::defer_state`].
+    pub async fn release_state(&mut self, view: ViewNumber) {
+        self.defer_state_for.remove(&view);
+        let input = self
+            .deferred_states
+            .remove(&view)
+            .expect("a state request for this view was deferred");
+        self.apply(input).await;
     }
 
     /// Apply a [`ConsensusInput`] and drain outputs, auto-responding to
@@ -1105,7 +1131,11 @@ impl ConsensusHarness {
         match output {
             ConsensusOutput::RequestState(req) => {
                 let input = state_verified_input(&req.proposal, req.view);
-                self.consensus.apply(input, outbox);
+                if self.defer_state_for.contains(&req.view) {
+                    self.deferred_states.insert(req.view, input);
+                } else {
+                    self.consensus.apply(input, outbox);
+                }
             },
             ConsensusOutput::RecordAction(view, _, kind) => {
                 self.consensus.apply(
@@ -1283,6 +1313,109 @@ pub(crate) fn build_cert2(
         private_key,
         &test_upgrade_lock::<TestTypes>(),
     )
+}
+
+/// A single node's signature over some vote data, tagged with who produced it.
+pub(crate) type SignerShare = (u64, <BLSPubKey as SignatureKey>::PureAssembledSignatureType);
+
+/// Aggregate `shares` into a certificate over `data`.
+///
+/// The counterpart of [`build_cert`], which marks *every* committee member as a
+/// signer. That is fine when a test needs only *a* valid certificate, and wrong
+/// when the claim depends on who signed. This records exactly the given signers
+/// in the certificate's bit vector, so the result verifies only if they truly
+/// meet the threshold — and it accepts signatures produced elsewhere, which is
+/// what lets a test aggregate the votes real nodes emitted.
+///
+/// A share's `u64` is the seed index its key was generated from, and doubles as
+/// the position in the stake table's bit vector — the correspondence
+/// [`build_assembled_sig`] relies on too. Order within `shares` does not matter;
+/// BLS aggregation is a sum.
+///
+/// Panics if `shares` is below the success threshold, since such a certificate
+/// would not verify and the caller almost certainly meant otherwise. That count
+/// is compared against a stake-weighted threshold, which only holds while every
+/// member has unit stake, as under [`mock_membership`].
+pub(crate) fn assemble_cert<DATA, CERT>(
+    data: DATA,
+    view_number: ViewNumber,
+    epoch_membership: &hotshot_types::epoch_membership::EpochMembership<TestTypes>,
+    shares: &[SignerShare],
+) -> CERT
+where
+    DATA: hotshot_types::simple_vote::Voteable<TestTypes> + 'static,
+    CERT: hotshot_types::vote::Certificate<TestTypes, DATA, Voteable = DATA>,
+{
+    use bitvec::bitvec;
+    use hotshot_types::{simple_vote::VersionedVoteData, stake_table::StakeTableEntries};
+
+    let upgrade_lock = test_upgrade_lock::<TestTypes>();
+    let stake_table = CERT::stake_table(epoch_membership);
+    let entries = StakeTableEntries::from_iter(stake_table.iter()).0;
+    let threshold = CERT::threshold(epoch_membership);
+    assert!(
+        alloy::primitives::U256::from(shares.len()) >= threshold,
+        "{} signers is below the threshold of {threshold}",
+        shares.len()
+    );
+    let qc_pp = <BLSPubKey as SignatureKey>::public_parameter(&entries, threshold);
+
+    let mut signer_bits = bitvec![0; stake_table.len()];
+    let mut signatures = Vec::new();
+    for (node, signature) in shares {
+        signer_bits.set(*node as usize, true);
+        signatures.push(signature.clone());
+    }
+
+    let assembled =
+        <BLSPubKey as SignatureKey>::assemble(&qc_pp, signer_bits.as_bitslice(), &signatures[..]);
+    let vote_commitment = VersionedVoteData::new(data.clone(), view_number, &upgrade_lock)
+        .expect("versioned vote data")
+        .commit();
+    CERT::create_signed_certificate(vote_commitment, data, assembled, view_number)
+}
+
+/// Sign `data` as `node` would, and return the signature tagged with `node`.
+///
+/// For votes a test must fabricate — an adversary's, or a node it does not run.
+pub(crate) fn sign_vote_as<DATA>(node: u64, data: DATA, view_number: ViewNumber) -> SignerShare
+where
+    DATA: hotshot_types::simple_vote::Voteable<TestTypes> + 'static,
+{
+    use hotshot_types::{simple_vote::SimpleVote, vote::Vote};
+
+    let (public_key, private_key) = BLSPubKey::generated_from_seed_indexed([0u8; 32], node);
+    let vote = SimpleVote::<TestTypes, DATA>::create_signed_vote(
+        data,
+        view_number,
+        &public_key,
+        &private_key,
+        &test_upgrade_lock::<TestTypes>(),
+    )
+    .expect("sign vote");
+    (node, vote.signature())
+}
+
+/// Build a timeout certificate signed by exactly `signers`.
+///
+/// The signer set carries meaning: a node that sent a timeout vote for
+/// `view_number` has raised its `timeout_view` to it, which constrains what it
+/// may do afterwards.
+pub(crate) fn build_timeout_cert_signed_by(
+    view_number: ViewNumber,
+    epoch: EpochNumber,
+    epoch_membership: &hotshot_types::epoch_membership::EpochMembership<TestTypes>,
+    signers: &[u64],
+) -> TimeoutCertificate2<TestTypes> {
+    let data = TimeoutData2 {
+        view: view_number,
+        epoch: Some(epoch),
+    };
+    let shares: Vec<SignerShare> = signers
+        .iter()
+        .map(|node| sign_vote_as(*node, data.clone(), view_number))
+        .collect();
+    assemble_cert(data, view_number, epoch_membership, &shares)
 }
 
 pub(crate) fn build_timeout_cert(

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -39,7 +39,7 @@ async fn test_safety_genesis_no_lock() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
 
     assert!(
@@ -67,12 +67,12 @@ async fn test_timeout_filters_vote1_not_processing() {
     // Send stale proposal (view 2, which is <= timeout_view 3).
     // It is still processed (state validation requested) but vote1 is suppressed.
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
 
     // Send fresh proposal (view 4, which is > timeout_view 3)
     harness
-        .apply(test_data.views[3].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[3].proposal_input_consensus(&node_key))
         .await;
 
     // Both proposals are processed.
@@ -94,14 +94,14 @@ async fn test_vote1_for_sequential_views() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
 
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
 
     assert_eq!(
@@ -129,7 +129,7 @@ async fn test_vote1_with_seeded_parent_proposal() {
 
     // The view-2 proposal arrives and builds on the re-seeded parent.
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
 
     assert!(
@@ -156,7 +156,7 @@ async fn test_vote1_parent_reconstruction_from_lock() {
         .seed_locked_cert(test_data.views[0].cert1.clone());
 
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
 
     assert!(
@@ -178,7 +178,7 @@ async fn test_vote1_blocked_without_parent_proposal() {
         .await;
 
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
 
     assert!(
@@ -195,7 +195,7 @@ async fn test_vote1_genesis_parent() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
 
     assert!(
@@ -213,14 +213,14 @@ async fn test_vote2_missing_cert1() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
 
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
@@ -240,14 +240,14 @@ async fn test_vote2_with_cert1() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
 
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
@@ -268,14 +268,14 @@ async fn test_single_view_decide() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
 
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
@@ -300,13 +300,13 @@ async fn test_cert2_broadcast_once() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
@@ -348,7 +348,7 @@ async fn test_late_cert2_decides_after_view_change_gc() {
     // Drive views 1..=4 forward with Cert1 only, so nothing decides.
     for view in &test_data.views[0..4] {
         harness
-            .apply(view.proposal_input_consensus(&node_key))
+            .apply_pair(view.proposal_input_consensus(&node_key))
             .await;
         harness.apply(view.block_reconstructed_input()).await;
         harness.apply(view.cert1_input()).await;
@@ -382,7 +382,7 @@ async fn test_gap_fill_decide_of_older_view() {
 
     // Decide view 4 without ever delivering views 1-3, leaving a gap.
     harness
-        .apply(test_data.views[3].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[3].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[3].block_reconstructed_input())
@@ -437,7 +437,7 @@ async fn test_no_duplicate_vote1() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
@@ -459,14 +459,14 @@ async fn test_no_duplicate_vote2() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
 
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
@@ -489,7 +489,7 @@ async fn test_state_validation_failed_removes_proposal() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
@@ -499,9 +499,10 @@ async fn test_state_validation_failed_removes_proposal() {
     // by directly applying the proposal input, then manually sending
     // StateValidationFailed instead of letting the harness auto-respond.
     // We need to call consensus.apply directly to avoid auto StateVerified.
-    let proposal_input = test_data.views[1].proposal_input_consensus(&node_key);
+    let (proposal_input, vid_share_input) = test_data.views[1].proposal_input_consensus(&node_key);
     let mut outbox = Outbox::new();
     harness.consensus.apply(proposal_input, &mut outbox);
+    harness.consensus.apply(vid_share_input, &mut outbox);
     harness.collected.extend(outbox.take());
 
     // Send StateVerificationFailed — removes proposal
@@ -539,14 +540,14 @@ async fn test_decide_requires_cert2() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
 
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
@@ -569,7 +570,7 @@ async fn test_vote2_missing_block_reconstructed() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
@@ -577,7 +578,7 @@ async fn test_vote2_missing_block_reconstructed() {
 
     // View 2: proposal + cert1, but NO block_reconstructed for view 2
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness.apply(test_data.views[1].cert1_input()).await;
 
@@ -595,7 +596,7 @@ async fn test_vote2_block_reconstructed_arrives_late() {
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
@@ -603,7 +604,7 @@ async fn test_vote2_block_reconstructed_arrives_late() {
 
     // View 2: proposal + cert1 first (no block_reconstructed yet)
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness.apply(test_data.views[1].cert1_input()).await;
 
@@ -627,7 +628,7 @@ async fn test_multi_view_chain_decide() {
 
     for view in &test_data.views {
         harness
-            .apply(view.proposal_input_consensus(&node_key))
+            .apply_pair(view.proposal_input_consensus(&node_key))
             .await;
         harness.apply(view.block_reconstructed_input()).await;
         harness.apply(view.cert1_input()).await;
@@ -647,7 +648,7 @@ async fn test_timeout_prevents_vote1_but_allows_vote2() {
 
     // Process view 1 to establish state.
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
@@ -671,7 +672,7 @@ async fn test_timeout_prevents_vote1_but_allows_vote2() {
     // The proposal is still stored (inputs are processed), but vote1 is
     // suppressed because view 2 <= timeout_view.
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
@@ -702,7 +703,7 @@ async fn test_leader_sends_proposal() {
     let mut harness = ConsensusHarness::new(leader_index).await;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&leader_for_view_2))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&leader_for_view_2))
         .await;
     harness.apply(test_data.views[0].cert1_input()).await;
 
@@ -740,7 +741,7 @@ async fn test_propose_refuses_when_stored_proposal_differs_from_cert() {
     // triggers RequestBlockAndHeader for view 2 (auto-built by the harness
     // against the canonical view-1 proposal as parent).
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&leader_for_view_2))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&leader_for_view_2))
         .await;
 
     // Sanity: header for view 2 has been built off the canonical view-1
@@ -814,7 +815,7 @@ async fn test_leader_proposes_after_timeout() {
 
     // Build up locked_cert: process view 1 so cert1 sets locked_cert
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&leader_for_view_3))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&leader_for_view_3))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
@@ -1022,7 +1023,7 @@ async fn test_non_leader_does_not_propose() {
     let mut harness = ConsensusHarness::new(non_leader_index).await;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&non_leader_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&non_leader_key))
         .await;
     harness.apply(test_data.views[0].cert1_input()).await;
 
@@ -1043,7 +1044,7 @@ async fn test_safety_rejects_proposal_below_lock() {
 
     // Process view 1 fully: proposal + block_reconstructed + cert1 → locked_qc = view 1
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
@@ -1052,7 +1053,7 @@ async fn test_safety_rejects_proposal_below_lock() {
 
     // Process view 2 fully → locked_qc = view 2
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
@@ -1067,7 +1068,7 @@ async fn test_safety_rejects_proposal_below_lock() {
     // Safety:   genesis commitment != cert1(view 2) commitment = false
     // → Proposal rejected by is_safe, no RequestState emitted.
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
 
     let state_requests_after = count_matching(harness.outputs(), is_request_state);
@@ -1088,7 +1089,7 @@ async fn test_vote_after_timeout_cert() {
 
     // Process view 1 fully → locked_qc = view 1
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
@@ -1097,7 +1098,7 @@ async fn test_vote_after_timeout_cert() {
 
     // Process view 2 proposal + block_reconstructed (need parent data for view 3)
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
@@ -1126,7 +1127,7 @@ async fn test_vote_after_timeout_cert() {
     // Process proposal for view 3. Its justify_qc is at view 2, which is
     // >= locked_qc at view 1 (liveness passes). Parent data for view 2 exists.
     harness
-        .apply(test_data.views[2].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[2].proposal_input_consensus(&node_key))
         .await;
 
     assert!(
@@ -1152,7 +1153,7 @@ async fn test_no_vote_after_timeout_for_proposal_below_lock() {
     // Process views 1-3 fully → locked_qc = cert1 for view 3
     for i in 0..3 {
         harness
-            .apply(test_data.views[i].proposal_input_consensus(&node_key))
+            .apply_pair(test_data.views[i].proposal_input_consensus(&node_key))
             .await;
         harness
             .apply(test_data.views[i].block_reconstructed_input())
@@ -1173,7 +1174,7 @@ async fn test_no_vote_after_timeout_for_proposal_below_lock() {
     //          justify_qc commitment ≠ locked_qc commitment → false (safety fails)
     // → Proposal rejected by is_safe.
     harness
-        .apply(test_data.views[2].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[2].proposal_input_consensus(&node_key))
         .await;
 
     assert_eq!(
@@ -1192,13 +1193,13 @@ async fn test_decide_not_repeated_for_same_view() {
 
     // Full round for view 2
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
     harness
-        .apply(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
@@ -1245,7 +1246,7 @@ async fn test_restart_does_not_redecide_anchor() {
 
     // Drive the first decide after the restart at the next view.
     harness
-        .apply(decider.proposal_input_consensus(&node_key))
+        .apply_pair(decider.proposal_input_consensus(&node_key))
         .await;
     harness.apply(decider.block_reconstructed_input()).await;
     harness.apply(decider.cert1_input()).await;
@@ -1469,10 +1470,9 @@ async fn test_vote1_gated_on_storage() {
     let consensus = &mut harness.consensus;
     let mut outbox = Outbox::new();
 
-    consensus.apply(
-        test_data.views[0].proposal_input_consensus(&node_key),
-        &mut outbox,
-    );
+    let (proposal_input, vid_share_input) = test_data.views[0].proposal_input_consensus(&node_key);
+    consensus.apply(proposal_input, &mut outbox);
+    consensus.apply(vid_share_input, &mut outbox);
     consensus.apply(
         state_verified_input(&test_data.views[0].proposal.data, view),
         &mut outbox,
@@ -1517,10 +1517,9 @@ async fn test_vote2_gated_on_vid_storage() {
     let consensus = &mut harness.consensus;
     let mut outbox = Outbox::new();
 
-    consensus.apply(
-        test_data.views[0].proposal_input_consensus(&node_key),
-        &mut outbox,
-    );
+    let (proposal_input, vid_share_input) = test_data.views[0].proposal_input_consensus(&node_key);
+    consensus.apply(proposal_input, &mut outbox);
+    consensus.apply(vid_share_input, &mut outbox);
     consensus.apply(
         state_verified_input(&test_data.views[0].proposal.data, view),
         &mut outbox,
@@ -1574,10 +1573,9 @@ async fn test_pending_vote1_dropped_on_timeout() {
     let consensus = &mut harness.consensus;
     let mut outbox = Outbox::new();
 
-    consensus.apply(
-        test_data.views[0].proposal_input_consensus(&node_key),
-        &mut outbox,
-    );
+    let (proposal_input, vid_share_input) = test_data.views[0].proposal_input_consensus(&node_key);
+    consensus.apply(proposal_input, &mut outbox);
+    consensus.apply(vid_share_input, &mut outbox);
     consensus.apply(
         state_verified_input(&test_data.views[0].proposal.data, view),
         &mut outbox,
@@ -1612,7 +1610,7 @@ async fn test_proposal_release_follows_storage() {
     let mut harness = ConsensusHarness::new(leader_index).await;
 
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&leader_for_view_2))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&leader_for_view_2))
         .await;
     harness.apply(test_data.views[0].cert1_input()).await;
 

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -850,7 +850,7 @@ async fn test_timeout_proposal_chains_from_lock_not_timed_out_cert1() {
 
     // Lock on cert1(1).
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&leader_for_view_3))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&leader_for_view_3))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
@@ -909,7 +909,7 @@ async fn test_bridged_legacy_qc_adopts_lock_and_reproposes() {
 
     // Lock on cert1(1); hold view 2's proposal but no cert for it.
     harness
-        .apply(test_data.views[0].proposal_input_consensus(&leader_for_view_3))
+        .apply_pair(test_data.views[0].proposal_input_consensus(&leader_for_view_3))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -8,10 +8,12 @@ use hotshot_example_types::{
 };
 use hotshot_types::{
     data::{EpochNumber, Leaf2, ViewNumber},
+    message::Proposal as SignedProposal,
+    simple_certificate::TimeoutCertificate2,
     traits::signature_key::SignatureKey,
 };
 
-use super::common::utils::TestData;
+use super::common::utils::{TestData, TestView};
 use crate::{
     consensus::{ConsensusInput, ConsensusOutput},
     coordinator::GcScope,
@@ -1667,5 +1669,264 @@ async fn test_seed_proposals_populates_undecided_chain() {
             .map(|v| v.view_number)
             .collect::<Vec<_>>(),
         "every seeded proposal should surface as an undecided leaf"
+    );
+}
+
+/// `template`'s proposal re-parented onto `parent` and re-signed by `template`'s
+/// leader, with `evidence` as the view-change certificate for the gap.
+///
+/// The payload is `template`'s, so the VID shares dispersed for that view still
+/// match it and only the ancestry differs. That is what makes a competing branch
+/// out of material the honest nodes already hold.
+fn reparented_proposal(
+    template: &TestView,
+    parent: &TestView,
+    evidence: TimeoutCertificate2<TestTypes>,
+) -> SignedProposal<TestTypes, Proposal<TestTypes>> {
+    let parent_leaf: Leaf2<TestTypes> = parent.proposal.data.clone().into();
+    let mut proposal = template.proposal.data.clone();
+    proposal.block_header = TestBlockHeader::new(
+        &parent_leaf,
+        template.proposal.data.block_header.payload_commitment,
+        template
+            .proposal
+            .data
+            .block_header
+            .builder_commitment
+            .clone(),
+        template.proposal.data.block_header.metadata,
+        TEST_VERSIONS.test.base,
+    );
+    proposal.justify_qc = parent.cert1.clone();
+    proposal.view_change_evidence = Some(evidence);
+
+    let signature = <BLSPubKey as SignatureKey>::sign(
+        &template.leader_private_key,
+        proposal_commitment(&proposal).as_ref(),
+    )
+    .expect("sign re-parented proposal");
+    SignedProposal::new(proposal, signature)
+}
+
+/// One node does not vote for both sides of a fork.
+///
+/// A single-node version of `tests::safety`, which builds the same conflict out
+/// of a whole committee. The two commits of a fork need two quorums, and two
+/// quorums drawn from `3f + 1` nodes meet in an honest node, so a fork needs one
+/// node to vote on both sides. This drives exactly that node.
+///
+/// The setup is what makes the second vote reachable at all. The lock is the
+/// only thing that rejects a proposal reaching back past view 3, and it advances
+/// only on a phase-2 vote, which needs the block. So a node holding view 3's
+/// *certificate* but not its *block* is past view 3 and still unlocked: it
+/// accepts a proposal parented at view 1 and votes phase-1 for it. When view 3's
+/// block finally lands, everything a phase-2 vote there requires is present.
+///
+/// `Consensus::voted_for_branch_excluding` is what refuses it — the phase-1 vote
+/// at view 6 was justified at view 1, so the branch it endorsed holds no block
+/// for view 3.
+#[tokio::test]
+async fn test_no_fork_votes_from_one_node() {
+    let mut harness = ConsensusHarness::new(0).await;
+    let test_data = TestData::new(6).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+
+    // View 1 arrives in full, so the node locks there. The fork's proposal is
+    // parented here, which is what lets it pass the admission check.
+    harness
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
+        .await;
+    harness
+        .apply(test_data.views[0].block_reconstructed_input())
+        .await;
+    harness.apply(test_data.views[0].cert1_input()).await;
+    assert_eq!(
+        harness.consensus.locked_view(),
+        Some(ViewNumber::new(1)),
+        "view 1 arrived in full, so it should be locked"
+    );
+
+    // The certificate for view 3 arrives but its block does not: the node
+    // leaves view 3 behind without locking on it.
+    harness
+        .apply(ConsensusInput::AdvanceView(
+            crate::cert_verifier::ValidCert::new(
+                test_data.views[2].cert1.clone(),
+                test_data.views[2].epoch_number,
+            ),
+        ))
+        .await;
+    assert_eq!(
+        (
+            harness.consensus.current_view(),
+            harness.consensus.locked_view()
+        ),
+        (ViewNumber::new(4), Some(ViewNumber::new(1))),
+        "past view 3, still locked at view 1"
+    );
+
+    // The competing proposal: view 6, parented at view 1, so it skips view 3
+    // entirely. The timeout certificate for view 5 is what lets it reach back.
+    let signed = reparented_proposal(
+        &test_data.views[5],
+        &test_data.views[0],
+        test_data.views[4].timeout_cert.clone(),
+    );
+
+    harness
+        .apply(ConsensusInput::Proposal(
+            test_data.views[5].leader_public_key,
+            crate::message::ProposalMessage::validated(signed),
+        ))
+        .await;
+    harness
+        .apply(ConsensusInput::VidShare(
+            test_data.views[5].vid_share_for(&node_key),
+        ))
+        .await;
+
+    // The phase-1 vote is parked pending persistence, so the recorded action is
+    // the decision to vote; counting sends alone understates it. At view 6 that
+    // action can only be the phase-1 vote, since no `Certificate1` for view 6 is
+    // ever supplied.
+    let voted_fork = harness.outputs().iter().any(|o| {
+        matches!(o, ConsensusOutput::RecordAction(v, _, ActionKind::Vote)
+            if *v == ViewNumber::new(6))
+    });
+    assert!(
+        voted_fork,
+        "the forked proposal should have been admitted and voted on"
+    );
+
+    // The block for view 3 lands at last. Phase-2 votes are sent directly, so
+    // `SendVote2` at view 3 is unambiguous — unlike the recorded action, which
+    // view 3's phase-1 vote also produces.
+    harness
+        .apply_pair(test_data.views[2].proposal_input_consensus(&node_key))
+        .await;
+    harness
+        .apply(test_data.views[2].block_reconstructed_input())
+        .await;
+    harness.apply(test_data.views[2].cert1_input()).await;
+
+    let view3_commit = proposal_commitment(&test_data.views[2].proposal.data);
+    let voted_committed = harness.outputs().iter().any(|o| {
+        matches!(o, ConsensusOutput::SendVote2(v)
+            if v.data.leaf_commit == view3_commit)
+    });
+
+    assert!(
+        !voted_committed,
+        "one node voted for both sides of a fork: phase-1 at view 6 on a branch parented at view \
+         1, and phase-2 at view 3"
+    );
+}
+
+/// The same fork with the two votes in the opposite order.
+///
+/// [`test_no_fork_votes_from_one_node`] has the phase-1 vote on the competing
+/// branch come first, and `Consensus::voted_for_branch_excluding` refuses the
+/// phase-2 vote that would follow. Swapping the order gives the node the same
+/// pair of votes by a different route, and nothing about a fork says which
+/// arrives first.
+///
+/// What separates the two orders is when a proposal is measured against the
+/// lock. `handle_proposal_with_vid_share` checks it on arrival, once, and the
+/// phase-1 vote can be cast much later: it waits on state validation, which a
+/// real node runs asynchronously. A phase-2 vote in that window takes the lock,
+/// and the check that would have caught the competing proposal has already
+/// passed. `maybe_vote_1` re-checks for that reason.
+///
+/// The harness answers `RequestState` inline, so the window has to be opened
+/// deliberately with [`ConsensusHarness::defer_state`].
+#[tokio::test]
+async fn test_no_fork_votes_from_one_node_reversed() {
+    let mut harness = ConsensusHarness::new(0).await;
+    let test_data = TestData::new(6).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+
+    // View 1 in full, as before: the lock the competing proposal is parented on.
+    harness
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
+        .await;
+    harness
+        .apply(test_data.views[0].block_reconstructed_input())
+        .await;
+    harness.apply(test_data.views[0].cert1_input()).await;
+    assert_eq!(
+        harness.consensus.locked_view(),
+        Some(ViewNumber::new(1)),
+        "view 1 arrived in full, so it should be locked"
+    );
+
+    // The competing proposal arrives while the node is still locked at view 1,
+    // so it is admitted. Its state validation is withheld, which is the only
+    // thing keeping the phase-1 vote from being cast right here.
+    let signed = reparented_proposal(
+        &test_data.views[5],
+        &test_data.views[0],
+        test_data.views[4].timeout_cert.clone(),
+    );
+    let fork_commit = proposal_commitment(&signed.data);
+
+    harness.defer_state(ViewNumber::new(6));
+    harness
+        .apply(ConsensusInput::Proposal(
+            test_data.views[5].leader_public_key,
+            crate::message::ProposalMessage::validated(signed),
+        ))
+        .await;
+    harness
+        .apply(ConsensusInput::VidShare(
+            test_data.views[5].vid_share_for(&node_key),
+        ))
+        .await;
+    let acted_at_6 = |harness: &ConsensusHarness| {
+        harness.outputs().iter().any(|o| {
+            matches!(o, ConsensusOutput::RecordAction(v, _, ActionKind::Vote)
+                if *v == ViewNumber::new(6))
+        })
+    };
+    assert!(
+        !acted_at_6(&harness),
+        "the phase-1 vote should still be waiting on state validation"
+    );
+
+    // View 3 arrives in full and the node commits to it, taking the lock.
+    harness
+        .apply_pair(test_data.views[2].proposal_input_consensus(&node_key))
+        .await;
+    harness
+        .apply(test_data.views[2].block_reconstructed_input())
+        .await;
+    harness.apply(test_data.views[2].cert1_input()).await;
+
+    let view3_commit = proposal_commitment(&test_data.views[2].proposal.data);
+    let voted_committed = harness.outputs().iter().any(|o| {
+        matches!(o, ConsensusOutput::SendVote2(v)
+            if v.data.leaf_commit == view3_commit)
+    });
+    assert!(
+        voted_committed,
+        "view 3 arrived in full, so the node should have voted phase-2 there"
+    );
+    assert_eq!(
+        harness.consensus.locked_view(),
+        Some(ViewNumber::new(3)),
+        "the phase-2 vote should have taken the lock at view 3"
+    );
+
+    // Only now does view 6's state validation come back. The proposal skips
+    // view 3, which the node has since committed to.
+    harness.release_state(ViewNumber::new(6)).await;
+
+    let sent_fork_vote1 = harness.outputs().iter().any(|o| {
+        matches!(o, ConsensusOutput::SendVote1(v)
+            if v.vote.data.leaf_commit == fork_commit)
+    });
+    assert!(
+        !(acted_at_6(&harness) || sent_fork_vote1),
+        "one node voted for both sides of a fork: phase-2 at view 3, and phase-1 at view 6 on a \
+         branch parented at view 1"
     );
 }

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -15,7 +15,7 @@ use super::common::{
 use crate::{
     consensus::{ConsensusInput, ConsensusOutput},
     helpers::proposal_commitment,
-    message::{EpochChangeMessage, Proposal, ProposalMessage},
+    message::{EpochChangeError, EpochChangeMessage, Proposal, ProposalMessage},
     tests::common::assertions::{
         any, count_matching, has_request_drb_for_epoch, is_proposal, is_request_block_and_header,
         is_vote1,
@@ -117,14 +117,11 @@ async fn test_handle_epoch_change_valid() {
     );
 }
 
-/// An EpochChangeMessage with mismatched cert1 and cert2 view numbers should be rejected.
+/// An EpochChangeMessage with mismatched cert1 and cert2 view numbers is not
+/// well-formed.
 #[tokio::test]
-async fn test_handle_epoch_change_mismatched_views() {
-    let mut harness = ConsensusHarness::new(0).await;
+async fn test_epoch_change_mismatched_views_not_well_formed() {
     let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
-    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
-
-    run_views_full(&mut harness, &test_data, &node_key, 0..9).await;
 
     // Mix cert1 from view 9 with cert2 from view 10 — mismatched views
     let proposal: Proposal<TestTypes> = test_data.views[9].proposal.data.clone();
@@ -134,28 +131,39 @@ async fn test_handle_epoch_change_mismatched_views() {
         proposal,
     );
 
-    let view_changed_before = count_matching(harness.outputs(), is_view_changed);
-
-    harness
-        .apply(ConsensusInput::EpochChange(epoch_change))
-        .await;
-
-    assert_eq!(
-        view_changed_before,
-        count_matching(harness.outputs(), is_view_changed),
-        "Mismatched EpochChange should be rejected — no new ViewChanged"
-    );
+    assert!(matches!(
+        epoch_change.well_formed(EPOCH_HEIGHT),
+        Err(EpochChangeError::CertificateMismatch)
+    ));
 }
 
-/// An EpochChangeMessage where the block is not the last block of the epoch
-/// should be rejected (block_number % epoch_height != 0).
+/// Certificates from different epochs are not well-formed. Each certificate
+/// can be individually crypto-valid (adjacent epochs often share a stake
+/// table), so this must be caught structurally before verification.
 #[tokio::test]
-async fn test_handle_epoch_change_wrong_block_number() {
-    let mut harness = ConsensusHarness::new(0).await;
-    let test_data = TestData::new(11).await;
-    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+async fn test_epoch_change_cross_epoch_certificates_not_well_formed() {
+    let test_data = TestData::new_with_epoch_height(21, EPOCH_HEIGHT).await;
 
-    run_views_full(&mut harness, &test_data, &node_key, 0..6).await;
+    // cert1 from the epoch-1 boundary (view 10), cert2 from the epoch-2
+    // boundary (view 20); both are genuine boundary certificates.
+    let proposal: Proposal<TestTypes> = test_data.views[9].proposal.data.clone();
+    let epoch_change = EpochChangeMessage::validated(
+        test_data.views[9].cert1.clone(),
+        test_data.views[19].cert2.clone(),
+        proposal,
+    );
+
+    assert!(matches!(
+        epoch_change.well_formed(EPOCH_HEIGHT),
+        Err(EpochChangeError::CertificateMismatch)
+    ));
+}
+
+/// An EpochChangeMessage whose block is not the last block of the epoch
+/// (block_number % epoch_height != 0) is not well-formed.
+#[tokio::test]
+async fn test_epoch_change_wrong_block_number_not_well_formed() {
+    let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
 
     // Use view 6 (block 6) which is NOT the last block of the epoch
     let mid_view = &test_data.views[5];
@@ -163,28 +171,17 @@ async fn test_handle_epoch_change_wrong_block_number() {
     let epoch_change =
         EpochChangeMessage::validated(mid_view.cert1.clone(), mid_view.cert2.clone(), proposal);
 
-    let view_changed_before = count_matching(harness.outputs(), is_view_changed);
-
-    harness
-        .apply(ConsensusInput::EpochChange(epoch_change))
-        .await;
-
-    assert_eq!(
-        view_changed_before,
-        count_matching(harness.outputs(), is_view_changed),
-        "EpochChange with wrong block number should be rejected"
-    );
+    assert!(matches!(
+        epoch_change.well_formed(EPOCH_HEIGHT),
+        Err(EpochChangeError::NotLastBlock)
+    ));
 }
 
 /// An EpochChangeMessage whose proposal commitment doesn't match cert1's
-/// leaf_commit should be rejected.
+/// leaf_commit is not well-formed.
 #[tokio::test]
-async fn test_handle_epoch_change_proposal_mismatch() {
-    let mut harness = ConsensusHarness::new(0).await;
+async fn test_epoch_change_proposal_mismatch_not_well_formed() {
     let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
-    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
-
-    run_views_full(&mut harness, &test_data, &node_key, 0..9).await;
 
     // Use cert1/cert2 from view 10 but proposal from view 9 — commitment mismatch
     let epoch_view = &test_data.views[9];
@@ -195,17 +192,10 @@ async fn test_handle_epoch_change_proposal_mismatch() {
         wrong_proposal,
     );
 
-    let view_changed_before = count_matching(harness.outputs(), is_view_changed);
-
-    harness
-        .apply(ConsensusInput::EpochChange(epoch_change))
-        .await;
-
-    assert_eq!(
-        view_changed_before,
-        count_matching(harness.outputs(), is_view_changed),
-        "EpochChange with mismatched proposal should be rejected"
-    );
+    assert!(matches!(
+        epoch_change.well_formed(EPOCH_HEIGHT),
+        Err(EpochChangeError::ProposalMismatch)
+    ));
 }
 
 /// A stale EpochChangeMessage (cert1 view < locked_cert view) should be rejected.

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -49,7 +49,7 @@ async fn run_views_full(
 
     for i in range {
         harness
-            .apply(test_data.views[i].proposal_input_consensus(node_key))
+            .apply_pair(test_data.views[i].proposal_input_consensus(node_key))
             .await;
         harness
             .apply(test_data.views[i].block_reconstructed_input())
@@ -430,10 +430,12 @@ async fn test_epoch_change_votes() {
         .clone();
 
     harness
-        .apply(ConsensusInput::ProposalWithVidShare(
-            first_view.leader_public_key,
-            ProposalMessage::validated(signed_proposal),
-            vid_share,
+        .apply_pair((
+            ConsensusInput::Proposal(
+                first_view.leader_public_key,
+                ProposalMessage::validated(signed_proposal),
+            ),
+            ConsensusInput::VidShare(vid_share),
         ))
         .await;
 
@@ -460,7 +462,7 @@ async fn test_first_epoch_leader_proposes_without_drb() {
     // should propose — but maybe_propose also needs to skip the DRB check.
     for i in 0..7 {
         harness
-            .apply(test_data.views[i].proposal_input_consensus(&node_key))
+            .apply_pair(test_data.views[i].proposal_input_consensus(&node_key))
             .await;
         harness
             .apply(test_data.views[i].block_reconstructed_input())
@@ -529,10 +531,12 @@ async fn test_second_epoch_leader_proposes_without_drb() {
         .expect("VID share not found")
         .clone();
     harness
-        .apply(ConsensusInput::ProposalWithVidShare(
-            first_e2_view.leader_public_key,
-            ProposalMessage::validated(signed),
-            vid_share,
+        .apply_pair((
+            ConsensusInput::Proposal(
+                first_e2_view.leader_public_key,
+                ProposalMessage::validated(signed),
+            ),
+            ConsensusInput::VidShare(vid_share),
         ))
         .await;
     harness
@@ -544,7 +548,7 @@ async fn test_second_epoch_leader_proposes_without_drb() {
     // ---- Epoch 2 views 12-16 (blocks 12-16, before transition window) ----
     for i in 11..16 {
         harness
-            .apply(test_data.views[i].proposal_input_consensus(&node_key))
+            .apply_pair(test_data.views[i].proposal_input_consensus(&node_key))
             .await;
         harness
             .apply(test_data.views[i].block_reconstructed_input())
@@ -558,7 +562,7 @@ async fn test_second_epoch_leader_proposes_without_drb() {
     // Process view 17 (block 17, first block in transition window).
     // After cert1 for view 17, the leader for view 18 should propose.
     harness
-        .apply(test_data.views[16].proposal_input_consensus(&node_key))
+        .apply_pair(test_data.views[16].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[16].block_reconstructed_input())
@@ -617,10 +621,12 @@ async fn test_epoch3_transition_requests_drb_for_future_epoch() {
         .expect("VID share not found")
         .clone();
     harness
-        .apply(ConsensusInput::ProposalWithVidShare(
-            first_e2_view.leader_public_key,
-            ProposalMessage::validated(signed),
-            vid_share,
+        .apply_pair((
+            ConsensusInput::Proposal(
+                first_e2_view.leader_public_key,
+                ProposalMessage::validated(signed),
+            ),
+            ConsensusInput::VidShare(vid_share),
         ))
         .await;
     harness
@@ -632,7 +638,7 @@ async fn test_epoch3_transition_requests_drb_for_future_epoch() {
     // ---- Epoch 2 views 12-16 (before transition window) ----
     for i in 11..16 {
         harness
-            .apply(test_data.views[i].proposal_input_consensus(&node_key))
+            .apply_pair(test_data.views[i].proposal_input_consensus(&node_key))
             .await;
         harness
             .apply(test_data.views[i].block_reconstructed_input())
@@ -662,10 +668,9 @@ async fn test_epoch3_transition_requests_drb_for_future_epoch() {
         .expect("VID share not found")
         .clone();
     harness
-        .apply(ConsensusInput::ProposalWithVidShare(
-            v17.leader_public_key,
-            ProposalMessage::validated(signed),
-            vid_share,
+        .apply_pair((
+            ConsensusInput::Proposal(v17.leader_public_key, ProposalMessage::validated(signed)),
+            ConsensusInput::VidShare(vid_share),
         ))
         .await;
 

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -104,11 +104,8 @@ async fn test_handle_epoch_change_valid() {
     // Construct a valid EpochChangeMessage for view 10 (block 10, last block of epoch 1)
     let epoch_view = &test_data.views[9];
     let proposal: Proposal<TestTypes> = epoch_view.proposal.data.clone();
-    let epoch_change = EpochChangeMessage {
-        cert1: epoch_view.cert1.clone(),
-        cert2: epoch_view.cert2.clone(),
-        proposal,
-    };
+    let epoch_change =
+        EpochChangeMessage::validated(epoch_view.cert1.clone(), epoch_view.cert2.clone(), proposal);
 
     harness
         .apply(ConsensusInput::EpochChange(epoch_change))
@@ -131,11 +128,11 @@ async fn test_handle_epoch_change_mismatched_views() {
 
     // Mix cert1 from view 9 with cert2 from view 10 — mismatched views
     let proposal: Proposal<TestTypes> = test_data.views[9].proposal.data.clone();
-    let epoch_change = EpochChangeMessage {
-        cert1: test_data.views[8].cert1.clone(),
-        cert2: test_data.views[9].cert2.clone(),
+    let epoch_change = EpochChangeMessage::validated(
+        test_data.views[8].cert1.clone(),
+        test_data.views[9].cert2.clone(),
         proposal,
-    };
+    );
 
     let view_changed_before = count_matching(harness.outputs(), is_view_changed);
 
@@ -163,11 +160,8 @@ async fn test_handle_epoch_change_wrong_block_number() {
     // Use view 6 (block 6) which is NOT the last block of the epoch
     let mid_view = &test_data.views[5];
     let proposal: Proposal<TestTypes> = mid_view.proposal.data.clone();
-    let epoch_change = EpochChangeMessage {
-        cert1: mid_view.cert1.clone(),
-        cert2: mid_view.cert2.clone(),
-        proposal,
-    };
+    let epoch_change =
+        EpochChangeMessage::validated(mid_view.cert1.clone(), mid_view.cert2.clone(), proposal);
 
     let view_changed_before = count_matching(harness.outputs(), is_view_changed);
 
@@ -195,11 +189,11 @@ async fn test_handle_epoch_change_proposal_mismatch() {
     // Use cert1/cert2 from view 10 but proposal from view 9 — commitment mismatch
     let epoch_view = &test_data.views[9];
     let wrong_proposal: Proposal<TestTypes> = test_data.views[8].proposal.data.clone();
-    let epoch_change = EpochChangeMessage {
-        cert1: epoch_view.cert1.clone(),
-        cert2: epoch_view.cert2.clone(),
-        proposal: wrong_proposal,
-    };
+    let epoch_change = EpochChangeMessage::validated(
+        epoch_view.cert1.clone(),
+        epoch_view.cert2.clone(),
+        wrong_proposal,
+    );
 
     let view_changed_before = count_matching(harness.outputs(), is_view_changed);
 
@@ -228,11 +222,8 @@ async fn test_handle_epoch_change_stale() {
     // is at view 10 after processing all views, so view 6 is behind the lock.
     let stale_view = &test_data.views[5];
     let proposal: Proposal<TestTypes> = stale_view.proposal.data.clone();
-    let stale_epoch_change = EpochChangeMessage {
-        cert1: stale_view.cert1.clone(),
-        cert2: stale_view.cert2.clone(),
-        proposal,
-    };
+    let stale_epoch_change =
+        EpochChangeMessage::validated(stale_view.cert1.clone(), stale_view.cert2.clone(), proposal);
 
     let view_changed_before = count_matching(harness.outputs(), is_view_changed);
 
@@ -267,11 +258,8 @@ async fn test_handle_epoch_change_replay_of_crossed_boundary() {
     // Replay the epoch 1 → 2 boundary (view 10, block 10).
     let epoch_view = &test_data.views[9];
     let proposal: Proposal<TestTypes> = epoch_view.proposal.data.clone();
-    let epoch_change = EpochChangeMessage {
-        cert1: epoch_view.cert1.clone(),
-        cert2: epoch_view.cert2.clone(),
-        proposal,
-    };
+    let epoch_change =
+        EpochChangeMessage::validated(epoch_view.cert1.clone(), epoch_view.cert2.clone(), proposal);
 
     harness
         .apply(ConsensusInput::EpochChange(epoch_change))
@@ -357,11 +345,8 @@ async fn test_epoch_change_leader_proposes() {
     let epoch_view = &test_data.views[9];
 
     let proposal: Proposal<TestTypes> = epoch_view.proposal.data.clone();
-    let epoch_change = EpochChangeMessage {
-        cert1: epoch_view.cert1.clone(),
-        cert2: epoch_view.cert2.clone(),
-        proposal,
-    };
+    let epoch_change =
+        EpochChangeMessage::validated(epoch_view.cert1.clone(), epoch_view.cert2.clone(), proposal);
 
     let mut harness = ConsensusHarness::new(1).await;
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 1).0;
@@ -394,11 +379,11 @@ async fn test_epoch_change_votes() {
     let epoch_view = &test_data.views[9]; // view 10, last block of epoch 1
 
     let epoch_proposal: Proposal<TestTypes> = epoch_view.proposal.data.clone();
-    let epoch_change = EpochChangeMessage {
-        cert1: epoch_view.cert1.clone(),
-        cert2: epoch_view.cert2.clone(),
-        proposal: epoch_proposal,
-    };
+    let epoch_change = EpochChangeMessage::validated(
+        epoch_view.cert1.clone(),
+        epoch_view.cert2.clone(),
+        epoch_proposal,
+    );
 
     // Use node 0 (non-leader for the first view of epoch 2)
     let mut harness = ConsensusHarness::new(0).await;
@@ -500,11 +485,11 @@ async fn test_second_epoch_leader_proposes_without_drb() {
     // ---- Epoch boundary ----
     let epoch_view = &test_data.views[9];
     let epoch_proposal: Proposal<TestTypes> = epoch_view.proposal.data.clone();
-    let epoch_change = EpochChangeMessage {
-        cert1: epoch_view.cert1.clone(),
-        cert2: epoch_view.cert2.clone(),
-        proposal: epoch_proposal,
-    };
+    let epoch_change = EpochChangeMessage::validated(
+        epoch_view.cert1.clone(),
+        epoch_view.cert2.clone(),
+        epoch_proposal,
+    );
     harness
         .apply(ConsensusInput::EpochChange(epoch_change))
         .await;
@@ -593,11 +578,11 @@ async fn test_epoch3_transition_requests_drb_for_future_epoch() {
     // ---- Epoch boundary ----
     let epoch_view = &test_data.views[9];
     let epoch_proposal: Proposal<TestTypes> = epoch_view.proposal.data.clone();
-    let epoch_change = EpochChangeMessage {
-        cert1: epoch_view.cert1.clone(),
-        cert2: epoch_view.cert2.clone(),
-        proposal: epoch_proposal,
-    };
+    let epoch_change = EpochChangeMessage::validated(
+        epoch_view.cert1.clone(),
+        epoch_view.cert2.clone(),
+        epoch_proposal,
+    );
     harness
         .apply(ConsensusInput::EpochChange(epoch_change))
         .await;

--- a/crates/hotshot/new-protocol/src/tests/integration.rs
+++ b/crates/hotshot/new-protocol/src/tests/integration.rs
@@ -7,7 +7,7 @@ use hotshot_types::{traits::signature_key::SignatureKey, vote::HasViewNumber};
 use super::common::{harness::TestHarness, utils::TestData};
 use crate::{
     consensus::ConsensusInput,
-    message::{CatchupEvidence, ConsensusMessage, EpochChangeMessage, Proposal},
+    message::{CatchupEvidence, ConsensusMessage, EpochChangeMessage, Proposal, Validated},
     tests::common::assertions::{
         any, count_matching, is_block_built, is_block_reconstructed, is_cert1, is_cert2,
         is_drb_result, is_header_created, is_header_created_for_view, is_leaf_decided, is_proposal,
@@ -89,9 +89,7 @@ async fn send_timeout_votes(
             any(inputs, is_timeout_cert)
         })
         .await;
-    harness.apply_and_process(ConsensusInput::TimeoutCertificate(
-        test_view.timeout_cert.clone(),
-    ));
+    harness.apply_and_process(test_view.timeout_cert_input());
 }
 
 /// Integration: sequential views both produce Vote1 through real state validation.
@@ -332,14 +330,10 @@ async fn test_leader_proposes_after_timeout() {
 const EPOCH_HEIGHT: u64 = 10;
 
 /// Helper to build an EpochChangeMessage from test data at the epoch boundary view.
-fn epoch_change_message(test_data: &TestData) -> EpochChangeMessage<TestTypes> {
+fn epoch_change_message(test_data: &TestData) -> EpochChangeMessage<TestTypes, Validated> {
     let epoch_view = &test_data.views[9]; // view 10, last block of epoch 1
     let proposal: Proposal<TestTypes> = epoch_view.proposal.data.clone();
-    EpochChangeMessage {
-        cert1: epoch_view.cert1.clone(),
-        cert2: epoch_view.cert2.clone(),
-        proposal,
-    }
+    EpochChangeMessage::validated(epoch_view.cert1.clone(), epoch_view.cert2.clone(), proposal)
 }
 
 /// Run views through the full integration pipeline.
@@ -435,11 +429,11 @@ async fn cross_epoch_boundary(
 ) {
     let boundary_view = &test_data.views[boundary_idx];
     let proposal: Proposal<TestTypes> = boundary_view.proposal.data.clone();
-    let epoch_change = EpochChangeMessage {
-        cert1: boundary_view.cert1.clone(),
-        cert2: boundary_view.cert2.clone(),
+    let epoch_change = EpochChangeMessage::validated(
+        boundary_view.cert1.clone(),
+        boundary_view.cert2.clone(),
         proposal,
-    };
+    );
     harness.apply_and_process(ConsensusInput::EpochChange(epoch_change));
 
     // Send vote1s and vote2s through the normal pipeline.
@@ -613,6 +607,15 @@ async fn test_timeout_vote_lock_advances_view() {
     let high_qc = CatchupEvidence::Qc(test_data.views[0].cert1.clone());
     harness.message(test_data.views[1].timeout_vote_input(1, Some(high_qc.clone())));
 
+    harness
+        .process_until_output(|outputs| {
+            any(
+                outputs,
+                |o| matches!(o, ConsensusOutput::ViewChanged(view, _) if **view == 2),
+            )
+        })
+        .await;
+
     assert_eq!(
         view_changed_to(harness.outputs(), 2),
         1,
@@ -644,6 +647,10 @@ async fn test_timeout_vote_tc_advances_view() {
     // timeout certificate for view 2 that formed without us.
     let tc = CatchupEvidence::Tc(test_data.views[1].timeout_cert.clone());
     harness.message(test_data.views[2].timeout_vote_input(1, Some(tc)));
+
+    harness
+        .process_until(|inputs| any(inputs, is_timeout_cert))
+        .await;
 
     assert_eq!(
         *harness.current_view(),
@@ -716,6 +723,10 @@ async fn test_timeout_vote_evidence_overrides_distance_check() {
     // certificate for view 31.
     let tc = CatchupEvidence::Tc(test_data.views[30].timeout_cert.clone());
     harness.message(test_data.views[31].timeout_vote_input(1, Some(tc)));
+
+    harness
+        .process_until(|inputs| any(inputs, is_timeout_cert))
+        .await;
 
     assert_eq!(
         *harness.current_view(),

--- a/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
@@ -225,6 +225,7 @@ async fn build_cutover_coordinator(
 
     use crate::{
         block::{BlockBuilder, BlockBuilderConfig},
+        cert_verifier::CertVerifiers,
         consensus::Consensus,
         epoch::EpochManager,
         proposal::{ProposalValidator, VidShareValidator},
@@ -305,6 +306,7 @@ async fn build_cutover_coordinator(
         .timeout_collector(VoteCollector::new(membership.clone(), upgrade_lock.clone()))
         .timeout_one_honest_collector(VoteCollector::new(membership.clone(), upgrade_lock.clone()))
         .epoch_root_collector(VoteCollector::new(membership.clone(), upgrade_lock.clone()))
+        .cert_verifiers(CertVerifiers::new(membership.clone(), upgrade_lock.clone()))
         .vid_disperser(vid_disperser)
         .vid_reconstructor(VidReconstructor::new())
         .epoch_manager(EpochManager::new(epoch_height, membership.clone()))

--- a/crates/hotshot/new-protocol/src/tests/safety.rs
+++ b/crates/hotshot/new-protocol/src/tests/safety.rs
@@ -1,0 +1,480 @@
+//! Safety of the two-phase vote across nodes.
+//!
+//! A fork needs two quorums: one certifying a block at view `v`, another
+//! certifying a block at a later view whose ancestry skips `v`. The second
+//! quorum can only form from nodes that are not locked at `v`, and a node locks
+//! at `v` exactly when it casts a phase-2 vote there. So the two quorums compete
+//! for the same nodes, and whether they can both form comes down to whether a
+//! node can serve both: voting phase-1 in a later view while unlocked, then
+//! phase-2 in the earlier one once its block arrives. Nothing about when a
+//! certificate and a block turn up orders them against the node's other votes,
+//! so `Consensus::voted_for_branch_excluding` is what refuses the second vote.
+//! This test builds the whole fork and stops at that refusal.
+//!
+//! The nodes here are separate `Consensus` instances fed by hand, which is what
+//! a network does for them. Delivery order is the variable under test, so it is
+//! controlled rather than left to a real network.
+
+use hotshot::types::BLSPubKey;
+use hotshot_example_types::{
+    block_types::TestBlockHeader,
+    node_types::{TEST_VERSIONS, TestTypes},
+};
+use hotshot_types::{
+    data::{EpochNumber, ViewNumber},
+    message::Proposal,
+    stake_table::StakeTableEntries,
+    traits::{block_contents::BlockHeader, signature_key::SignatureKey},
+    vote::{Certificate, HasViewNumber, Vote},
+};
+
+use crate::{
+    cert_verifier::ValidCert,
+    consensus::{ConsensusInput, ConsensusOutput},
+    helpers::{proposal_commitment, test_upgrade_lock},
+    message::{Certificate1, Certificate2},
+    tests::common::utils::{
+        ConsensusHarness, SignerShare, TestData, assemble_cert, build_timeout_cert_signed_by,
+        mock_membership, sign_vote_as,
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Two conflicting quorums, assembled from real node behaviour
+// ---------------------------------------------------------------------------
+
+/// The certificate threshold for the 10-node test committee: `(10 * 2) / 3 + 1`.
+const THRESHOLD: usize = 7;
+
+/// Nodes whose signatures the adversary supplies. Node 6 leads view 6, so the
+/// competing proposal is signed by a node the adversary controls.
+const BYZANTINE: [u64; 3] = [6, 7, 8];
+
+/// Honest nodes that never receive view 2's block, so they never lock there.
+///
+/// Node 2 is excluded: it leads view 2 and therefore holds that block whatever
+/// the network does.
+const NEVER_LOCKED: [u64; 3] = [0, 1, 3];
+
+/// Honest nodes that receive view 2 in full and lock on it.
+const LOCKED: [u64; 3] = [2, 4, 5];
+
+/// The honest node that is unlocked when the competing proposal arrives and
+/// receives view 2's block only afterwards.
+const LATE: u64 = 9;
+
+/// Who sent a timeout vote for view 5, and so backs the competing proposal's
+/// view-change evidence.
+///
+/// The honest signers are nodes that left view 2 — 0, 1 and 3 on a timeout
+/// certificate for it, node 2 by locking there — and then timed out through
+/// views 3, 4 and 5. [`LATE`] is not among them because it never left view 2,
+/// which the execution notes on the test below explain.
+///
+/// That exclusion is forced by the execution rather than chosen, and it is also
+/// what keeps the scenario sharp: a timeout vote endorses no branch, so barring
+/// the phase-2 vote on `timeout_view` would stop the nodes that timed out at
+/// view 5 and let [`LATE`], which never timed out at all, walk straight past.
+const TIMED_OUT_AT_5: [u64; 7] = [0, 1, 2, 3, 6, 7, 8];
+
+/// One quorum, not two.
+///
+/// Seven honest nodes are run as separate consensus instances and fed by hand,
+/// which is what a network does for them. Three roles:
+///
+/// - `LOCKED` receive view 2 complete. They vote phase-2 there and lock, so they
+///   refuse the competing proposal.
+/// - `NEVER_LOCKED` receive view 2's proposal and its phase-1 certificate but
+///   never its block. Reconstruction is what a phase-2 vote requires, so they
+///   never lock, and they accept the competing proposal.
+/// - `LATE` is the interesting one. It is in the same state as `NEVER_LOCKED`
+///   when the competing proposal arrives, so it votes phase-1 there — and then
+///   view 2's block lands, which is everything it needs to vote phase-2 at view
+///   2 as well and stand on both sides.
+///
+/// That second vote is refused. `LATE`'s phase-1 vote at view 6 is justified at
+/// view 1, so the branch it endorsed holds no block for view 2, and a commit
+/// vote there afterwards is the double count itself.
+///
+/// The scenario is built out to where that matters. Both sides are driven as far
+/// as the nodes will take them: the competing branch collects its phase-1
+/// certificate and then its commit certificate, since the nodes that voted
+/// phase-1 at view 6 go on to vote phase-2 there. View 2 gets three phase-2
+/// votes and stops one short of a commit, `LATE` no longer being counted twice.
+/// Two quorums drawn from ten nodes meet in four: the three adversary nodes and
+/// one honest one. Everything rests on that one node, and it now stands on a
+/// single side.
+///
+/// So the competing branch wins and view 2's block is orphaned, which is what
+/// safety asks for — orphaned rather than committed and then contradicted.
+///
+/// Nothing here is counted where it could be verified. The only fabricated
+/// signatures are the adversary's, which is what an adversary can do anyway.
+///
+/// # What distinguishes `LATE`
+///
+/// Neither of the two properties that look like they would catch it. `LATE` has
+/// not left view 2 when the second vote comes due, so a guard phrased as "vote
+/// phase-2 only in the vote's own view" would admit it; and its timer never
+/// fires, so `timeout_view` is still 0 and a bar of `view > timeout_view` would
+/// admit it too. The test asserts both states where it reaches them, so
+/// narrowing the scenario to one those guards would catch fails here rather than
+/// passing quietly.
+///
+/// What is left is that it voted phase-1 in a *later* view while unlocked and
+/// would then have voted phase-2 in an earlier one — one node in both quorums.
+/// That is what `Consensus::voted_for_branch_excluding` refuses.
+///
+/// # What the execution requires
+///
+/// **View 1's certificate is withheld from `LATE` until late.** Its view-2 timer
+/// starts when it enters view 2, which is when it locks view 1. Hold that back
+/// until the rest of the network has produced the timeout certificate for view 5,
+/// then deliver in one burst inside a single view duration: view 1 complete, view
+/// 2's proposal and phase-1 certificate without the block, the competing
+/// proposal, and last view 2's block. `LATE` need not have taken part in views 1
+/// to 5 at all — view 2's phase-1 certificate forms from the six other honest
+/// nodes and the adversary without its vote.
+///
+/// **`LATE` never receives a timeout certificate for view 2.** That retires the
+/// view for VID reconstruction, so view 2's block would never arrive and the
+/// second vote could not happen.
+///
+/// Both are permitted under asynchrony, and both are constraints on any execution
+/// matching this scenario.
+///
+#[tokio::test]
+async fn conflicting_quorums_cannot_both_reach_threshold() {
+    let test_data = TestData::new(6).await;
+    let committed = &test_data.views[1]; // view 2, parented at view 1
+    let leader6 = test_data.views[5].leader_public_key;
+
+    // The evidence for the gap, naming exactly who timed out at view 5 — see
+    // `TIMED_OUT_AT_5` for why the late node must not be among them.
+    assert!(
+        !TIMED_OUT_AT_5.contains(&LATE),
+        "the late node never reached view 5, so it cannot be a signer here"
+    );
+    let timeout_cert_5 = {
+        let membership = mock_membership();
+        let epoch_membership = membership
+            .membership_for_epoch(Some(EpochNumber::genesis()))
+            .expect("genesis membership");
+        build_timeout_cert_signed_by(
+            ViewNumber::new(5),
+            EpochNumber::genesis(),
+            &epoch_membership,
+            &TIMED_OUT_AT_5,
+        )
+    };
+
+    // The competing proposal must come from a node the adversary controls.
+    assert!(
+        BYZANTINE
+            .iter()
+            .any(|i| BLSPubKey::generated_from_seed_indexed([0; 32], *i).0 == leader6),
+        "view 6's leader must be one of the adversary's nodes"
+    );
+
+    // View 6, parented at view 1, so it skips view 2 entirely. It reuses view
+    // 6's payload so the honest nodes' VID shares still match, and carries a
+    // timeout certificate for view 5 as the evidence for the gap.
+    let forked = {
+        let template = &test_data.views[5];
+        let parent_leaf = test_data.views[0].proposal.data.clone().into();
+        let mut proposal = template.proposal.data.clone();
+        proposal.block_header = TestBlockHeader::new(
+            &parent_leaf,
+            template.proposal.data.block_header.payload_commitment,
+            template
+                .proposal
+                .data
+                .block_header
+                .builder_commitment
+                .clone(),
+            template.proposal.data.block_header.metadata,
+            TEST_VERSIONS.test.base,
+        );
+        proposal.justify_qc = test_data.views[0].cert1.clone();
+        proposal.view_change_evidence = Some(timeout_cert_5.clone());
+        proposal
+    };
+    let forked_signed = {
+        let signature = <BLSPubKey as SignatureKey>::sign(
+            &test_data.views[5].leader_private_key,
+            proposal_commitment(&forked).as_ref(),
+        )
+        .expect("sign the competing proposal");
+        Proposal::new(forked, signature)
+    };
+
+    let committed_commit = proposal_commitment(&committed.proposal.data);
+    let forked_commit = proposal_commitment(&forked_signed.data);
+    let fork_cert_parent_view = forked_signed.data.justify_qc.view_number();
+    let mut voted_phase2_at_committed = Vec::new();
+    let mut voted_phase1_at_fork = Vec::new();
+    let mut committed_shares: Vec<SignerShare> = Vec::new();
+    let mut fork_shares: Vec<SignerShare> = Vec::new();
+    let mut committed_data = None;
+    let mut fork_data = None;
+    let mut harnesses = Vec::new();
+
+    for node in NEVER_LOCKED.iter().chain(&LOCKED).chain([LATE].iter()) {
+        let node = *node;
+        let key = BLSPubKey::generated_from_seed_indexed([0; 32], node).0;
+        let mut harness = ConsensusHarness::new(node).await;
+
+        // View 1 in full: every honest node holds and locks it. The competing
+        // proposal is parented here, which is why they can admit it at all.
+        harness
+            .apply_pair(test_data.views[0].proposal_input_consensus(&key))
+            .await;
+        harness
+            .apply(test_data.views[0].block_reconstructed_input())
+            .await;
+        harness.apply(test_data.views[0].cert1_input()).await;
+
+        // View 2: everyone gets the proposal and the phase-1 certificate. Only
+        // `LOCKED` gets the block, so only `LOCKED` votes phase-2 and locks.
+        harness
+            .apply_pair(committed.proposal_input_consensus(&key))
+            .await;
+        if LOCKED.contains(&node) {
+            harness.apply(committed.block_reconstructed_input()).await;
+        }
+        harness.apply(committed.cert1_input()).await;
+
+        // A node without view 2's block is still in view 2: the phase-2 vote is
+        // what advances the view, and a phase-1 certificate does not.
+        if !LOCKED.contains(&node) {
+            assert_eq!(
+                harness.consensus.current_view(),
+                ViewNumber::new(2),
+                "a node without view 2's block has not left view 2"
+            );
+        }
+
+        // The `NEVER_LOCKED` nodes sit in view 2 while the rest of the network
+        // times out through views 2 to 5, so their timers fire. It changes
+        // nothing — their phase-1 vote at view 6 needs only `6 > timeout_view` —
+        // but it is what a real execution looks like.
+        //
+        // `LATE` is deliberately not given one. See the note on its timer in the
+        // test's documentation: it enters view 2 only moments before the rest of
+        // the burst, so its timer never fires and its `timeout_view` stays 0.
+        if NEVER_LOCKED.contains(&node) {
+            harness
+                .apply(ConsensusInput::Timeout(
+                    ViewNumber::new(2),
+                    EpochNumber::genesis(),
+                ))
+                .await;
+        }
+
+        // The competing proposal reaches everyone.
+        harness
+            .apply(ConsensusInput::Proposal(
+                leader6,
+                crate::message::ProposalMessage::validated(forked_signed.clone()),
+            ))
+            .await;
+        harness
+            .apply(ConsensusInput::VidShare(
+                test_data.views[5].vid_share_for(&key),
+            ))
+            .await;
+
+        // View 2's block finally reaches the late node, after it has already
+        // voted on the competing branch.
+        if node == LATE {
+            // Still in view 2. Casting a phase-1 vote does not advance the view,
+            // and a received proposal's `view_change_evidence` is never applied
+            // as an input — it is read only when building a proposal. So a guard
+            // phrased as "vote phase-2 only while `current_view` is the vote's
+            // view" would not stop what follows.
+            assert_eq!(
+                harness.consensus.current_view(),
+                ViewNumber::new(2),
+                "the late node is still in view 2 after voting phase-1 at view 6"
+            );
+            harness.apply(committed.block_reconstructed_input()).await;
+        }
+
+        // Take the signatures the node actually produced. The phase-1 vote is
+        // parked until its action is persisted, which the harness does, so it
+        // reaches the outbox like any other.
+        for output in harness.outputs().iter() {
+            match output {
+                ConsensusOutput::SendVote1(v) if v.vote.data.leaf_commit == forked_commit => {
+                    voted_phase1_at_fork.push(node);
+                    fork_shares.push((node, v.vote.signature()));
+                    fork_data.get_or_insert(v.vote.data);
+                },
+                ConsensusOutput::SendVote2(v) if v.data.leaf_commit == committed_commit => {
+                    voted_phase2_at_committed.push(node);
+                    committed_shares.push((node, v.signature()));
+                    committed_data.get_or_insert_with(|| v.data.clone());
+                },
+                _ => {},
+            }
+        }
+        harnesses.push((node, harness));
+    }
+
+    // The late node reached both sides and was admitted to one.
+    assert_eq!(
+        voted_phase1_at_fork,
+        vec![0, 1, 3, 9],
+        "the unlocked nodes and the late node vote phase-1 on the competing branch"
+    );
+    assert_eq!(
+        voted_phase2_at_committed,
+        vec![2, 4, 5],
+        "only the locked nodes vote phase-2 at view 2: the late node has voted for a branch \
+         without it"
+    );
+
+    // The adversary adds its own signatures over the same data, which is all it
+    // has to do: the honest votes above are what it cannot forge.
+    let committed_data = committed_data.expect("a phase-2 vote was cast at view 2");
+    let fork_data = fork_data.expect("a phase-1 vote was cast at view 6");
+    for node in BYZANTINE {
+        committed_shares.push(sign_vote_as(
+            node,
+            committed_data.clone(),
+            committed.view_number,
+        ));
+        fork_shares.push(sign_vote_as(node, fork_data, ViewNumber::new(6)));
+    }
+    assert_eq!(
+        (committed_shares.len(), fork_shares.len()),
+        (THRESHOLD - 1, THRESHOLD),
+        "view 2 should fall exactly one signature short of a quorum, the competing branch not at \
+         all"
+    );
+
+    let membership = mock_membership();
+    let epoch_membership = membership
+        .membership_for_epoch(Some(EpochNumber::genesis()))
+        .expect("genesis membership");
+    let entries = StakeTableEntries::from_iter(epoch_membership.stake_table()).0;
+    let threshold = epoch_membership.success_threshold();
+
+    // The same check the proposal validator applies to a justify QC. Below the
+    // threshold there is nothing to check: `assemble_cert` will not build a
+    // certificate that could never verify.
+    let upgrade_lock = test_upgrade_lock::<TestTypes>();
+    let committed_valid = committed_shares.len() >= THRESHOLD
+        && assemble_cert::<_, Certificate2<TestTypes>>(
+            committed_data,
+            committed.view_number,
+            &epoch_membership,
+            &committed_shares,
+        )
+        .is_valid_cert(&entries, threshold, &upgrade_lock)
+        .is_ok();
+    let fork_cert: Certificate1<TestTypes> = assemble_cert(
+        fork_data,
+        ViewNumber::new(6),
+        &epoch_membership,
+        &fork_shares,
+    );
+    let fork_valid = fork_cert
+        .is_valid_cert(&entries, threshold, &upgrade_lock)
+        .is_ok();
+
+    // The branches conflict: view 6's parent is view 1, so view 2 is not an
+    // ancestor of it.
+    assert_eq!(
+        fork_cert_parent_view,
+        ViewNumber::new(1),
+        "the competing branch must skip the committed view"
+    );
+
+    // Drive the competing branch to a commit as well.
+    //
+    // `maybe_vote_2_and_update_lock` checks the vote mark, the certificate, the
+    // proposal and reconstruction — not whether the branch extends the lock. So
+    // the same nodes that voted phase-1 at view 6 vote phase-2 there once the
+    // certificate and the block arrive, even the one now locked at view 2. That
+    // commit is the one that stands, and it is only harmless because view 2
+    // never reached one.
+    let mut double_commit_shares: Vec<SignerShare> = Vec::new();
+    let mut double_commit_data = None;
+    for (node, harness) in harnesses.iter_mut() {
+        if !voted_phase1_at_fork.contains(node) {
+            continue;
+        }
+        let before = harness.outputs().len();
+        harness
+            .apply(ConsensusInput::Certificate1(ValidCert::new(
+                fork_cert.clone(),
+                EpochNumber::genesis(),
+            )))
+            .await;
+        harness
+            .apply(ConsensusInput::BlockReconstructed(
+                ViewNumber::new(6),
+                test_data.views[5].vid_commitment(),
+            ))
+            .await;
+        for output in harness.outputs().iter().skip(before) {
+            if let ConsensusOutput::SendVote2(v) = output
+                && v.data.leaf_commit == forked_commit
+            {
+                double_commit_shares.push((*node, v.signature()));
+                double_commit_data.get_or_insert_with(|| v.data.clone());
+            }
+        }
+    }
+    for node in BYZANTINE {
+        if let Some(data) = double_commit_data.clone() {
+            double_commit_shares.push(sign_vote_as(node, data, ViewNumber::new(6)));
+        }
+    }
+    let double_commit_valid = double_commit_data.is_some_and(|data| {
+        double_commit_shares.len() >= THRESHOLD
+            && assemble_cert::<_, Certificate2<TestTypes>>(
+                data,
+                ViewNumber::new(6),
+                &epoch_membership,
+                &double_commit_shares,
+            )
+            .is_valid_cert(&entries, threshold, &upgrade_lock)
+            .is_ok()
+    });
+
+    // The two blocks sit at the same height on branches that do not extend one
+    // another, so certifying both is what a fork would look like.
+    assert_eq!(
+        (
+            BlockHeader::<TestTypes>::block_number(&committed.proposal.data.block_header),
+            BlockHeader::<TestTypes>::block_number(&forked_signed.data.block_header)
+        ),
+        (2, 2),
+        "the two blocks should be at the same height"
+    );
+
+    // The competing branch got everything it could: a phase-1 certificate and
+    // then a commit. Asserting it keeps the two below from passing because the
+    // scenario quietly stopped short.
+    assert!(
+        fork_valid,
+        "the competing branch's phase-1 certificate should verify"
+    );
+    assert!(
+        double_commit_valid,
+        "the competing branch should reach a commit certificate"
+    );
+
+    assert!(
+        !(committed_valid && fork_valid),
+        "both certificates verify: a phase-2 certificate at view 2 and a phase-1 certificate at \
+         view 6 whose branch does not extend it"
+    );
+    assert!(
+        !(committed_valid && double_commit_valid),
+        "both branches commit: phase-2 certificates at view 2 and view 6 over different blocks at \
+         height 2"
+    );
+}

--- a/crates/hotshot/new-protocol/src/tests/stake_table_changes.rs
+++ b/crates/hotshot/new-protocol/src/tests/stake_table_changes.rs
@@ -49,6 +49,39 @@ async fn validator_joins_at_epoch_boundary() {
         .unwrap();
 }
 
+/// 10 nodes, epoch_height=15; the committee narrows to nodes 0-4 at epoch 3
+/// (blocks 31-45) and is replaced wholesale by the disjoint set 5-9 at
+/// epoch 4 (blocks 46-60) — a 100% turnover of the active committee.
+///
+/// The incoming cohort followed epoch 3 via broadcast cert2s without VID
+/// shares. The handoff works because the boundary leaf is final (Cert1 +
+/// Cert2): the coordinator seeds a commitment-only state for it, so the
+/// first epoch-4 leader and voters need neither the epoch-3 tail's payloads
+/// nor its replayed state.
+///
+/// Reaching block 55 proves nodes 5-9 drove epoch 4: nodes 0-4 hold no
+/// epoch-4 stake, so no quorum forms without the incoming cohort. The
+/// 55-decision target also binds the outgoing nodes 0-4, which can only
+/// meet it as retained followers — peers keep a leaving validator for one
+/// extra epoch, so 0-4 follow epoch 4 by broadcast until the cliff at
+/// block 60. Shortening that retention window breaks this test.
+#[tokio::test(flavor = "multi_thread")]
+async fn validator_set_replaced_at_epoch_boundary() {
+    TestRunner::builder()
+        .num_nodes(10)
+        .target_decisions(55)
+        .max_runtime(Duration::from_secs(500))
+        .epoch_height(15)
+        .stake_table_schedule(StakeTableSchedule {
+            initial: (0..10).collect(),
+            changes: vec![(3, vec![0, 1, 2, 3, 4]), (4, vec![5, 6, 7, 8, 9])],
+        })
+        .build()
+        .run()
+        .await
+        .unwrap();
+}
+
 /// 6 nodes, epoch_height=10; all form epochs 1-2, node 5 is removed from
 /// the committee at epoch 3 (blocks 21-30).
 ///

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -149,6 +149,50 @@ async fn test_state_request_missing_parent_inserts_empty() {
     );
 }
 
+/// A state request whose parent is entirely unknown is retried once the
+/// parent is seeded from its header — the ordering where a first-of-epoch
+/// proposal arrives before the boundary leaf's `EpochChangeMessage`.
+#[tokio::test]
+async fn test_state_request_missing_parent_retried_after_seed() {
+    let mut manager =
+        StateManager::new(Arc::new(TestInstanceState::default()), test_upgrade_lock());
+    let test_data = TestData::new(3).await;
+
+    // View 2 arrives while view 1 (its parent) is entirely unknown.
+    manager.request_state(make_state_request(&test_data.views[1]));
+
+    let view_1_commit = proposal_commitment(&test_data.views[0].proposal.data.clone());
+    assert!(
+        manager.pending_contains_commitment(&view_1_commit),
+        "View 2 should be queued on its missing parent's commitment"
+    );
+    assert!(
+        manager.validated_contains_view(test_data.views[1].view_number),
+        "A from_header stub should be inserted for view 2"
+    );
+
+    // The parent becomes final (e.g. via a verified EpochChangeMessage):
+    // seeding it must restart the queued request.
+    manager.seed_from_header(test_data.views[0].proposal.data.clone());
+
+    assert!(
+        !manager.pending_contains_commitment(&view_1_commit),
+        "the queued request should be consumed, not re-queued"
+    );
+
+    let output = manager.next().await.expect("view 2 should complete");
+    assert!(
+        matches!(
+            output,
+            StateManagerOutput::State {
+                validated: true,
+                ..
+            }
+        ),
+        "View 2 should validate against the seeded parent state"
+    );
+}
+
 /// State request with seeded genesis parent spawns validation and produces output.
 #[tokio::test]
 async fn test_state_request_with_genesis_parent() {

--- a/crates/hotshot/new-protocol/src/vote.rs
+++ b/crates/hotshot/new-protocol/src/vote.rs
@@ -12,6 +12,7 @@
 mod accumulate;
 
 use std::{
+    any::{type_name, type_name_of_val},
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     marker::PhantomData,
     mem,
@@ -30,9 +31,9 @@ use hotshot_types::{
     vote::{Certificate, HasViewNumber, LightClientStateUpdateVoteAccumulator, Vote},
 };
 use tokio_util::task::JoinMap;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
-use crate::message::Vote1;
+use crate::{cert_verifier::ValidCert, message::Vote1};
 
 /// Information about a vote.
 ///
@@ -102,16 +103,21 @@ impl<T, V, C> Tally<T> for SimpleTally<T, V, C>
 where
     T: NodeType,
     V: Vote<T> + Send + 'static,
-    C: Certificate<T, V::Commitment, Voteable = V::Commitment> + Send + 'static,
+    C: Certificate<T, V::Commitment, Voteable = V::Commitment> + HasEpoch + Send + 'static,
 {
     type Vote = V;
-    type Output = C;
+    type Output = ValidCert<C>;
 
     fn tally(r: Receiver<V>, m: EpochMembership<T>, l: UpgradeLock<T>) -> Option<Self::Output> {
-        let mut a = CheckedAccumulator::new(m, l);
+        let mut a = CheckedAccumulator::<T, V, C>::new(m, l);
         while let Ok(v) = r.recv() {
             if let Some(c) = a.add(v) {
-                return Some(c);
+                if let Some(e) = c.epoch() {
+                    return Some(ValidCert::new(c, e));
+                } else {
+                    warn!(cert = type_name::<C>(), "certificate has no epoch number");
+                    break;
+                }
             }
         }
         None
@@ -120,7 +126,7 @@ where
 
 /// The quorum and light-client state certificates formed at an epoch-root view.
 pub type EpochRootCerts<T> = (
-    QuorumCertificate2<T>,
+    ValidCert<QuorumCertificate2<T>>,
     LightClientStateUpdateCertificateV2<T>,
 );
 
@@ -169,7 +175,15 @@ impl<T: NodeType> Tally<T> for EpochRootTally<T> {
 
             if let (Some(q), Some(s)) = (&quorum_cert, &state_cert) {
                 info!(view = %q.view_number(), epoch = %s.epoch, "epoch-root certificates formed");
-                return Some((q.clone(), s.clone()));
+                if let Some(e) = q.epoch() {
+                    return Some((ValidCert::new(q.clone(), e), s.clone()));
+                } else {
+                    warn!(
+                        cert = type_name_of_val(q),
+                        "certificate has no epoch number"
+                    );
+                    break;
+                }
             }
         }
 
@@ -308,7 +322,7 @@ impl<T, V, C> VoteCollector<T, SimpleTally<T, V, C>>
 where
     T: NodeType,
     V: Vote<T> + Send + 'static,
-    C: Certificate<T, V::Commitment, Voteable = V::Commitment> + Send + 'static,
+    C: Certificate<T, V::Commitment, Voteable = V::Commitment> + HasEpoch + Send + 'static,
 {
     /// Compute the accumulated stake.
     ///
@@ -460,7 +474,11 @@ mod tests {
             + Send
             + Sync
             + 'static,
-        C: Certificate<TestTypes, V::Commitment, Voteable = V::Commitment> + Send + Sync + 'static,
+        C: Certificate<TestTypes, V::Commitment, Voteable = V::Commitment>
+            + HasEpoch
+            + Send
+            + Sync
+            + 'static,
     >() -> VoteCollector<TestTypes, SimpleTally<TestTypes, V, C>> {
         let membership = mock_membership();
         VoteCollector::new(membership, test_upgrade_lock())
@@ -491,6 +509,7 @@ mod tests {
             + Sync
             + 'static,
         C: Certificate<TestTypes, V::Commitment, Voteable = V::Commitment>
+            + HasEpoch
             + Debug
             + Send
             + Sync
@@ -554,7 +573,7 @@ mod tests {
 
         let membership = mock_membership();
         let epoch_membership = membership.membership_for_epoch(Some(epoch)).unwrap();
-        verify_cert(&cert, &expected_data, &epoch_membership);
+        verify_cert(cert.cert(), &expected_data, &epoch_membership);
     }
 
     /// Sending votes for multiple views produces a valid certificate for each view,
@@ -595,7 +614,7 @@ mod tests {
         let membership = mock_membership();
         let epoch_membership = membership.membership_for_epoch(Some(epoch)).unwrap();
         for cert in &certs {
-            verify_cert(cert, &expected_data, &epoch_membership);
+            verify_cert(cert.cert(), &expected_data, &epoch_membership);
         }
     }
 
@@ -619,7 +638,7 @@ mod tests {
 
         let membership = mock_membership();
         let epoch_membership = membership.membership_for_epoch(Some(epoch)).unwrap();
-        verify_cert(&cert, &expected_data, &epoch_membership);
+        verify_cert(cert.cert(), &expected_data, &epoch_membership);
     }
 
     /// Sending votes for multiple views in parallel produces valid certificates for each,
@@ -654,7 +673,7 @@ mod tests {
         let membership = mock_membership();
         let epoch_membership = membership.membership_for_epoch(Some(epoch)).unwrap();
         for cert in &certs {
-            verify_cert(cert, &expected_data, &epoch_membership);
+            verify_cert(cert.cert(), &expected_data, &epoch_membership);
         }
     }
 
@@ -767,7 +786,7 @@ mod tests {
         assert_no_certs(&mut task).await;
         let membership = mock_membership();
         let epoch_membership = membership.membership_for_epoch(Some(epoch)).unwrap();
-        verify_cert(&cert, &vote_2_data(), &epoch_membership);
+        verify_cert(cert.cert(), &vote_2_data(), &epoch_membership);
     }
 
     /// Channel closed before threshold means no certificate is produced.

--- a/crates/hotshot/new-protocol/src/vote/accumulate.rs
+++ b/crates/hotshot/new-protocol/src/vote/accumulate.rs
@@ -5,7 +5,7 @@ use hotshot::types::SignatureKey;
 use hotshot_types::{
     epoch_membership::EpochMembership,
     message::UpgradeLock,
-    simple_vote::VersionedVoteData,
+    simple_vote::{HasEpoch, VersionedVoteData},
     stake_table::StakeTableEntries,
     traits::node_implementation::NodeType,
     vote::{Certificate, Vote, VoteAccumulator},
@@ -23,7 +23,7 @@ pub struct CheckedAccumulator<T, V, C>
 where
     T: NodeType,
     V: Vote<T>,
-    C: Certificate<T, V::Commitment, Voteable = V::Commitment>,
+    C: Certificate<T, V::Commitment, Voteable = V::Commitment> + HasEpoch,
 {
     accumulator: VoteAccumulator<T, V, C>,
 
@@ -44,7 +44,7 @@ impl<T, V, C> CheckedAccumulator<T, V, C>
 where
     T: NodeType,
     V: Vote<T>,
-    C: Certificate<T, V::Commitment, Voteable = V::Commitment>,
+    C: Certificate<T, V::Commitment, Voteable = V::Commitment> + HasEpoch,
 {
     pub fn new(membership: EpochMembership<T>, lock: UpgradeLock<T>) -> Self {
         Self {

--- a/crates/hotshot/types/src/data.rs
+++ b/crates/hotshot/types/src/data.rs
@@ -66,15 +66,15 @@ macro_rules! impl_u64_wrapper {
     ($t:ty, $genesis_val:expr) => {
         impl $t {
             /// Create a genesis number
-            pub fn genesis() -> Self {
+            pub const fn genesis() -> Self {
                 Self($genesis_val)
             }
             /// Create a new number with the given value.
-            pub fn new(n: u64) -> Self {
+            pub const fn new(n: u64) -> Self {
                 Self(n)
             }
             /// Return the u64 format
-            pub fn u64(&self) -> u64 {
+            pub const fn u64(&self) -> u64 {
                 self.0
             }
         }

--- a/crates/hotshot/types/src/epoch_membership.rs
+++ b/crates/hotshot/types/src/epoch_membership.rs
@@ -337,7 +337,8 @@ impl<TYPES: NodeType> EpochMembershipCoordinator<TYPES> {
 
         // First figure out which epochs we need to fetch
         loop {
-            let has_stake_table = self.membership.snapshot(try_epoch).is_some();
+            let has_stake_table = self.membership.snapshot(try_epoch).is_some()
+                || self.membership.load_stake_table(try_epoch).await;
             if has_stake_table {
                 // We have this stake table but we need to make sure we have the
                 // epoch root of the requested epoch

--- a/crates/hotshot/types/src/traits/election.rs
+++ b/crates/hotshot/types/src/traits/election.rs
@@ -314,6 +314,11 @@ pub trait Membership<T: NodeType>: Debug + Send + Sync {
     /// Called to notify the Membership when a new DRB result has been calculated.
     fn add_drb_result(&self, e: EpochNumber, d: DrbResult);
 
+    /// Load the committee for `epoch` from local storage.
+    ///
+    /// Returns `true` if a snapshot for `epoch` is available afterwards.
+    fn load_stake_table(&self, epoch: EpochNumber) -> impl Future<Output = bool> + Send;
+
     /// Called to notify the Membership that Epochs are enabled.
     /// Implementations should copy the pre-epoch stake table into epoch and epoch+1
     /// when this is called. The value of initial_drb_result should be used for DRB

--- a/hotshot-query-service/src/availability.rs
+++ b/hotshot-query-service/src/availability.rs
@@ -708,10 +708,18 @@ where
         }
         .boxed()
     })?
-    .get("get_cert2", |req, state| {
+    .get("get_cert2", move |req, state| {
         async move {
             let height: u64 = req.integer_param("height")?;
-            state.get_cert2(height).await.map_err(|err| err.into())
+            state
+                .get_cert2(height)
+                .await
+                .with_timeout(timeout)
+                .await
+                .ok_or(Error::Custom {
+                    message: format!("no cert2 available for height {height}"),
+                    status: StatusCode::NOT_FOUND,
+                })
         }
         .boxed()
     })?;

--- a/hotshot-query-service/src/availability/data_source.rs
+++ b/hotshot-query-service/src/availability/data_source.rs
@@ -14,7 +14,7 @@ use std::ops::{Bound, RangeBounds};
 
 use async_trait::async_trait;
 use futures::{
-    future::Future,
+    future::{Future, FutureExt},
     stream::{BoxStream, StreamExt},
 };
 pub use hotshot_new_protocol::message::Certificate2;
@@ -31,7 +31,7 @@ use super::{
         QueryablePayload, TransactionHash, VidCommonMetadata, VidCommonQueryData,
     },
 };
-use crate::{Header, Payload, QueryResult, types::HeightIndexed};
+use crate::{Header, Payload, types::HeightIndexed};
 
 pub type FetchStream<T> = BoxStream<'static, Fetch<T>>;
 
@@ -226,8 +226,8 @@ where
             .boxed()
     }
 
-    async fn get_cert2(&self, _height: u64) -> QueryResult<Option<Certificate2<Types>>> {
-        Ok(None)
+    async fn get_cert2(&self, _height: u64) -> Fetch<Certificate2<Types>> {
+        Fetch::Pending(futures::future::pending().boxed())
     }
 }
 

--- a/hotshot-query-service/src/data_source/extension.rs
+++ b/hotshot-query-service/src/data_source/extension.rs
@@ -315,7 +315,7 @@ where
         self.data_source.get_block_containing_transaction(h).await
     }
 
-    async fn get_cert2(&self, height: u64) -> QueryResult<Option<Certificate2<Types>>> {
+    async fn get_cert2(&self, height: u64) -> Fetch<Certificate2<Types>> {
         self.data_source.get_cert2(height).await
     }
 }

--- a/hotshot-query-service/src/data_source/fetching.rs
+++ b/hotshot-query-service/src/data_source/fetching.rs
@@ -125,6 +125,7 @@ use crate::{
 };
 
 mod block;
+mod cert2;
 mod header;
 mod leaf;
 mod transaction;
@@ -132,6 +133,7 @@ mod vid;
 
 use self::{
     block::{PayloadFetcher, PayloadRangeFetcher},
+    cert2::Cert2Fetcher,
     leaf::{LeafFetcher, LeafRangeFetcher},
     transaction::TransactionRequest,
     vid::{VidCommonFetcher, VidCommonRequest},
@@ -487,6 +489,18 @@ where
         Builder::new(storage, provider)
     }
 
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn is_fetching_cert2(&self, height: u64) -> bool {
+        match &self.fetcher.cert2_fetcher {
+            Some(fetcher) => {
+                fetcher
+                    .is_fetching(&request::Certificate2Request { height })
+                    .await
+            },
+            None => false,
+        }
+    }
+
     async fn new(builder: Builder<Types, S, P>) -> anyhow::Result<Self> {
         let leaf_only = builder.is_leaf_only();
         let aggregator = builder.aggregator;
@@ -779,8 +793,10 @@ where
         self.fetcher.clone().get(TransactionRequest::from(h)).await
     }
 
-    async fn get_cert2(&self, height: u64) -> QueryResult<Option<Certificate2<Types>>> {
-        self.fetcher.get_cert2(height).await
+    async fn get_cert2(&self, height: u64) -> Fetch<Certificate2<Types>> {
+        self.fetcher
+            .get(request::Certificate2Request { height })
+            .await
     }
 }
 
@@ -960,6 +976,7 @@ where
     payload_range_fetcher: Option<Arc<PayloadRangeFetcher<Types, S, P>>>,
     vid_common_fetcher: Option<Arc<VidCommonFetcher<Types, S, P>>>,
     vid_common_range_fetcher: Option<Arc<VidCommonRangeFetcher<Types, S, P>>>,
+    cert2_fetcher: Option<Arc<Cert2Fetcher<Types, S, P>>>,
     range_chunk_size: usize,
     sync_status_chunk_size: usize,
     // Duration to sleep after each active fetch,
@@ -1036,6 +1053,12 @@ where
             };
         let leaf_fetcher = fetching::Fetcher::new(retry_semaphore.clone(), backoff.clone());
         let leaf_range_fetcher = fetching::Fetcher::new(retry_semaphore.clone(), backoff.clone());
+        let cert2_fetcher = (!builder.is_leaf_only()).then(|| {
+            Arc::new(fetching::Fetcher::new(
+                retry_semaphore.clone(),
+                backoff.clone(),
+            ))
+        });
 
         let leaf_only = builder.leaf_only;
         let sync_status_metrics =
@@ -1051,6 +1074,7 @@ where
             payload_range_fetcher,
             vid_common_fetcher,
             vid_common_range_fetcher,
+            cert2_fetcher,
             range_chunk_size: builder.range_chunk_size,
             sync_status_chunk_size: builder.sync_status_chunk_size,
             active_fetch_delay: builder.active_fetch_delay,
@@ -1812,42 +1836,6 @@ where
 impl<Types, S, P> Fetcher<Types, S, P>
 where
     Types: NodeType,
-    Header<Types>: QueryableHeader<Types>,
-    Payload<Types>: QueryablePayload<Types>,
-    S: VersionedDataSource + 'static,
-    for<'a> S::ReadOnly<'a>: NodeStorage<Types>,
-    for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
-    P: AvailabilityProvider<Types>,
-{
-    /// Load a cert2 from availability storage
-    async fn get_cert2(self: &Arc<Self>, height: u64) -> QueryResult<Option<Certificate2<Types>>> {
-        let mut tx = self.read().await.map_err(|err| QueryError::Error {
-            message: err.to_string(),
-        })?;
-
-        if let Some(cert2) = tx.load_cert2(height).await? {
-            return Ok(Some(cert2));
-        }
-
-        drop(tx);
-
-        let Some(cert2) = self
-            .provider
-            .fetch(request::Certificate2Request { height })
-            .await
-            .flatten()
-        else {
-            return Ok(None);
-        };
-
-        self.store(&(height, cert2.clone())).await;
-        Ok(Some(cert2))
-    }
-}
-
-impl<Types, S, P> Fetcher<Types, S, P>
-where
-    Types: NodeType,
     S: VersionedDataSource,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
 {
@@ -1927,6 +1915,7 @@ where
     block: Notifier<BlockQueryData<Types>>,
     leaf: Notifier<LeafQueryData<Types>>,
     vid_common: Notifier<VidCommonQueryData<Types>>,
+    cert2: Notifier<Certificate2<Types>>,
 }
 
 impl<Types> Default for Notifiers<Types>
@@ -1938,6 +1927,7 @@ where
             block: Notifier::new(),
             leaf: Notifier::new(),
             vid_common: Notifier::new(),
+            cert2: Notifier::new(),
         }
     }
 }
@@ -2380,8 +2370,8 @@ impl<Types: NodeType> Storable<Types> for (u64, Certificate2<Types>) {
         format!("cert2 at height {}", self.0)
     }
 
-    async fn notify(&self, _notifiers: &Notifiers<Types>) {
-        // No passive listeners for cert2.
+    async fn notify(&self, notifiers: &Notifiers<Types>) {
+        notifiers.cert2.notify(&self.1).await;
     }
 
     async fn store(

--- a/hotshot-query-service/src/data_source/fetching/block.rs
+++ b/hotshot-query-service/src/data_source/fetching/block.rs
@@ -104,14 +104,7 @@ where
             AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
         P: AvailabilityProvider<Types>,
     {
-        fetch_header_and_then(
-            tx,
-            req,
-            HeaderCallback::Payload {
-                fetcher: fetcher.clone(),
-            },
-        )
-        .await
+        fetch_header_and_then(tx, req, [HeaderCallback::Payload { fetcher }]).await
     }
 
     async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>
@@ -194,6 +187,7 @@ pub(super) fn fetch_block_with_header<Types, S, P>(
             header,
             fetcher: fetcher.clone(),
         }),
+        true,
     );
 }
 
@@ -428,7 +422,7 @@ where
             AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
         P: AvailabilityProvider<Types>,
     {
-        fetch_header_range_and_then(tx, req, HeaderCallback::Payload { fetcher }).await
+        fetch_header_range_and_then(tx, req, [HeaderCallback::Payload { fetcher }]).await
     }
 
     async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>
@@ -505,6 +499,7 @@ pub(super) fn fetch_block_range<Types, S, P>(
         once(BlockRangeCallback {
             fetcher: fetcher.clone(),
         }),
+        true,
     );
 }
 

--- a/hotshot-query-service/src/data_source/fetching/cert2.rs
+++ b/hotshot-query-service/src/data_source/fetching/cert2.rs
@@ -1,0 +1,172 @@
+use std::{future::IntoFuture, sync::Arc};
+
+use async_trait::async_trait;
+use derivative::Derivative;
+use futures::future::{BoxFuture, FutureExt};
+use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
+use versions::NEW_PROTOCOL_VERSION;
+
+use super::{AvailabilityProvider, FetchRequest, Fetchable, Fetcher, Heights, Notifiers};
+use crate::{
+    Header, Payload, QueryError, QueryResult,
+    availability::{Certificate2, QueryableHeader, QueryablePayload},
+    data_source::{
+        VersionedDataSource,
+        storage::{
+            AvailabilityStorage, NodeStorage, UpdateAvailabilityStorage,
+            pruning::PrunedHeightStorage,
+        },
+    },
+    fetching::{self, Callback, request::Certificate2Request},
+};
+
+pub(super) type Cert2Fetcher<Types, S, P> =
+    fetching::Fetcher<Certificate2Request, Cert2Callback<Types, S, P>>;
+
+impl FetchRequest for Certificate2Request {
+    fn might_exist(self, heights: Heights) -> bool {
+        heights.might_exist(self.height)
+    }
+}
+
+#[async_trait]
+impl<Types> Fetchable<Types> for Certificate2<Types>
+where
+    Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
+    Payload<Types>: QueryablePayload<Types>,
+{
+    type Request = Certificate2Request;
+
+    fn satisfies(&self, req: Self::Request) -> bool {
+        self.data.block_number == req.height
+    }
+
+    async fn passive_fetch(
+        notifiers: &Notifiers<Types>,
+        req: Self::Request,
+    ) -> BoxFuture<'static, Option<Self>> {
+        notifiers
+            .cert2
+            .wait_for(move |cert2| cert2.satisfies(req))
+            .await
+            .into_future()
+            .boxed()
+    }
+
+    async fn active_fetch<S, P>(
+        _tx: &mut impl AvailabilityStorage<Types>,
+        fetcher: Arc<Fetcher<Types, S, P>>,
+        req: Self::Request,
+    ) -> anyhow::Result<()>
+    where
+        S: VersionedDataSource + 'static,
+        for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
+        for<'a> S::ReadOnly<'a>:
+            AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
+        P: AvailabilityProvider<Types>,
+    {
+        fetch_cert2(&fetcher, req.height);
+        Ok(())
+    }
+
+    async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>
+    where
+        S: AvailabilityStorage<Types>,
+    {
+        // Report a missing cert2 as `Missing` so `get` triggers an active fetch.
+        storage
+            .load_cert2(req.height)
+            .await?
+            .ok_or(QueryError::Missing)
+    }
+}
+
+/// Backfill the cert2 for `header`'s block, if it is new enough to have one.
+pub(super) fn fetch_cert2_with_header<Types, S, P>(
+    fetcher: &Arc<Fetcher<Types, S, P>>,
+    header: &Header<Types>,
+) where
+    Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
+    Payload<Types>: QueryablePayload<Types>,
+    S: VersionedDataSource + 'static,
+    for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
+    for<'a> S::ReadOnly<'a>: AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
+    P: AvailabilityProvider<Types>,
+{
+    if header.version() >= NEW_PROTOCOL_VERSION {
+        fetch_cert2(fetcher, header.block_number());
+    }
+}
+
+pub(super) fn fetch_cert2<Types, S, P>(fetcher: &Arc<Fetcher<Types, S, P>>, height: u64)
+where
+    Types: NodeType,
+    Header<Types>: QueryableHeader<Types>,
+    Payload<Types>: QueryablePayload<Types>,
+    S: VersionedDataSource + 'static,
+    for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
+    for<'a> S::ReadOnly<'a>: AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
+    P: AvailabilityProvider<Types>,
+{
+    // No cert2 backfill in leaf-only mode, where derived data is not fetched.
+    let Some(cert2_fetcher) = &fetcher.cert2_fetcher else {
+        return;
+    };
+    cert2_fetcher.clone().spawn_fetch(
+        Certificate2Request { height },
+        fetcher.provider.clone(),
+        [Cert2Callback {
+            fetcher: fetcher.clone(),
+        }],
+        false,
+    );
+}
+
+/// Stores and notifies a fetched cert2, if one was found.
+#[derive(Derivative)]
+#[derivative(Debug(bound = ""))]
+pub(super) struct Cert2Callback<Types: NodeType, S, P> {
+    #[derivative(Debug = "ignore")]
+    pub(super) fetcher: Arc<Fetcher<Types, S, P>>,
+}
+
+impl<Types: NodeType, S, P> PartialEq for Cert2Callback<Types, S, P> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<Types: NodeType, S, P> Eq for Cert2Callback<Types, S, P> {}
+
+impl<Types: NodeType, S, P> Ord for Cert2Callback<Types, S, P> {
+    fn cmp(&self, _other: &Self) -> std::cmp::Ordering {
+        std::cmp::Ordering::Equal
+    }
+}
+
+impl<Types: NodeType, S, P> PartialOrd for Cert2Callback<Types, S, P> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<Types: NodeType, S, P> Callback<Option<Certificate2<Types>>> for Cert2Callback<Types, S, P>
+where
+    Header<Types>: QueryableHeader<Types>,
+    Payload<Types>: QueryablePayload<Types>,
+    S: VersionedDataSource + 'static,
+    for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
+    for<'a> S::ReadOnly<'a>: AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
+    P: AvailabilityProvider<Types>,
+{
+    async fn run(self, cert2: Option<Certificate2<Types>>) {
+        let Some(cert2) = cert2 else {
+            return;
+        };
+        let height = cert2.data.block_number;
+        tracing::info!(height, "fetched cert2");
+        self.fetcher.store_and_notify(&(height, cert2)).await;
+    }
+}

--- a/hotshot-query-service/src/data_source/fetching/header.rs
+++ b/hotshot-query-service/src/data_source/fetching/header.rs
@@ -12,7 +12,7 @@
 
 //! Header fetching.
 
-use std::{cmp::Ordering, future::IntoFuture, sync::Arc};
+use std::{cmp::Ordering, future::IntoFuture, iter::once, sync::Arc};
 
 use anyhow::bail;
 use async_trait::async_trait;
@@ -22,8 +22,8 @@ use futures::{FutureExt, future::BoxFuture};
 use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
 
 use super::{
-    AvailabilityProvider, Fetcher, block::fetch_block_with_header, leaf::fetch_leaf_with_callbacks,
-    vid::fetch_vid_common_with_header,
+    AvailabilityProvider, Fetcher, block::fetch_block_with_header, cert2::fetch_cert2_with_header,
+    leaf::fetch_leaf_with_callbacks, vid::fetch_vid_common_with_header,
 };
 use crate::{
     Header, Payload, QueryError, QueryResult,
@@ -102,9 +102,9 @@ where
         fetch_header_and_then(
             tx,
             req,
-            HeaderCallback::Payload {
+            [HeaderCallback::Payload {
                 fetcher: fetcher.clone(),
-            },
+            }],
         )
         .await
     }
@@ -133,6 +133,11 @@ where
         #[derivative(Debug = "ignore")]
         fetcher: Arc<Fetcher<Types, S, P>>,
     },
+    /// Callback when fetching the leaf in order to then backfill the corresponding cert2.
+    Cert2 {
+        #[derivative(Debug = "ignore")]
+        fetcher: Arc<Fetcher<Types, S, P>>,
+    },
 }
 
 impl<Types: NodeType, S, P> PartialEq for HeaderCallback<Types, S, P> {
@@ -151,12 +156,15 @@ impl<Types: NodeType, S, P> PartialOrd for HeaderCallback<Types, S, P> {
 
 impl<Types: NodeType, S, P> Ord for HeaderCallback<Types, S, P> {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Arbitrarily, we choose to run payload callbacks before VID callbacks.
-        match (self, other) {
-            (Self::Payload { .. }, Self::VidCommon { .. }) => Ordering::Less,
-            (Self::VidCommon { .. }, Self::Payload { .. }) => Ordering::Greater,
-            _ => Ordering::Equal,
+        // Arbitrarily, we order the callbacks payload < VID < cert2.
+        fn rank<Types: NodeType, S, P>(cb: &HeaderCallback<Types, S, P>) -> u8 {
+            match cb {
+                HeaderCallback::Payload { .. } => 0,
+                HeaderCallback::VidCommon { .. } => 1,
+                HeaderCallback::Cert2 { .. } => 2,
+            }
         }
+        rank(self).cmp(&rank(other))
     }
 }
 
@@ -167,12 +175,14 @@ where
     Payload<Types>: QueryablePayload<Types>,
     S: VersionedDataSource + 'static,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
+    for<'a> S::ReadOnly<'a>: AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
     P: AvailabilityProvider<Types>,
 {
     fn fetcher(&self) -> Arc<Fetcher<Types, S, P>> {
         match self {
             Self::Payload { fetcher } => fetcher.clone(),
             Self::VidCommon { fetcher } => fetcher.clone(),
+            Self::Cert2 { fetcher } => fetcher.clone(),
         }
     }
 
@@ -192,10 +202,14 @@ where
                 );
                 fetch_vid_common_with_header(fetcher, header);
             },
+            Self::Cert2 { fetcher } => {
+                fetch_cert2_with_header(&fetcher, &header);
+            },
         }
     }
 
-    pub(super) fn run_range(self, start: u64, end: u64) {
+    pub(super) fn run_range(self, leaves: &NonEmptyRange<LeafQueryData<Types>>) {
+        let (start, end) = (leaves.start(), leaves.end());
         match self {
             Self::Payload { fetcher } => {
                 tracing::info!("fetched leaves {start}..{end}, will now fetch payload",);
@@ -205,14 +219,19 @@ where
                 tracing::info!("fetched leaves {start}..{end}, will now fetch VID common",);
                 fetch_vid_common_range(fetcher, start, end);
             },
+            Self::Cert2 { fetcher } => {
+                for leaf in leaves.iter() {
+                    fetch_cert2_with_header(&fetcher, leaf.leaf().block_header());
+                }
+            },
         }
     }
 }
 
-pub(super) async fn fetch_header_and_then<Types, S, P>(
+pub(super) async fn fetch_header_and_then<Types, S, P, I>(
     tx: &mut impl AvailabilityStorage<Types>,
     req: BlockId<Types>,
-    callback: HeaderCallback<Types, S, P>,
+    callbacks: I,
 ) -> anyhow::Result<()>
 where
     Types: NodeType,
@@ -222,18 +241,32 @@ where
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
     for<'a> S::ReadOnly<'a>: AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
     P: AvailabilityProvider<Types>,
+    I: IntoIterator<Item = HeaderCallback<Types, S, P>> + Send,
+    I::IntoIter: Send,
 {
+    let mut callbacks = callbacks.into_iter().peekable();
+    let Some(first) = callbacks.peek() else {
+        return Ok(());
+    };
+    let fetcher = first.fetcher();
+
+    let callbacks = callbacks.chain(once(HeaderCallback::Cert2 {
+        fetcher: fetcher.clone(),
+    }));
+
     // Check if at least the header is available in local storage. If it is, we benefit two ways:
     // 1. We know for sure the corresponding block exists, so we can unconditionally trigger an
     //    active fetch without unnecessarily bothering our peers.
     // 2. We only need to fetch the missing data (e.g. payload or VID common), not the full block.
     //    Not only is this marginally less data to download, there are some providers that may only
     //    be able to provide certain data. For example, the HotShot DA committee members may be able
-    //    to provide paylaods, but not full blocks. Or, in the case where VID recovery is needed,
+    //    to provide payloads, but not full blocks. Or, in the case where VID recovery is needed,
     //    the VID common data may be available but the full block may not exist anywhere.
     match tx.get_header(req).await {
         Ok(header) => {
-            callback.run(header);
+            for callback in callbacks {
+                callback.run(header.clone());
+            }
             return Ok(());
         },
         Err(QueryError::Missing | QueryError::NotFound) => {
@@ -254,7 +287,12 @@ where
     // header and leaf.
     match req {
         BlockId::Number(n) => {
-            fetch_leaf_with_callbacks(callback.fetcher(), n.into(), [callback.into()]).await?;
+            fetch_leaf_with_callbacks(
+                fetcher,
+                n.into(),
+                callbacks.map(Into::into).collect::<Vec<_>>(),
+            )
+            .await?;
         },
         BlockId::Hash(h) => {
             // Given only the hash, we cannot tell if the corresponding leaf actually exists, since
@@ -270,10 +308,10 @@ where
     Ok(())
 }
 
-pub(super) async fn fetch_header_range_and_then<Types, S, P>(
+pub(super) async fn fetch_header_range_and_then<Types, S, P, I>(
     tx: &mut impl AvailabilityStorage<Types>,
     req: RangeRequest,
-    callback: HeaderCallback<Types, S, P>,
+    callbacks: I,
 ) -> anyhow::Result<()>
 where
     Types: NodeType,
@@ -283,12 +321,26 @@ where
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
     for<'a> S::ReadOnly<'a>: AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
     P: AvailabilityProvider<Types>,
+    I: IntoIterator<Item = HeaderCallback<Types, S, P>> + Send,
+    I::IntoIter: Send,
 {
+    let mut callbacks = callbacks.into_iter().peekable();
+    let Some(first) = callbacks.peek() else {
+        return Ok(());
+    };
+    let fetcher = first.fetcher();
+
+    let callbacks = callbacks.chain(once(HeaderCallback::Cert2 {
+        fetcher: fetcher.clone(),
+    }));
+
     // Check if the headers are already available in local storage; then we only need to fetch the
     // payload data.
     match <NonEmptyRange<LeafQueryData<Types>>>::load(tx, req).await {
-        Ok(_) => {
-            callback.run_range(req.start, req.end);
+        Ok(leaves) => {
+            for callback in callbacks {
+                callback.run_range(&leaves);
+            }
             return Ok(());
         },
         Err(QueryError::Missing | QueryError::NotFound) => {
@@ -304,7 +356,8 @@ where
     }
 
     // Fetch the headers (in fact, the entire leaves) first, then fetch the remaining payload data.
-    fetch_leaf_range_with_callbacks(callback.fetcher(), req, [callback.into()]).await?;
+    fetch_leaf_range_with_callbacks(fetcher, req, callbacks.map(Into::into).collect::<Vec<_>>())
+        .await?;
 
     Ok(())
 }

--- a/hotshot-query-service/src/data_source/fetching/leaf.rs
+++ b/hotshot-query-service/src/data_source/fetching/leaf.rs
@@ -109,7 +109,11 @@ where
             AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
         P: AvailabilityProvider<Types>,
     {
-        fetch_leaf_with_callbacks(fetcher, req, None).await
+        let cert2 = HeaderCallback::Cert2 {
+            fetcher: fetcher.clone(),
+        }
+        .into();
+        fetch_leaf_with_callbacks(fetcher, req, once(cert2)).await
     }
 
     async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>
@@ -143,6 +147,7 @@ where
                 request::LeafRequest::new(n as u64),
                 fetcher.provider.clone(),
                 once(LeafCallback::Leaf { fetcher }).chain(callbacks),
+                true,
             );
         },
         LeafId::Hash(h) => {
@@ -229,7 +234,12 @@ pub(super) fn trigger_fetch_for_parent<Types, S, P>(
                         fetcher: fetcher.clone(),
                     }
                     .into(),
+                    HeaderCallback::Cert2 {
+                        fetcher: fetcher.clone(),
+                    }
+                    .into(),
                 ],
+                true,
             );
         }
         .instrument(span),
@@ -364,7 +374,7 @@ where
                 // continue bulk fetching, rather than kick of a chain reaction of individual
                 // fetches, which will end up fetching the same data, slower.
             },
-            Self::Continuation { callback } => callback.run_range(leaves.start(), leaves.end()),
+            Self::Continuation { callback } => callback.run_range(&leaves),
         }
     }
 }
@@ -442,7 +452,11 @@ where
             AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
         P: AvailabilityProvider<Types>,
     {
-        fetch_leaf_range_with_callbacks(fetcher, req, None).await
+        let cert2 = HeaderCallback::Cert2 {
+            fetcher: fetcher.clone(),
+        }
+        .into();
+        fetch_leaf_range_with_callbacks(fetcher, req, once(cert2)).await
     }
 
     async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>
@@ -515,6 +529,7 @@ where
         },
         fetcher.provider.clone(),
         once(LeafCallback::Leaf { fetcher }).chain(callbacks),
+        true,
     );
 
     Ok(())

--- a/hotshot-query-service/src/data_source/fetching/vid.rs
+++ b/hotshot-query-service/src/data_source/fetching/vid.rs
@@ -115,9 +115,9 @@ where
         fetch_header_and_then(
             tx,
             req.0,
-            HeaderCallback::VidCommon {
+            [HeaderCallback::VidCommon {
                 fetcher: fetcher.clone(),
-            },
+            }],
         )
         .await
     }
@@ -219,6 +219,7 @@ pub(super) fn fetch_vid_common_with_header<Types, S, P>(
             header,
             fetcher: fetcher.clone(),
         }),
+        true,
     );
 }
 
@@ -382,7 +383,7 @@ where
             AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
         P: AvailabilityProvider<Types>,
     {
-        fetch_header_range_and_then(tx, req, HeaderCallback::VidCommon { fetcher }).await
+        fetch_header_range_and_then(tx, req, [HeaderCallback::VidCommon { fetcher }]).await
     }
 
     async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>
@@ -461,6 +462,7 @@ pub(super) fn fetch_vid_common_range<Types, S, P>(
         once(VidCommonRangeCallback {
             fetcher: fetcher.clone(),
         }),
+        true,
     );
 }
 

--- a/hotshot-query-service/src/data_source/storage.rs
+++ b/hotshot-query-service/src/data_source/storage.rs
@@ -249,6 +249,8 @@ where
         &mut self,
         hash: TransactionHash<Types>,
     ) -> QueryResult<BlockQueryData<Types>>;
+
+    async fn load_cert2(&mut self, height: u64) -> QueryResult<Option<Certificate2<Types>>>;
 }
 
 pub trait UpdateAvailabilityStorage<Types>: Send
@@ -347,8 +349,6 @@ where
     ) -> QueryResult<TimeWindowQueryData<Header<Types>>>;
 
     async fn latest_qc_chain(&mut self) -> QueryResult<Option<[CertificatePair<Types>; 2]>>;
-
-    async fn load_cert2(&mut self, height: u64) -> QueryResult<Option<Certificate2<Types>>>;
 
     /// Load the earliest cert2 whose finalized block height is at or above `height`.
     ///

--- a/hotshot-query-service/src/data_source/storage/fail_storage.rs
+++ b/hotshot-query-service/src/data_source/storage/fail_storage.rs
@@ -447,6 +447,11 @@ where
         self.maybe_fail_read(FailableAction::GetTransaction).await?;
         self.inner.get_block_with_transaction(hash).await
     }
+
+    async fn load_cert2(&mut self, height: u64) -> QueryResult<Option<Certificate2<Types>>> {
+        self.maybe_fail_read(FailableAction::Any).await?;
+        self.inner.load_cert2(height).await
+    }
 }
 
 impl<Types, T> UpdateAvailabilityStorage<Types> for Transaction<T>
@@ -581,11 +586,6 @@ where
     async fn latest_qc_chain(&mut self) -> QueryResult<Option<[CertificatePair<Types>; 2]>> {
         self.maybe_fail_read(FailableAction::Any).await?;
         self.inner.latest_qc_chain().await
-    }
-
-    async fn load_cert2(&mut self, height: u64) -> QueryResult<Option<Certificate2<Types>>> {
-        self.maybe_fail_read(FailableAction::Any).await?;
-        self.inner.load_cert2(height).await
     }
 
     async fn load_earliest_cert2(

--- a/hotshot-query-service/src/data_source/storage/fs.rs
+++ b/hotshot-query-service/src/data_source/storage/fs.rs
@@ -644,6 +644,15 @@ where
             .context(NotFoundSnafu)?;
         self.inner.get_block((*height as usize).into())
     }
+
+    async fn load_cert2(&mut self, height: u64) -> QueryResult<Option<Certificate2<Types>>> {
+        Ok(self
+            .inner
+            .cert2_storage
+            .iter()
+            .nth(height as usize)
+            .flatten())
+    }
 }
 
 impl<Types: NodeType> UpdateAvailabilityStorage<Types>
@@ -916,15 +925,6 @@ where
 
     async fn latest_qc_chain(&mut self) -> QueryResult<Option<[CertificatePair<Types>; 2]>> {
         Ok(self.inner.latest_qc_chain.clone())
-    }
-
-    async fn load_cert2(&mut self, height: u64) -> QueryResult<Option<Certificate2<Types>>> {
-        Ok(self
-            .inner
-            .cert2_storage
-            .iter()
-            .nth(height as usize)
-            .flatten())
     }
 
     async fn load_earliest_cert2(

--- a/hotshot-query-service/src/data_source/storage/sql/queries/availability.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/availability.rs
@@ -21,14 +21,14 @@ use snafu::OptionExt;
 use sqlx::FromRow;
 
 use super::{
-    super::transaction::{Transaction, TransactionMode, query},
-    BLOCK_COLUMNS, LEAF_COLUMNS, PAYLOAD_COLUMNS, PAYLOAD_METADATA_COLUMNS, QueryBuilder,
-    VID_COMMON_COLUMNS, VID_COMMON_METADATA_COLUMNS,
+    super::transaction::{Transaction, TransactionMode, query, query_as},
+    BLOCK_COLUMNS, DecodeError, LEAF_COLUMNS, PAYLOAD_COLUMNS, PAYLOAD_METADATA_COLUMNS,
+    QueryBuilder, VID_COMMON_COLUMNS, VID_COMMON_METADATA_COLUMNS,
 };
 use crate::{
     Header, MissingSnafu, Payload, QueryError, QueryResult,
     availability::{
-        BlockId, BlockQueryData, LeafId, LeafQueryData, NamespaceInfo, NamespaceMap,
+        BlockId, BlockQueryData, Certificate2, LeafId, LeafQueryData, NamespaceInfo, NamespaceMap,
         PayloadQueryData, QueryableHeader, QueryablePayload, TransactionHash, VidCommonQueryData,
     },
     data_source::storage::{
@@ -356,6 +356,18 @@ where
         );
         let row = query.query(&sql).fetch_one(self.as_mut()).await?;
         Ok(BlockQueryData::from_row(&row)?)
+    }
+
+    async fn load_cert2(&mut self, height: u64) -> QueryResult<Option<Certificate2<Types>>> {
+        let Some((json,)) = query_as("SELECT data FROM cert2 WHERE height = $1")
+            .bind(height as i64)
+            .fetch_optional(self.as_mut())
+            .await?
+        else {
+            return Ok(None);
+        };
+        let cert2 = serde_json::from_value(json).decode_error("malformed cert2")?;
+        Ok(cert2)
     }
 }
 

--- a/hotshot-query-service/src/data_source/storage/sql/queries/node.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/node.rs
@@ -292,18 +292,6 @@ where
         Ok(qcs)
     }
 
-    async fn load_cert2(&mut self, height: u64) -> QueryResult<Option<Certificate2<Types>>> {
-        let Some((json,)) = query_as("SELECT data FROM cert2 WHERE height = $1")
-            .bind(height as i64)
-            .fetch_optional(self.as_mut())
-            .await?
-        else {
-            return Ok(None);
-        };
-        let cert2 = serde_json::from_value(json).decode_error("malformed cert2")?;
-        Ok(cert2)
-    }
-
     async fn load_earliest_cert2(
         &mut self,
         height: u64,

--- a/hotshot-query-service/src/fetching.rs
+++ b/hotshot-query-service/src/fetching.rs
@@ -79,6 +79,14 @@ impl<T, C> Fetcher<T, C> {
             backoff,
         }
     }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn is_fetching(&self, req: &T) -> bool
+    where
+        T: Eq + std::hash::Hash,
+    {
+        self.in_progress.lock().await.contains_key(req)
+    }
 }
 
 impl<T, C> Fetcher<T, C> {
@@ -97,14 +105,17 @@ impl<T, C> Fetcher<T, C> {
     /// Note that while callbacks are allowed to be async, they are executed sequentially while an
     /// exclusive lock is held, and thus they should not take too long to run or block indefinitely.
     ///
-    /// The spawned task will continue trying to fetch the object until it succeeds, so it is the
-    /// caller's responsibility only to use this method for resources which are known to exist and
-    /// be fetchable by `provider`.
+    /// When `retry_forever` is `true`, the spawned task will continue trying to fetch the object
+    /// until it succeeds, so it is the caller's responsibility to only fetch resources which are
+    /// known to exist and be fetchable by `provider`. When `retry_forever` is `false`, the task
+    /// instead gives up the first time no provider can supply the object, running no callbacks.
+    /// This suits resources that are not guaranteed to exist on any peer (e.g. sparse objects).
     pub fn spawn_fetch<Types>(
         &self,
         req: T,
         provider: impl Provider<Types, T> + 'static,
         callbacks: impl IntoIterator<Item = C> + Send + 'static,
+        retry_forever: bool,
     ) where
         T: Request<Types> + 'static,
         C: Callback<T::Response> + 'static,
@@ -143,12 +154,16 @@ impl<T, C> Fetcher<T, C> {
                 // Acquire a permit from the semaphore to rate limit the number of concurrent fetch requests
                 let permit = permit.acquire().await;
                 if let Some(res) = provider.fetch(req).await {
-                    break res;
+                    break Some(res);
                 }
 
-                // We only fetch objects which are known to exist, so we should eventually succeed
-                // in fetching if we retry enough. For example, we may be fetching a block from a
-                // peer who hasn't received the block yet.
+                if !retry_forever {
+                    break None;
+                }
+
+                // We only fetch objects which are known to exist, so we should eventually
+                // succeed in fetching if we retry enough. For example, we may be fetching a block
+                // from a peer who hasn't received the block yet.
                 //
                 // To understand why it is ok to retry indefinitely, think about manual
                 // intervention: if we don't retry, or retry with a limit, we may require manual
@@ -180,8 +195,10 @@ impl<T, C> Fetcher<T, C> {
             // `in_progress`, and so it is safe to acquire any lock _after_ acquiring `in_progress`.
             let mut in_progress = in_progress.lock().await;
             let callbacks = in_progress.remove(&req).unwrap_or_default();
-            for callback in callbacks {
-                callback.run(res.clone()).await;
+            if let Some(res) = res {
+                for callback in callbacks {
+                    callback.run(res.clone()).await;
+                }
             }
         });
     }

--- a/hotshot-query-service/src/fetching/provider/any.rs
+++ b/hotshot-query-service/src/fetching/provider/any.rs
@@ -257,6 +257,15 @@ where
         self.vid_common_range_providers.push(Arc::new(provider));
         self
     }
+
+    /// Add a sub provider which fetches cert2s.
+    pub fn with_cert2_provider<P>(mut self, provider: P) -> Self
+    where
+        P: Provider<Types, Certificate2Request> + Debug + 'static,
+    {
+        self.cert2_providers.push(Arc::new(provider));
+        self
+    }
 }
 
 async fn any_fetch<Types, P, T>(providers: &[Arc<P>], req: T) -> Option<T::Response>

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -204,12 +204,21 @@ impl<Ver: StaticVersionType> TrustedQueryServiceProvider<Ver> {
     pub async fn fetch_cert2<Types: NodeType>(
         &self,
         height: u64,
-    ) -> anyhow::Result<Option<Certificate2<Types>>> {
-        self.client
+    ) -> anyhow::Result<Certificate2<Types>> {
+        let cert2: Certificate2<Types> = self
+            .client
             .get(&format!("availability/cert2/{height}"))
             .send()
             .await
-            .context("fetching cert2")
+            .context("fetching cert2")?;
+
+        ensure!(
+            cert2.data.block_number == height,
+            "received cert2 with the wrong height ({})",
+            cert2.data.block_number,
+        );
+
+        Ok(cert2)
     }
 }
 
@@ -220,7 +229,9 @@ where
     Types: NodeType,
 {
     async fn fetch(&self, req: Certificate2Request) -> Option<Option<Certificate2<Types>>> {
-        self.handle_result(req, self.fetch_cert2(req.height).await)
+        // A found cert2 is `Some(Some(_))`; a 404 (or other error) is `None`, which `any_fetch`
+        // skips so it tries the next provider instead of resolving as absent.
+        self.handle_result(req, self.fetch_cert2(req.height).await.map(Some))
     }
 }
 
@@ -328,7 +339,7 @@ where
 // These tests run the `postgres` Docker image, which doesn't work on Windows.
 #[cfg(all(test, not(target_os = "windows")))]
 mod test {
-    use std::{future::IntoFuture, time::Duration};
+    use std::{future::IntoFuture, marker::PhantomData, time::Duration};
 
     use committable::Committable;
     use futures::{
@@ -336,8 +347,10 @@ mod test {
         stream::StreamExt,
     };
     use hotshot_example_types::node_types::{EpochVersion, TEST_VERSIONS};
+    use hotshot_types::data::ViewNumber;
     use test_utils::reserve_tcp_port;
     use tide_disco::{Api, App};
+    use tokio::time::timeout;
     use toml::toml;
     use vbs::version::StaticVersion;
 
@@ -346,7 +359,7 @@ mod test {
         ApiState,
         availability::{
             self, AvailabilityDataSource, BlockId, BlockInfo, BlockQueryData, BlockWithTransaction,
-            Fetch, UpdateAvailabilityData, define_api,
+            Certificate2, Fetch, UpdateAvailabilityData, define_api,
         },
         data_source::{
             AvailabilityProvider, FetchingDataSource, Transaction, VersionedDataSource,
@@ -358,12 +371,12 @@ mod test {
                 sql::testing::TmpDb,
             },
         },
-        fetching::provider::{NoFetching, Provider as ProviderTrait, TestProvider},
+        fetching::provider::{AnyProvider, NoFetching, Provider as ProviderTrait, TestProvider},
         node::data_source::NodeDataSource,
         task::BackgroundTask,
         testing::{
             consensus::{MockDataSource, MockNetwork},
-            mocks::{MockBase, MockTypes, mock_transaction},
+            mocks::{MockBase, MockPayload, MockTypes, mock_transaction},
             sleep,
         },
         types::HeightIndexed,
@@ -373,6 +386,79 @@ mod test {
     type EpochProvider = TestProvider<TrustedQueryServiceProvider<EpochVersion>>;
 
     fn ignore<T>(_: T) {}
+
+    async fn v6_leaf(number: u64) -> LeafQueryData<MockTypes> {
+        use committable::Committable;
+        use hotshot_types::{data::Leaf2, simple_certificate::QuorumCertificate2};
+
+        let mut leaf = Leaf2::<MockTypes>::genesis(
+            &Default::default(),
+            &Default::default(),
+            TEST_VERSIONS.test.base,
+        )
+        .await;
+        leaf.block_header_mut().block_number = number;
+        leaf.block_header_mut().version = versions::NEW_PROTOCOL_VERSION;
+        let mut qc = QuorumCertificate2::<MockTypes>::genesis(
+            &Default::default(),
+            &Default::default(),
+            TEST_VERSIONS.test,
+        )
+        .await;
+        qc.view_number = ViewNumber::new(number);
+        qc.data.leaf_commit = Committable::commit(&leaf);
+        LeafQueryData::new(leaf, qc).unwrap()
+    }
+
+    /// A cert2 finalizing `leaf`.
+    fn cert2_for(leaf: &LeafQueryData<MockTypes>) -> Certificate2<MockTypes> {
+        use committable::Committable;
+        use hotshot_types::simple_vote::Vote2Data;
+
+        let data = Vote2Data {
+            leaf_commit: leaf.leaf().commit(),
+            epoch: Default::default(),
+            block_number: leaf.height(),
+        };
+        Certificate2::new(
+            data.clone(),
+            data.commit(),
+            leaf.leaf().view_number(),
+            None,
+            PhantomData,
+        )
+    }
+
+    /// Serve the availability API for `data_source` on a fresh port and return the port and the
+    /// background task running the server.
+    async fn serve_availability(
+        data_source: impl AvailabilityDataSource<MockTypes> + Send + Sync + 'static,
+    ) -> (u16, BackgroundTask) {
+        let port = reserve_tcp_port().unwrap();
+        let mut app = App::<_, Error>::with_state(ApiState::from(data_source));
+        app.register_module(
+            "availability",
+            define_api(
+                &Default::default(),
+                MockBase::instance(),
+                "1.0.0".parse().unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let task = BackgroundTask::spawn(
+            "server",
+            app.serve(format!("0.0.0.0:{port}"), MockBase::instance()),
+        );
+        (port, task)
+    }
+
+    fn trusted_provider(port: u16) -> TrustedQueryServiceProvider<MockBase> {
+        TrustedQueryServiceProvider::new(
+            format!("http://localhost:{port}").parse().unwrap(),
+            MockBase::instance(),
+        )
+    }
 
     /// Build a data source suitable for this suite of tests.
     async fn builder<P: AvailabilityProvider<MockTypes> + Clone>(
@@ -1679,6 +1765,311 @@ mod test {
 
         assert_eq!(block.hash(), leaf.block_hash());
         assert_eq!(vid.block_hash(), leaf.block_hash());
+    }
+
+    /// Test that fetching a leaf also backfills the leaf's cert2.
+    ///
+    /// A server node stores three V6 leaves and a cert2 for the first one. A client node fetches
+    /// the first leaf from the server and must automatically backfill its cert2, without an
+    /// explicit cert2 request. Fetching the second leaf, which has no cert2 (the common case,
+    /// since only the newest leaf of each decide batch carries one), must resolve as "absent"
+    /// and store nothing, rather than retrying forever.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_backfill_cert2_with_leaf() {
+        // A server that has V6 leaves and, at height 1, a cert2 in storage.
+        let server_db = TmpDb::init().await;
+        let server = data_source(&server_db, &NoFetching).await;
+
+        // The leaf at `height` is a decide head and carries a cert2. The leaf at `sparse_height`
+        // has none, the common case, since only the newest leaf of each decide batch carries one.
+        // The last leaf just seeds the client's block height.
+        let height = 1u64;
+        let leaf = v6_leaf(height).await;
+        let sparse_height = 2u64;
+        let sparse_leaf = v6_leaf(sparse_height).await;
+        let later_leaf = v6_leaf(3).await;
+        let cert2 = cert2_for(&leaf);
+
+        {
+            let mut tx = server.write().await.unwrap();
+            tx.insert_leaf(&leaf).await.unwrap();
+            tx.insert_leaf(&sparse_leaf).await.unwrap();
+            tx.insert_leaf(&later_leaf).await.unwrap();
+            tx.insert_cert2(height, cert2.clone()).await.unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        let (port, _server_task) = serve_availability(server).await;
+
+        // A client with no cert2, fetching leaves from the server.
+        let client_db = TmpDb::init().await;
+        let provider = Provider::new(trusted_provider(port));
+        let client = builder(&client_db, &provider)
+            .await
+            .with_max_retry_interval(Duration::from_secs(1))
+            .build()
+            .await
+            .unwrap();
+
+        // Seed the client with the later leaf so it knows the block height and can actively fetch
+        // the earlier leaf. This carries no cert2, so it does not pre-populate what we are testing.
+        {
+            let mut tx = client.write().await.unwrap();
+            tx.insert_leaf(&later_leaf).await.unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        // Fetching the earlier leaf triggers the cert2 backfill callback.
+        let fetched = client
+            .get_leaf(height as usize)
+            .await
+            .with_timeout(Duration::from_secs(30))
+            .await
+            .unwrap();
+        assert_eq!(fetched.height(), height);
+
+        // The cert2 is backfilled into the client's storage without an explicit cert2 request.
+        // Read it directly from storage so this check does not itself trigger a fetch.
+        let backfilled = timeout(Duration::from_secs(30), async {
+            loop {
+                {
+                    let mut tx = client.read().await.unwrap();
+                    if let Some(cert2) = tx.load_cert2(height).await.unwrap() {
+                        break cert2;
+                    }
+                }
+                sleep(Duration::from_millis(200)).await;
+            }
+        })
+        .await
+        .expect("cert2 was not backfilled");
+        assert_eq!(backfilled.data.leaf_commit, cert2.data.leaf_commit);
+
+        // Fetching a leaf with no cert2 (the sparse common case) resolves the backfill as
+        // "absent": the fetch completes and nothing is stored, rather than retrying forever.
+        let fetched = client
+            .get_leaf(sparse_height as usize)
+            .await
+            .with_timeout(Duration::from_secs(30))
+            .await
+            .unwrap();
+        assert_eq!(fetched.height(), sparse_height);
+        sleep(Duration::from_secs(1)).await;
+        {
+            let mut tx = client.read().await.unwrap();
+            let cert2: Option<Certificate2<MockTypes>> =
+                tx.load_cert2(sparse_height).await.unwrap();
+            assert!(cert2.is_none());
+        }
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_backfill_cert2_with_scanner() {
+        // A server holding full blocks (so the scanner's block fetch succeeds) and, at height 1, a
+        // cert2. The scanner fetches missing blocks, which triggers the leaf fetch and hence the
+        // cert2 backfill.
+        let server_db = TmpDb::init().await;
+        let server = data_source(&server_db, &NoFetching).await;
+
+        // The scanner scans the whole range `[0, block_height)`, so the server needs a contiguous
+        // set of leaves and blocks from genesis. Only height 1 carries a cert2.
+        let height = 1u64;
+        let mut leaves = Vec::new();
+        for n in 0..=2 {
+            leaves.push(v6_leaf(n).await);
+        }
+        let leaf = leaves[height as usize].clone();
+        let tip = leaves.last().unwrap().clone();
+        let cert2 = cert2_for(&leaf);
+        {
+            let mut tx = server.write().await.unwrap();
+            for l in &leaves {
+                tx.insert_leaf(l).await.unwrap();
+                let block =
+                    BlockQueryData::<MockTypes>::new(l.header().clone(), MockPayload::genesis());
+                tx.insert_block(&block).await.unwrap();
+            }
+            tx.insert_cert2(height, cert2.clone()).await.unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        let (port, _server_task) = serve_availability(server).await;
+
+        // A client that fetches from the server and runs the proactive scanner frequently. We do
+        // NOT call get_leaf/get_cert2 ourselves: the scanner alone should discover the missing
+        // history and backfill the cert2 as a side effect of fetching the leaf.
+        let client_db = TmpDb::init().await;
+        let provider = Provider::new(trusted_provider(port));
+        let client = client_db
+            .config()
+            .builder::<MockTypes, _>(provider)
+            .await
+            .unwrap()
+            .with_proactive_interval(Duration::from_secs(1))
+            .with_sync_status_ttl(Duration::from_secs(1))
+            .with_max_retry_interval(Duration::from_secs(1))
+            .build()
+            .await
+            .unwrap();
+
+        // Seed the tip so the scanner knows the block height and scans the range below it.
+        {
+            let mut tx = client.write().await.unwrap();
+            tx.insert_leaf(&tip).await.unwrap();
+            let tip_block =
+                BlockQueryData::<MockTypes>::new(tip.header().clone(), MockPayload::genesis());
+            tx.insert_block(&tip_block).await.unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        let backfilled = timeout(Duration::from_secs(30), async {
+            loop {
+                {
+                    let mut tx = client.read().await.unwrap();
+                    if let Some(cert2) = tx.load_cert2(height).await.unwrap() {
+                        break cert2;
+                    }
+                }
+                sleep(Duration::from_millis(500)).await;
+            }
+        })
+        .await
+        .expect("scanner did not backfill cert2");
+        assert_eq!(backfilled.data.leaf_commit, cert2.data.leaf_commit);
+    }
+
+    // A cert2 provider that cannot supply the cert2 must not short-circuit the backfill: the fetch
+    // walks past it to a provider that has it. This covers both ways a provider fails to supply a
+    // cert2 — since a peer that responds "absent" 404s, `fetch_cert2` errors and the provider
+    // returns `None`, the same outer-`None` a transport failure (`fail()`) produces here.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_cert2_fetch_walks_past_failing_peers() {
+        let server_db = TmpDb::init().await;
+        let server = data_source(&server_db, &NoFetching).await;
+        let leaf = v6_leaf(1).await;
+        let tip = v6_leaf(2).await;
+        let cert2 = cert2_for(&leaf);
+        {
+            let mut tx = server.write().await.unwrap();
+            tx.insert_leaf(&leaf).await.unwrap();
+            tx.insert_leaf(&tip).await.unwrap();
+            tx.insert_cert2(leaf.height(), cert2.clone()).await.unwrap();
+            tx.commit().await.unwrap();
+        }
+        let (port, _server_task) = serve_availability(server).await;
+
+        // A healthy leaf provider (so the leaf fetch succeeds), and cert2 providers that are two
+        // failing then one healthy: the failures must not short-circuit the cert2 backfill.
+        let failing_a = TestProvider::new(trusted_provider(port));
+        let failing_b = TestProvider::new(trusted_provider(port));
+        failing_a.fail();
+        failing_b.fail();
+        let provider = AnyProvider::<MockTypes>::default()
+            .with_leaf_provider(TestProvider::new(trusted_provider(port)))
+            .with_cert2_provider(failing_a)
+            .with_cert2_provider(failing_b)
+            .with_cert2_provider(TestProvider::new(trusted_provider(port)));
+
+        let client_db = TmpDb::init().await;
+        let client = builder(&client_db, &provider)
+            .await
+            .with_max_retry_interval(Duration::from_secs(1))
+            .build()
+            .await
+            .unwrap();
+        {
+            let mut tx = client.write().await.unwrap();
+            tx.insert_leaf(&tip).await.unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        client
+            .get_leaf(leaf.height() as usize)
+            .await
+            .with_timeout(Duration::from_secs(30))
+            .await
+            .unwrap();
+        let backfilled = timeout(Duration::from_secs(30), async {
+            loop {
+                {
+                    let mut tx = client.read().await.unwrap();
+                    if let Some(cert2) = tx.load_cert2(leaf.height()).await.unwrap() {
+                        break cert2;
+                    }
+                }
+                sleep(Duration::from_millis(200)).await;
+            }
+        })
+        .await
+        .expect("cert2 not backfilled while a peer had it");
+        assert_eq!(backfilled.data.leaf_commit, cert2.data.leaf_commit);
+    }
+
+    // When no cert2 provider can answer, the backfill resolves and
+    // stores nothing. The leaf is fetched from a healthy provider so its backfill callback fires
+    // while the cert2 providers all fail.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_cert2_fetch_resolves_when_no_peer_has_it() {
+        let server_db = TmpDb::init().await;
+        let server = data_source(&server_db, &NoFetching).await;
+        let leaf = v6_leaf(1).await;
+        let tip = v6_leaf(2).await;
+        {
+            let mut tx = server.write().await.unwrap();
+            tx.insert_leaf(&leaf).await.unwrap();
+            tx.insert_leaf(&tip).await.unwrap();
+            tx.commit().await.unwrap();
+        }
+        let (port, _server_task) = serve_availability(server).await;
+
+        // Leaf provider is healthy; the only cert2 provider fails, so no cert2 fetch can be
+        // answered. (with_leaf_provider, not with_provider, so the failing cert2 provider is the
+        // sole entry in the cert2 list.)
+        let failing_cert2 = TestProvider::new(trusted_provider(port));
+        failing_cert2.fail();
+        let provider = AnyProvider::<MockTypes>::default()
+            .with_leaf_provider(TestProvider::new(trusted_provider(port)))
+            .with_cert2_provider(failing_cert2);
+
+        let client_db = TmpDb::init().await;
+        let client = builder(&client_db, &provider)
+            .await
+            .with_max_retry_interval(Duration::from_secs(1))
+            .build()
+            .await
+            .unwrap();
+        {
+            let mut tx = client.write().await.unwrap();
+            tx.insert_leaf(&tip).await.unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        // Fetching the leaf succeeds (via the healthy leaf provider) and fires the cert2 backfill,
+        // whose providers all fail.
+        client
+            .get_leaf(leaf.height() as usize)
+            .await
+            .with_timeout(Duration::from_secs(30))
+            .await
+            .unwrap();
+
+        sleep(Duration::from_secs(2)).await;
+
+        // Nothing is stored, and the fetch resolved rather than dangling: no cert2 fetch is still in
+        // progress. If cert2 retried forever, this request would still be in progress here.
+        {
+            let mut tx = client.read().await.unwrap();
+            let cert2: Option<Certificate2<MockTypes>> =
+                tx.load_cert2(leaf.height()).await.unwrap();
+            assert!(
+                cert2.is_none(),
+                "no cert2 should be stored when no peer has it"
+            );
+        }
+        assert!(
+            !client.is_fetching_cert2(leaf.height()).await,
+            "cert2 fetch should have resolved, not be left retrying"
+        );
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -20,7 +20,7 @@ use hotshot_types::data::EpochNumber;
 #[cfg(feature = "client")]
 use serde::de::DeserializeOwned;
 #[cfg(feature = "client")]
-use surf_disco::Url;
+use surf_disco::{Error as _, StatusCode, Url};
 #[cfg(feature = "client")]
 use tagged_base64::TaggedBase64;
 #[cfg(feature = "client")]
@@ -164,6 +164,15 @@ impl QueryServiceClient {
 }
 
 #[cfg(feature = "client")]
+fn is_not_found(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<hotshot_query_service_types::Error>()
+            .is_some_and(|e| e.status() == StatusCode::NOT_FOUND)
+    })
+}
+
+#[cfg(feature = "client")]
 impl Client for QueryServiceClient {
     async fn block_height(&self) -> Result<u64> {
         self.fetch("/node/block-height").await
@@ -248,7 +257,12 @@ impl Client for QueryServiceClient {
     }
 
     async fn cert2(&self, height: u64) -> Result<Option<Certificate2<SeqTypes>>> {
-        self.fetch(&format!("/availability/cert2/{height}")).await
+        // A peer that lacks the cert2 responds 404. We surface that as an error rather than
+        // `Ok(None)` so `FallbackClient` keeps trying other peers instead of stopping at the first
+        // one that lacks it; it resolves absent only once every peer has 404'd.
+        self.fetch::<Certificate2<SeqTypes>>(&format!("/availability/cert2/{height}"))
+            .await
+            .map(Some)
     }
 }
 
@@ -377,8 +391,17 @@ where
     }
 
     async fn cert2(&self, height: u64) -> Result<Option<Certificate2<SeqTypes>>> {
-        self.get_any(&self.clients, |client| client.cert2(height))
+        // Each peer 404s (an error) when it lacks the cert2, so `get_any` keeps trying peers until
+        // one has it. Once every peer has 404'd, `get_any` returns that not-found error, which we
+        // map back to `Ok(None)` (absent). Any other error propagates so the fetch is retried.
+        match self
+            .get_any(&self.clients, |client| client.cert2(height))
             .await
+        {
+            Ok(cert2) => Ok(cert2),
+            Err(err) if is_not_found(&err) => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 }
 

--- a/light-client/src/provider.rs
+++ b/light-client/src/provider.rs
@@ -165,7 +165,7 @@ where
         match self.fetch_certificate2(req.height).await {
             Ok(cert2) => Some(cert2),
             Err(err) => {
-                tracing::warn!(?req, "failed to fetch cert2: {err:#}");
+                tracing::info!(?req, %err, "failed to fetch cert2, will retry");
                 None
             },
         }


### PR DESCRIPTION
Backports the consensus/new-protocol fixes that landed on `main` after the last release-ff sync (#4712). All commits cherry-picked with `-x`, in main's merge order.

### This PR:
* #4698 — Move proposal/VID-share pairing into `Consensus`
* #4695 — Verify certificates asynchronously (adds `cert_verifier.rs`)
* #4743 — Check epoch change structure before signatures
* #4731 — Keep only a limited number of `EpochSnapshot`s (bounds memory)
* #4747 — Bound resources held for unauthenticated cliquenet peers
* #4730 — Backfill Cert2s in scanner task
* #4751 — Let a fully replaced committee start its epoch
* #4796 — Refuse vote2 in a view a later vote1 skipped (adds `tests/safety.rs`)

Backport adaptations (the only deviations from clean picks):
* #4730's `crates/espresso/api/src/axum.rs` hunk conflicted with release-ff's pre-aide axum router; resolved by applying the `get_cert2` None→404 change in release-ff's plain `Router`/`Json` style.
* Two test call sites in `tests/consensus.rs` (added to release-ff via the #4712 sync) still used the pre-#4698 single-input `apply()`; updated to `apply_pair(...)`, matching main exactly (separate commit).

### This PR does not:
* Backport the test-coverage PRs (#4732, #4752, #4753, #4755, #4756, #4771, #4773) — those follow in a stacked PR.
* Pull in any of the tide→axum migration work.

### Key places to review:
* The `get_cert2` handler in `crates/espresso/api/src/axum.rs` — the one manual conflict resolution.
* Everything else is byte-for-byte main content: after this PR, `crates/cliquenet/` is identical to `main`, and `crates/hotshot/new-protocol/` differs from `main` only by the not-yet-backported test PRs.

### Things tested
* `cargo nextest run -p hotshot-new-protocol -p cliquenet`: 253/253 pass (pre-#4796), then safety/consensus filter 45/45 after adding #4796.
* `cargo check --tests` clean on cliquenet, hotshot-new-protocol, hotshot-query-service, espresso-api, espresso-node, light-client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)