### PR TITLE
fix(node): skip legacy network wait once new-protocol cutover is decided

### DIFF
--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -17,7 +17,7 @@ use futures::{
     future::join_all,
     stream::{BoxStream, Stream, StreamExt},
 };
-use hotshot::SystemContext;
+use hotshot::{HotShotInitializer, SystemContext};
 use hotshot_events_service::events_source::{EventConsumer, EventsStreamer};
 use hotshot_new_protocol::{
     coordinator::Coordinator,
@@ -110,14 +110,15 @@ where
     N: ConnectedNetwork<PubKey>,
     P: SequencerPersistence,
 {
-    #[tracing::instrument(skip_all, fields(node_id = instance_state.node_id))]
+    #[tracing::instrument(skip_all, fields(node_id = initializer.instance_state.node_id))]
     #[allow(clippy::too_many_arguments)]
     pub async fn init<F>(
         network_config: NetworkConfig<SeqTypes>,
         upgrade: versions::Upgrade,
         validator_config: ValidatorConfig<SeqTypes>,
         membership_coordinator: EpochMembershipCoordinator<SeqTypes>,
-        instance_state: NodeState,
+        initializer: HotShotInitializer<SeqTypes>,
+        anchor_view: Option<ViewNumber>,
         storage: Option<RequestResponseStorage>,
         state_catchup: ParallelStateCatchup,
         persistence: Arc<P>,
@@ -137,6 +138,8 @@ where
         let pub_key = validator_config.public_key;
         tracing::info!(%pub_key, "initializing consensus");
 
+        let instance_state = initializer.instance_state.clone();
+
         // Stick our node ID in `metrics` so it is easily accessible via the status API.
         metrics
             .create_gauge("node_index".into(), None)
@@ -144,11 +147,6 @@ where
 
         // Start L1 client if it isn't already.
         instance_state.l1_client.spawn_tasks().await;
-
-        // Load saved consensus state from storage.
-        let (initializer, anchor_view) = persistence
-            .load_consensus_state(instance_state.clone(), upgrade)
-            .await?;
 
         info!(target: "announce", ?initializer, "starting up sequencer context with initializer");
 

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -58,6 +58,7 @@ pub use espresso_types::RECENT_STAKE_TABLES_LIMIT;
 use genesis::L1Finalized;
 pub use genesis::{Genesis, GenesisSource};
 use hotshot::{
+    HotShotInitializer,
     traits::implementations::{
         CdnMetricsValue, CdnTopic, CombinedNetworks, GossipConfig, KeyPair, Libp2pNetwork,
         MemoryNetwork, PushCdnNetwork, RequestResponseConfig, WrappedSignatureKey,
@@ -834,8 +835,14 @@ where
 
         // From `NEW_PROTOCOL_VERSION` on, all consensus traffic runs on
         // cliquenet and the legacy stack is torn down at startup, so don't
-        // hold up boot waiting for legacy connectivity.
-        if genesis.base_version < versions::NEW_PROTOCOL_VERSION {
+        // hold up boot waiting for legacy connectivity. The same applies when
+        // the configured base version predates the cutover but the network has
+        // already upgraded (a decided upgrade certificate is persisted): the
+        // legacy network may be gone entirely, so waiting could block boot
+        // forever.
+        if genesis.base_version < versions::NEW_PROTOCOL_VERSION
+            && !new_protocol_cutover_complete(&initializer)
+        {
             tracing::warn!("Waiting for at least one connection to be initialized");
             select! {
                 _ = cdn_network.wait_for_ready() => {
@@ -957,6 +964,26 @@ async fn check_cliquenet_info_registered(
          --out keys.env`), then (2) register it on-chain (`staking-cli update-network-config \
          --x25519-key <ESPRESSO_NODE_PUBLIC_X25519_KEY> --p2p-addr <host:port>`)."
     );
+}
+
+/// Whether the loaded consensus state shows the network has already upgraded
+/// to `NEW_PROTOCOL_VERSION`, even though the configured base version predates
+/// it: a decided upgrade certificate to the new protocol is stored and the
+/// view we restart from is past the cutover view.
+fn new_protocol_cutover_complete(initializer: &HotShotInitializer<SeqTypes>) -> bool {
+    let Some(cert) = &initializer.decided_upgrade_certificate else {
+        return false;
+    };
+    let complete = cert.data.new_version >= versions::NEW_PROTOCOL_VERSION
+        && initializer.start_view >= cert.data.new_version_first_view;
+    if complete {
+        tracing::info!(
+            start_view = %initializer.start_view,
+            cutover_view = %cert.data.new_version_first_view,
+            "network already upgraded to the new protocol, not waiting for the legacy network"
+        );
+    }
+    complete
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -795,6 +795,13 @@ where
             .build(),
     };
 
+    // Load saved consensus state from storage. It is loaded once here, both to
+    // seed consensus in `SequencerContext::init` below and to tell whether the
+    // network has already cut over to the new protocol.
+    let (initializer, anchor_view) = persistence
+        .load_consensus_state(instance_state, version_upgrade)
+        .await?;
+
     let combined_network = {
         info!("Initializing Libp2p network");
         // Mainnet keeps today's libp2p protocol strings byte-identical.
@@ -859,7 +866,8 @@ where
         version_upgrade,
         validator_config,
         coordinator,
-        instance_state,
+        initializer,
+        anchor_view,
         storage,
         state_catchup_providers,
         persistence,
@@ -1820,6 +1828,11 @@ pub mod testing {
                 }
             };
 
+            let (initializer, anchor_view) = persistence
+                .load_consensus_state(node_state, upgrade)
+                .await
+                .unwrap();
+
             SequencerContext::init(
                 NetworkConfig {
                     config,
@@ -1830,7 +1843,8 @@ pub mod testing {
                 upgrade,
                 validator_config,
                 coordinator,
-                node_state,
+                initializer,
+                anchor_view,
                 storage,
                 catchup_providers,
                 persistence,


### PR DESCRIPTION
## Problem

After the network upgrades to `NEW_PROTOCOL_VERSION` (0.6) via an upgrade certificate, the genesis config may still list an older base version. On restart, `init_node` blocks on `wait_for_ready()` for the legacy CDN/libp2p networks whenever `genesis.base_version < NEW_PROTOCOL_VERSION` — but post-cutover the legacy network may be gone entirely, so boot can hang forever.

## Fix

Skip the legacy-connectivity wait when the loaded consensus state shows the cutover already happened: a decided upgrade certificate to `NEW_PROTOCOL_VERSION` (or later) is persisted and the restart view is at or past the certificate's `new_version_first_view`.

Two commits:

1. **refactor(node): load consensus state once in init_node** — hoists `load_consensus_state` out of `SequencerContext::init` into its two callers; `init` now takes the `(initializer, anchor_view)` pair instead of `instance_state` (recovered from `initializer.instance_state`). No behavior change; it makes the loaded consensus state available before the network is constructed, so the cert is loaded exactly once.
2. **fix(node): skip legacy network wait once new-protocol cutover is decided** — adds the `new_protocol_cutover_complete` check to the wait condition.

## Notes for review

- The skip condition uses `initializer.start_view`, which is the same `max(restart_view, anchor_leaf.view)` that `ConsensusHandle::activate()` later sees as `cur_view` when deciding to run the new protocol — so "skip the wait" and "run the new protocol" derive from the same value.
- A node restarting after the cert is decided but *before* the cutover view still waits for the legacy network, since legacy consensus still has views to run.
- `start_consensus` still only tears down the legacy stack when the base version starts at the cutover; keeping legacy state readable for pre-cutover queries in the cert case is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)