### PR TITLE
test: validator key and address rotation at 0.6

### DIFF
--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -2409,6 +2409,62 @@ pub mod test_helpers {
             self.deferred.remove(0);
 
             let ctx = self
+                .init_and_start(i, state, persistence, catchup, upgrade)
+                .await;
+            self.peers.push(ctx);
+            self.peers.last().unwrap()
+        }
+
+        /// Shuts the node at index `i` down and reinitializes it from the
+        /// network's current configuration, picking up any rotated consensus
+        /// keys or coordinator address (see [`TestConfig::set_consensus_keys`]
+        /// and [`TestConfig::set_coordinator_addr`]). Node 0 hosts the query
+        /// API and cannot be restarted this way.
+        pub async fn restart_node<C: StateCatchup + 'static>(
+            &mut self,
+            i: usize,
+            state: ValidatedState,
+            persistence: P,
+            catchup: C,
+            upgrade: versions::Upgrade,
+        ) -> &SequencerContext<network::Memory, P::Persistence> {
+            assert_ne!(i, 0, "node 0 runs the API server and cannot be restarted");
+            assert!(
+                !self.deferred.contains(&i),
+                "node {i} was deferred and has not been started yet"
+            );
+            self.peers[i - 1].shut_down().await;
+            // The restarted node may rebind the very coordinator port it
+            // just released, but `shut_down` cannot await the listener drop:
+            // aborted tasks holding network senders keep it alive. Poll
+            // until the address is actually bindable again.
+            let addr = self.cfg.coordinator_addr(i).to_string();
+            timeout(Duration::from_secs(60), async {
+                while std::net::TcpListener::bind(&addr).is_err() {
+                    sleep(Duration::from_millis(100)).await;
+                }
+            })
+            .await
+            .expect("shut-down node did not release its coordinator port");
+
+            let ctx = self
+                .init_and_start(i, state, persistence, catchup, upgrade)
+                .await;
+            self.peers[i - 1] = ctx;
+            &self.peers[i - 1]
+        }
+
+        /// Initializes node `i` from the network's current configuration and
+        /// starts consensus on it, the same way construction does.
+        async fn init_and_start<C: StateCatchup + 'static>(
+            &self,
+            i: usize,
+            state: ValidatedState,
+            persistence: P,
+            catchup: C,
+            upgrade: versions::Upgrade,
+        ) -> SequencerContext<network::Memory, P::Persistence> {
+            let ctx = self
                 .cfg
                 .init_node(
                     i,
@@ -2424,8 +2480,7 @@ pub mod test_helpers {
                 )
                 .await;
             ctx.start_consensus().await;
-            self.peers.push(ctx);
-            self.peers.last().unwrap()
+            ctx
         }
 
         pub async fn stop_consensus(&mut self) {

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -1616,6 +1616,38 @@ pub mod testing {
             select_staking_key_sets(self.staking_priv_keys(), indices)
         }
 
+        /// The cliquenet coordinator address assigned to node `i`.
+        pub fn coordinator_addr(&self, i: usize) -> NetAddr {
+            self.coordinator_addrs[i].clone()
+        }
+
+        /// Rebinds node `i`'s cliquenet coordinator to `addr`, taking effect
+        /// the next time the node is initialized. Peers learn the address
+        /// from the stake table contract, so the caller must also publish it
+        /// there (`updateP2pAddr` or `updateNetworkConfig`).
+        pub fn set_coordinator_addr(&mut self, i: usize, addr: NetAddr) {
+            self.coordinator_addrs[i] = addr;
+        }
+
+        /// Replaces node `i`'s consensus keys, taking effect the next time
+        /// the node is initialized: it then signs with the new keys and
+        /// derives its cliquenet x25519 identity from the new BLS key (see
+        /// [`Self::init_node`]). The genesis stake table intentionally keeps
+        /// the old keys — it must stay identical across nodes — so the new
+        /// keys only become effective once the caller publishes the same
+        /// rotation on-chain (`updateConsensusKeysV2`, plus
+        /// `updateNetworkConfig` with the newly derived x25519 key) and the
+        /// change reaches an epoch's stake table snapshot.
+        ///
+        /// Caveat: the light-client state signer checks membership against
+        /// the genesis stake table, so a rotated node stops contributing
+        /// state-relay signatures. No test combines rotation with a state
+        /// relay yet.
+        pub fn set_consensus_keys(&mut self, i: usize, bls: BLSPrivKey, state: StateKeyPair) {
+            self.priv_keys[i] = bls;
+            self.state_key_pairs[i] = state;
+        }
+
         /// Contracts deployed by [`TestConfigBuilder::set_upgrades_with`], if
         /// that was used to set up this config.
         pub fn contracts(&self) -> Option<Contracts> {
@@ -1691,9 +1723,10 @@ pub mod testing {
                 .expect("x25519 keypair derivation should succeed");
             let coordinator_addr = self.coordinator_addrs[i].clone();
 
-            // Create our own (private, local) validator config
+            let pub_key = PubKey::from_private(&self.priv_keys[i]);
+
             let validator_config = ValidatorConfig {
-                public_key: my_peer_config.stake_table_entry.stake_key,
+                public_key: pub_key,
                 private_key: self.priv_keys[i].clone(),
                 stake_value: my_peer_config.stake_table_entry.stake_amount,
                 state_public_key: self.state_key_pairs[i].ver_key(),
@@ -1710,7 +1743,7 @@ pub mod testing {
             };
 
             let network = Arc::new(MemoryNetwork::new(
-                &my_peer_config.stake_table_entry.stake_key,
+                &pub_key,
                 &self.master_map,
                 &topics,
                 None,
@@ -1800,24 +1833,21 @@ pub mod testing {
 
             tracing::info!(
                 i,
-                key = %my_peer_config.stake_table_entry.stake_key,
-                state_key = %my_peer_config.state_ver_key,
+                key = %pub_key,
+                state_key = %self.state_key_pairs[i].ver_key(),
                 "starting node",
             );
 
-            let coordinator_network = {
-                let pub_key = my_peer_config.stake_table_entry.stake_key;
-                move |upgrade| {
-                    Cliquenet::create(
-                        "test-coordinator",
-                        pub_key,
-                        x25519_keypair,
-                        coordinator_addr,
-                        [],
-                        upgrade,
-                        Box::new(NoMetrics),
-                    )
-                }
+            let coordinator_network = move |upgrade| {
+                Cliquenet::create(
+                    "test-coordinator",
+                    pub_key,
+                    x25519_keypair,
+                    coordinator_addr,
+                    [],
+                    upgrade,
+                    Box::new(NoMetrics),
+                )
             };
 
             SequencerContext::init(

--- a/slow-tests/tests/stake_table_changes.rs
+++ b/slow-tests/tests/stake_table_changes.rs
@@ -31,7 +31,8 @@ use espresso_node::{
     testing::{TestConfig, TestConfigBuilder, wait_for_epochs},
 };
 use espresso_types::{
-    AuthenticatedValidatorMap, Header, SeqTypes, ValidatedState, v0::traits::SequencerPersistence,
+    AuthenticatedValidatorMap, Header, PubKey, SeqTypes, ValidatedState,
+    v0::traits::SequencerPersistence,
 };
 use futures::{
     future::join_all,
@@ -41,12 +42,19 @@ use hotshot::types::EventType;
 use hotshot_contract_adapter::stake_table::StakeTableContractVersion;
 use hotshot_query_service::{availability::LeafQueryData, types::HeightIndexed};
 use hotshot_types::{
-    new_protocol::CoordinatorEvent, traits::metrics::NoMetrics, utils::epoch_from_block_number,
+    addr::NetAddr,
+    light_client::StateKeyPair,
+    new_protocol::CoordinatorEvent,
+    signature_key::BLSKeyPair,
+    traits::{metrics::NoMetrics, signature_key::SignatureKey},
+    utils::epoch_from_block_number,
+    x25519,
 };
 use http_client::{Client, error::ClientErr};
 use rstest::rstest;
 use staking_cli::{
-    Transaction as StakingTransaction, demo::DelegationConfig, update_network_config,
+    NodeSignatures, Transaction as StakingTransaction, demo::DelegationConfig,
+    update_network_config,
 };
 use test_utils::reserve_tcp_port;
 use tokio::time::timeout;
@@ -68,6 +76,16 @@ const MAX_ACTIVATION_EPOCHS: u64 = 10;
 
 type SqlPersistence = <SqlDataSource as SequencerDataSource>::Options;
 
+/// State-peers catchup pointed at node 0's query API.
+fn node_catchup(api_port: u16) -> StatePeers<SequencerApiVersion> {
+    StatePeers::from_urls(
+        vec![format!("http://localhost:{api_port}").parse().unwrap()],
+        Default::default(),
+        Duration::from_secs(2),
+        &NoMetrics,
+    )
+}
+
 /// A running network for stake-table-change tests: SQL storage per node,
 /// node 0 serving the query API, state-peers catchup pointed at node 0, and
 /// only the validators at `registered` indices staked on the contract.
@@ -76,6 +94,9 @@ struct StakeTableTestNetwork<const NUM_NODES: usize> {
     client: Client<ClientErr, SequencerApiVersion>,
     stake_table: Address,
     api_port: u16,
+    /// The upgrade the network was started with, reused when starting or
+    /// restarting nodes.
+    upgrade: Upgrade,
     /// Every node's genesis state (its chain config carries the stake table
     /// address), reused for deferred-started nodes.
     genesis_state: ValidatedState,
@@ -114,14 +135,7 @@ impl<const NUM_NODES: usize> StakeTableTestNetwork<NUM_NODES> {
             .network_config(network_config)
             .persistences(persistence)
             .deferred_start(deferred)
-            .catchups(std::array::from_fn(|_| {
-                StatePeers::<SequencerApiVersion>::from_urls(
-                    vec![format!("http://localhost:{api_port}").parse().unwrap()],
-                    Default::default(),
-                    Duration::from_secs(2),
-                    &NoMetrics,
-                )
-            }));
+            .catchups(std::array::from_fn(|_| node_catchup(api_port)));
         if let Some(supply) = token_supply {
             builder = builder.initial_token_supply(supply);
         }
@@ -149,6 +163,7 @@ impl<const NUM_NODES: usize> StakeTableTestNetwork<NUM_NODES> {
             client,
             stake_table,
             api_port,
+            upgrade,
             genesis_state,
             _storage: storage,
         }
@@ -156,21 +171,34 @@ impl<const NUM_NODES: usize> StakeTableTestNetwork<NUM_NODES> {
 
     /// Starts a node deferred at [`Self::start`], with its reserved SQL
     /// storage slot and catchup from node 0's query API.
-    async fn start_deferred_node(&mut self, i: usize, upgrade: Upgrade) {
+    async fn start_deferred_node(&mut self, i: usize) {
         let persistence =
             <SqlDataSource as TestableSequencerDataSource>::persistence_options(&self._storage[i]);
-        let catchup = StatePeers::<SequencerApiVersion>::from_urls(
-            vec![
-                format!("http://localhost:{}", self.api_port)
-                    .parse()
-                    .unwrap(),
-            ],
-            Default::default(),
-            Duration::from_secs(2),
-            &NoMetrics,
-        );
         self.network
-            .start_deferred_node(i, self.genesis_state.clone(), persistence, catchup, upgrade)
+            .start_deferred_node(
+                i,
+                self.genesis_state.clone(),
+                persistence,
+                node_catchup(self.api_port),
+                self.upgrade,
+            )
+            .await;
+    }
+
+    /// Restarts node `i` on the network's current configuration — picking up
+    /// any rotated consensus keys or coordinator address — reusing its SQL
+    /// storage slot and catchup from node 0's query API.
+    async fn restart_node(&mut self, i: usize) {
+        let persistence =
+            <SqlDataSource as TestableSequencerDataSource>::persistence_options(&self._storage[i]);
+        self.network
+            .restart_node(
+                i,
+                self.genesis_state.clone(),
+                persistence,
+                node_catchup(self.api_port),
+                self.upgrade,
+            )
             .await;
     }
 
@@ -216,14 +244,7 @@ impl<const NUM_NODES: usize> StakeTableTestNetwork<NUM_NODES> {
             .network_config(network_config.clone())
             .persistences(persistence)
             .states(std::array::from_fn(|_| genesis_state.clone()))
-            .catchups(std::array::from_fn(|_| {
-                StatePeers::<SequencerApiVersion>::from_urls(
-                    vec![format!("http://localhost:{api_port}").parse().unwrap()],
-                    Default::default(),
-                    Duration::from_secs(2),
-                    &NoMetrics,
-                )
-            }))
+            .catchups(std::array::from_fn(|_| node_catchup(api_port)))
             .build();
 
         let network = TestNetwork::new(config, upgrade).await;
@@ -242,6 +263,7 @@ impl<const NUM_NODES: usize> StakeTableTestNetwork<NUM_NODES> {
             client,
             stake_table,
             api_port,
+            upgrade,
             genesis_state,
             _storage: storage,
         }
@@ -1364,7 +1386,7 @@ async fn fresh_node_joins(version: Upgrade, epoch_height: u64) -> anyhow::Result
         DelegationConfig::EqualAmounts,
     )
     .await?;
-    net.start_deferred_node(FRESH, version).await;
+    net.start_deferred_node(FRESH).await;
 
     let (activation_epoch, committee) = wait_for_committee(
         &net.client,
@@ -1415,4 +1437,162 @@ async fn test_stake_table_fresh_node_joins_v5() -> anyhow::Result<()> {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_stake_table_fresh_node_joins_v6() -> anyhow::Result<()> {
     fresh_node_joins(V6, 20).await
+}
+
+/// How [`rotate_validator`] rotates the validator's on-chain identity.
+enum Rotation {
+    /// A new cliquenet p2p address (`updateP2pAddr`, x25519 key unchanged),
+    /// the way an operator moving a node to a new host would publish it.
+    /// Peers merge the rotated connect info an epoch before its activation
+    /// epoch and redial, so the rotated node remains a live participant
+    /// throughout.
+    P2pAddr,
+    /// Fresh BLS and Schnorr keys (`updateConsensusKeysV2`) together with
+    /// the x25519 key derived from the new BLS key (`updateNetworkConfig`).
+    /// Until the rotation activates, the restarted node is a stranger to its
+    /// peers — the old identity leaves the cliquenet peer windows and the
+    /// new one joins via the epoch-boundary handoff — so the node has to
+    /// follow through catchup and re-enter the committee under its new
+    /// identity.
+    ConsensusKeys,
+}
+
+/// A committee validator rotates part of its on-chain identity mid-run (see
+/// [`Rotation`]) and restarts on the rotated configuration. The rotation
+/// must reach an active committee snapshot, the chain must keep deciding
+/// throughout, and the rotated node must decide past its activation epoch.
+async fn rotate_validator(rotation: Rotation) -> anyhow::Result<()> {
+    const NUM_NODES: usize = 5;
+    const EPOCH_HEIGHT: u64 = 20;
+    const ROTATED: usize = 1;
+
+    let network_config = TestConfigBuilder::<NUM_NODES>::default()
+        .epoch_height(EPOCH_HEIGHT)
+        .epoch_start_block(0)
+        .build();
+
+    let mut net = StakeTableTestNetwork::start(
+        network_config.clone(),
+        V6,
+        StakeTableContractVersion::V3,
+        DelegationConfig::EqualAmounts,
+        &(0..NUM_NODES).collect::<Vec<_>>(),
+        &[],
+        None,
+    )
+    .await;
+
+    let mut events = net.network.server.event_stream();
+    wait_for_epochs(&mut events, EPOCH_HEIGHT, 1).await;
+
+    let (account, provider) = network_config.validator_providers().remove(ROTATED);
+    let activated: Box<dyn Fn(&AuthenticatedValidatorMap) -> bool> = match rotation {
+        Rotation::P2pAddr => {
+            let port = reserve_tcp_port().expect("OS should have ephemeral ports available");
+            let new_addr: NetAddr = format!("127.0.0.1:{port}").parse().expect("valid address");
+            let receipt = StakingTransaction::UpdateP2pAddr {
+                stake_table: net.stake_table,
+                p2p_addr: new_addr.clone(),
+            }
+            .send(&provider)
+            .await?
+            .get_receipt()
+            .await?;
+            anyhow::ensure!(receipt.status(), "p2p address update reverted");
+
+            net.network
+                .cfg
+                .set_coordinator_addr(ROTATED, new_addr.clone());
+            Box::new(move |committee| {
+                committee
+                    .get(&account)
+                    .is_some_and(|v| v.p2p_addr.as_ref() == Some(&new_addr))
+            })
+        },
+        Rotation::ConsensusKeys => {
+            let (new_pub, new_bls) = PubKey::generated_from_seed_indexed([1; 32], ROTATED as u64);
+            let new_state = StateKeyPair::generate_from_seed_indexed([1; 32], ROTATED as u64);
+            let new_x25519 = x25519::Keypair::derive_from::<PubKey>(&new_bls)
+                .expect("x25519 keypair derivation should succeed");
+
+            // Send both halves of the rotation before awaiting either
+            // receipt, so no epoch root can land in between and pair the new
+            // BLS key with the old x25519 key.
+            let keys_tx = StakingTransaction::UpdateConsensusKeys {
+                stake_table: net.stake_table,
+                payload: NodeSignatures::create(
+                    account,
+                    &BLSKeyPair::from(new_bls.clone()),
+                    &new_state,
+                ),
+                version: StakeTableContractVersion::V3,
+            }
+            .send(&provider)
+            .await?;
+            let config_tx = update_network_config(
+                &provider,
+                net.stake_table,
+                new_x25519.public_key(),
+                network_config.coordinator_addr(ROTATED),
+            )
+            .await?;
+            anyhow::ensure!(
+                keys_tx.get_receipt().await?.status(),
+                "consensus keys update reverted"
+            );
+            anyhow::ensure!(
+                config_tx.get_receipt().await?.status(),
+                "network config update reverted"
+            );
+
+            net.network
+                .cfg
+                .set_consensus_keys(ROTATED, new_bls, new_state);
+            let expected_x25519 = new_x25519.public_key();
+            Box::new(move |committee| {
+                committee.get(&account).is_some_and(|v| {
+                    v.stake_table_key.as_ref() == Some(&new_pub)
+                        && v.x25519_key == Some(expected_x25519)
+                })
+            })
+        },
+    };
+    net.restart_node(ROTATED).await;
+
+    let (activation_epoch, _) = wait_for_committee(
+        &net.client,
+        &mut events,
+        EPOCH_HEIGHT,
+        FIRST_CONTRACT_EPOCH,
+        MAX_ACTIVATION_EPOCHS,
+        activated,
+    )
+    .await;
+    tracing::info!(activation_epoch, "rotation activated");
+
+    assert_node_live(&net.network.server, EPOCH_HEIGHT, 2).await;
+
+    let mut rotated_events = net.network.node(ROTATED).event_stream();
+    timeout(
+        Duration::from_secs(600),
+        wait_for_epochs(&mut rotated_events, EPOCH_HEIGHT, activation_epoch),
+    )
+    .await
+    .expect("the rotated node did not keep deciding past its activation epoch");
+    assert_node_live(net.network.node(ROTATED), EPOCH_HEIGHT, 1).await;
+
+    let all_nodes: Vec<_> = (0..NUM_NODES).map(|i| net.network.node(i)).collect();
+    assert_nodes_agree(&all_nodes, activation_epoch * EPOCH_HEIGHT).await;
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_stake_table_rotate_p2p_address_v6() -> anyhow::Result<()> {
+    rotate_validator(Rotation::P2pAddr).await
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_stake_table_rotate_consensus_keys_v6() -> anyhow::Result<()> {
+    rotate_validator(Rotation::ConsensusKeys).await
 }


### PR DESCRIPTION
Adds slow-test coverage for the two identity rotations the 0.6 stake table contract supports, exercising the full contract → fetcher → cliquenet → restart stack (nothing at the HotShot layer covers rotation):

- `test_stake_table_rotate_p2p_address_v6`: a committee validator publishes a new cliquenet address (`updateP2pAddr`) and restarts bound to it; peers redial at the epoch boundary and both the chain and the node stay live.
- `test_stake_table_rotate_consensus_keys_v6`: a validator publishes fresh BLS/Schnorr keys plus the derived x25519 key and restarts signing with them; it re-enters the committee as a "stranger" via catchup and the boundary handoff.

Supporting test infrastructure (first commit): `TestConfig::set_consensus_keys` / `set_coordinator_addr` and `TestNetwork::restart_node`. `init_node` now derives node identity from private keys rather than the genesis stake table entry (identical unless rotated), so rotations never touch the genesis, which must stay identical across nodes.

**Review focus:** the identity-derivation change in `init_node` (`crates/espresso/node/src/lib.rs`) — it affects every test network, though it's behavior-preserving for non-rotated nodes; and the port-release polling in `TestNetwork::restart_node`, which replaces a timing assumption with a deterministic wait because shutdown can't await the cliquenet listener drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
