### PR TITLE
fix(cliquenet-types): reject malformed bracketed p2p addresses

### DIFF
--- a/contracts/rust/adapter/src/stake_table.rs
+++ b/contracts/rust/adapter/src/stake_table.rs
@@ -441,7 +441,9 @@ mod test {
 // Solidity `validateP2pAddr` and Rust `NetAddr::from_str` both parse `host:port` strings.
 // If Solidity accepts an address that Rust rejects, the validator's p2p address is silently
 // dropped and they become unreachable for cliquenet. This proptest deploys StakeTableV3
-// on anvil and fuzzes the property: Solidity accepts => Rust accepts.
+// on anvil and fuzzes the property: Solidity accepts => Rust accepts, except the
+// malformed bracketed forms in `rejected_bracket_form`, which the node rejects by
+// design (see `NetAddr::from_str`).
 #[cfg(test)]
 mod proptest_p2p_addr {
     use alloy::providers::ProviderBuilder;
@@ -452,6 +454,16 @@ mod proptest_p2p_addr {
     };
 
     use crate::sol_types::StakeTableV3;
+
+    /// `[`-prefixed strings without a `]:<u16>` suffix or trailing `]`; the node
+    /// rejects exactly these even when the contract accepts them.
+    fn rejected_bracket_form(s: &str) -> bool {
+        s.starts_with('[')
+            && !s.ends_with(']')
+            && !s
+                .rfind("]:")
+                .is_some_and(|i| s[i + 2..].parse::<u16>().is_ok())
+    }
 
     fn p2p_addr_strategy() -> impl Strategy<Value = String> {
         prop_oneof![
@@ -480,6 +492,10 @@ mod proptest_p2p_addr {
             (1..65535u16).prop_map(|p| format!("::1:{p}")),
             // Bracketed IPv6
             (1..65535u16).prop_map(|p| format!("[::1]:{p}")),
+            // Malformed bracketed forms (contract accepts, node rejects)
+            ("[a-z]{1,10}", 1..65535u16, 1..65535u16)
+                .prop_map(|(h, p1, p2)| format!("[{h}]:{p1}:{p2}")),
+            ("[a-z]{1,10}", 1..65535u16).prop_map(|(h, p)| format!("[{h}:{p}")),
             // Two valid addresses concatenated
             (1..255u8, 1..255u8, 1..65535u16, 1..65535u16)
                 .prop_map(|(a, b, p1, p2)| format!("{a}.{b}.0.1:{p1},{a}.{b}.0.2:{p2}")),
@@ -530,9 +546,10 @@ mod proptest_p2p_addr {
                 });
 
                 if sol_valid {
-                    prop_assert!(
+                    prop_assert_eq!(
                         rust_valid,
-                        "Solidity accepted '{}' but Rust rejected it",
+                        !rejected_bracket_form(&addr_str),
+                        "Solidity accepted '{}'",
                         addr_str
                     );
                 }

--- a/crates/cliquenet-types/src/addr.rs
+++ b/crates/cliquenet-types/src/addr.rs
@@ -156,10 +156,15 @@ impl std::str::FromStr for NetAddr {
         };
 
         // Handle bracketed IPv6 like `[::1]:8080` or `[::1]` (no port).
+        // Rejecting other `[`-prefixed strings deliberately diverges from
+        // `StakeTableV3.validateP2pAddr`, which accepts some of them: the
+        // fetcher then drops the address and the validator is ineligible
+        // at V0_6 until it calls `updateP2pAddr`.
         if s.starts_with('[') {
             return match s.rfind("]:") {
                 Some(i) => parse(&s[..i + 1], Some(&s[i + 2..])),
-                None => parse(s, None),
+                None if s.ends_with(']') => parse(s, None),
+                None => Err(InvalidNetAddr(())),
             };
         }
 
@@ -234,6 +239,27 @@ mod tests {
     #[test]
     fn empty_is_invalid() {
         assert!("".parse::<NetAddr>().is_err())
+    }
+
+    /// `[host]:1234:5678` and `[2001:db8::1:9000` are contract-accepted;
+    /// rejecting them is deliberate (see `FromStr::from_str`).
+    #[test]
+    fn from_str_cases() {
+        let ok: &[(&str, NetAddr)] = &[
+            ("[::1]:8080", NetAddr::Inet("::1".parse().unwrap(), 8080)),
+            ("[::1]", NetAddr::Inet("::1".parse().unwrap(), 0)),
+            ("example.com:80", NetAddr::named("example.com", 80)),
+            ("example.com", NetAddr::named("example.com", 0)),
+            ("::1:8080", NetAddr::Inet("::1".parse().unwrap(), 8080)),
+        ];
+        for (s, expected) in ok {
+            let a: NetAddr = s.parse().unwrap_or_else(|_| panic!("parse {s}"));
+            assert_eq!(&a, expected, "for input {s}");
+        }
+        let err: &[&str] = &["[host]:1234:5678", "[2001:db8::1:9000", "[abc", ""];
+        for s in err {
+            assert!(s.parse::<NetAddr>().is_err(), "expected error for {s:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
NetAddr::from_str previously parsed `[`-prefixed strings without a bracketed sockaddr shape (e.g. "[2001:db8::1:9000") as a hostname with port 0. Such strings now return an error, as do other malformed bracketed forms like "[host]:1234:5678".

This deliberately diverges from StakeTableV3.validateP2pAddr, which accepts these strings: the stake table fetcher degrades a parse error to p2p_addr = None with a warning, so an affected validator is ineligible at V0_6 until it submits a valid address via updateP2pAddr. The solidity/rust equivalence proptest exempts `[`-prefixed inputs accordingly.

Replay safety: no such address exists on chain today. All 35 P2pAddrUpdated payloads on decaf are plain host:port and mainnet still runs StakeTable V2, so old and new nodes derive identical stake tables from current L1 data. Deploy before the mainnet V3 upgrade executes.
