### PR TITLE
Stricter address parsing

### DIFF
--- a/crates/cliquenet-types/src/addr.rs
+++ b/crates/cliquenet-types/src/addr.rs
@@ -20,13 +20,19 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 pub struct Hostname(Cow<'static, str>);
 
 impl Hostname {
-    /// The hostname `name`, or `None` if that is not a hostname.
+    /// The hostname `name`, in lower case, or `None` if that is not a hostname.
     pub fn new<S>(name: S) -> Option<Self>
     where
         S: Into<Cow<'static, str>>,
     {
         let name = name.into();
-        is_hostname(&name).then_some(Self(name))
+        if !is_hostname(&name) {
+            return None;
+        }
+        if name.bytes().any(|b| b.is_ascii_uppercase()) {
+            return Some(Self(name.to_ascii_lowercase().into()));
+        }
+        Some(Self(name))
     }
 
     pub fn as_str(&self) -> &str {
@@ -77,11 +83,11 @@ fn parse_port(s: &str) -> Result<u16, InvalidNetAddr> {
     s.parse().map_err(|_| InvalidNetAddr(()))
 }
 
-/// An IP literal written in one, canonical way.
-fn canonical_ip(text: &str) -> Option<IpAddr> {
-    let ip = IpAddr::from_str(text).ok()?;
-    // Ipv4Addr's Display impl conforms to RFC 5952.
-    (ip.to_string() == text && ip.to_canonical() == ip).then_some(ip)
+/// Whether `text` is the one, canonical way to write `ip`.
+fn is_canonical(ip: IpAddr, text: &str) -> bool {
+    // Ipv6Addr's Display impl conforms to RFC 5952, and an IPv4-mapped address is
+    // written as the IPv4 address it maps to.
+    ip.to_canonical() == ip && ip.to_string() == text
 }
 
 /// A network address.
@@ -93,15 +99,15 @@ fn canonical_ip(text: &str) -> Option<IpAddr> {
 /// `host:port` where host = IPv4 literal | "[" IPv6 literal "]" | hostname
 ///
 /// The port is decimal with no sign and no leading zeros. An IP literal is written the
-/// one way ([`canonical_ip`]). Brackets are for IPv6 and required, so bare `::1:8080` is
+/// one way ([`is_canonical`]). Brackets are for IPv6 and required, so bare `::1:8080` is
 /// rejected along with `[1.2.3.4]:5`, `[node.example.com]:8080` and an unclosed bracket.
-/// A hostname is a [`Hostname`].
+/// A hostname is a [`Hostname`], and is held in lower case.
 ///
 /// # Printing
 ///
 /// [`fmt::Display`] brackets an IPv6 literal, so printing and parsing are inverse:
 /// every address prints to a string that parses back to it, and every string this
-/// accepts prints back to itself.
+/// accepts prints back to itself, up to the case of a hostname.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NetAddr {
     Inet(IpAddr, u16),
@@ -114,14 +120,13 @@ impl NetAddr {
     /// An IP literal gives [`NetAddr::Inet`] and a hostname gives [`NetAddr::Name`];
     /// anything else is an error.
     pub fn host_port(host: &str, port: u16) -> Result<Self, InvalidNetAddr> {
-        if IpAddr::from_str(host).is_ok() {
-            return canonical_ip(host)
-                .map(|ip| Self::Inet(ip, port))
-                .ok_or(InvalidNetAddr(()));
+        match IpAddr::from_str(host) {
+            Ok(ip) if is_canonical(ip, host) => Ok(Self::Inet(ip, port)),
+            Ok(_) => Err(InvalidNetAddr(())),
+            Err(_) => Hostname::new(host.to_string())
+                .map(|h| Self::Name(h, port))
+                .ok_or(InvalidNetAddr(())),
         }
-        Hostname::new(host.to_string())
-            .map(|h| Self::Name(h, port))
-            .ok_or(InvalidNetAddr(()))
     }
 
     /// The address `name:port`, where `name` is a hostname.
@@ -187,7 +192,7 @@ impl NetAddr {
             Self::Inet(IpAddr::V6(v6), _) => {
                 !(v6.is_loopback() || v6.is_unspecified() || v6.is_multicast())
             },
-            Self::Name(host, _) => !host.as_str().eq_ignore_ascii_case("localhost"),
+            Self::Name(host, _) => host.as_str() != "localhost",
         }
     }
 }
@@ -241,15 +246,16 @@ impl FromStr for NetAddr {
         if let Some(rest) = s.strip_prefix('[') {
             let i = rest.rfind("]:").ok_or(InvalidNetAddr(()))?;
             let port = parse_port(&rest[i + 2..])?;
-            if let Some(ip @ IpAddr::V6(_)) = canonical_ip(&rest[..i]) {
-                Ok(Self::Inet(ip, port))
-            } else {
-                Err(InvalidNetAddr(()))
+            let host = &rest[..i];
+            match IpAddr::from_str(host) {
+                Ok(ip @ IpAddr::V6(_)) if is_canonical(ip, host) => Ok(Self::Inet(ip, port)),
+                _ => Err(InvalidNetAddr(())),
             }
         } else {
             let (host, port) = s.rsplit_once(':').ok_or(InvalidNetAddr(()))?;
             let port = parse_port(port)?;
-            if matches!(IpAddr::from_str(host), Ok(IpAddr::V6(_))) {
+            // Only an IPv6 literal has a colon in the host, and it must be bracketed.
+            if host.contains(':') {
                 return Err(InvalidNetAddr(()));
             }
             Self::host_port(host, port)
@@ -346,7 +352,7 @@ mod tests {
         /// No hostname is an IP literal, so a `Name` never prints as an address.
         fn prop_hostname_is_not_a_literal(a: NetAddr) -> bool {
             match a {
-                NetAddr::Name(h, _) => h.as_str().parse::<IpAddr>().is_err(),
+                NetAddr::Name(h, _) => h.parse::<IpAddr>().is_err(),
                 NetAddr::Inet(..) => true,
             }
         }
@@ -371,6 +377,9 @@ mod tests {
             ("a_b.example.com:80", "a_b.example.com:80"),
             ("_svc.example.com:80", "_svc.example.com:80"),
             ("a-b.c:80", "a-b.c:80"),
+            // a hostname is lower-cased
+            ("Node.Example.COM:8080", "node.example.com:8080"),
+            ("LOCALHOST:1234", "localhost:1234"),
             (
                 "crpk232f2b1uqepj3qmg.bdnodes.net:9977",
                 "crpk232f2b1uqepj3qmg.bdnodes.net:9977",
@@ -405,7 +414,6 @@ mod tests {
             "2001:db8::1:9000",
             ":::80",
             "2001:db8:::5",
-            "::ffff:1.2.3.4:80",
             "[weird",
             "[::1",
             "[a]b:1",
@@ -495,7 +503,7 @@ mod tests {
         assert_eq!(NetAddr::from((ip, 80)), v4);
         // An IPv4-translated address is not mapped, and stays IPv6.
         let translated: NetAddr = "[::ffff:0:102:304]:80".parse().unwrap();
-        assert!(!translated.is_ip() || translated.to_string() == "[::ffff:0:102:304]:80");
+        assert_eq!(translated.to_string(), "[::ffff:0:102:304]:80");
     }
 
     #[test]
@@ -507,6 +515,26 @@ mod tests {
         // has one spelling in both directions.
         assert!("::1:8080".parse::<std::net::SocketAddr>().is_err());
         assert!("::1:8080".parse::<NetAddr>().is_err());
+    }
+
+    /// One host, one address, one string: names differing only in case are one value.
+    #[test]
+    fn hostname_case_is_folded() {
+        let lower: NetAddr = "node.example.com:8080".parse().expect("parse");
+        for s in [
+            "NODE.EXAMPLE.COM:8080",
+            "Node.Example.Com:8080",
+            "nOdE.eXaMpLe.cOm:8080",
+        ] {
+            let a: NetAddr = s.parse().unwrap_or_else(|_| panic!("parse {s}"));
+            assert_eq!(a, lower, "{s} must be the same address");
+            assert_eq!(a.to_string(), lower.to_string(), "{s} must print the same");
+        }
+        assert_eq!(
+            Hostname::new("Example.COM").expect("hostname").as_str(),
+            "example.com"
+        );
+        assert_eq!(NetAddr::named("LOCALHOST", 80).to_string(), "localhost:80");
     }
 
     #[test]

--- a/crates/cliquenet-types/src/addr.rs
+++ b/crates/cliquenet-types/src/addr.rs
@@ -2,29 +2,142 @@ use std::{
     borrow::Cow,
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    ops::Deref,
+    str::FromStr,
 };
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
+/// Dot-separated ASCII labels.
+///
+/// A label is 1 to 63 characters of ASCII letters, digits, `-` and `_`, and may
+/// not begin or end with `-`. The whole name is at most 253 characters and is
+/// not made of digits and dots alone.
+///
+/// RFC 952 and RFC 1123 do not allow `_` but it is allowed here.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Hostname(Cow<'static, str>);
+
+impl Hostname {
+    /// The hostname `name`, or `None` if that is not a hostname.
+    pub fn new<S>(name: S) -> Option<Self>
+    where
+        S: Into<Cow<'static, str>>,
+    {
+        let name = name.into();
+        is_hostname(&name).then_some(Self(name))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for Hostname {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for Hostname {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+fn is_hostname(s: &str) -> bool {
+    if s.is_empty() || s.len() > 253 {
+        return false;
+    }
+    // Digits and dots alone is an address, not a name.
+    if s.bytes().all(|b| b.is_ascii_digit() || b == b'.') {
+        return false;
+    }
+    s.split('.').all(|label| {
+        !label.is_empty()
+            && label.len() <= 63
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && label
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    })
+}
+
+fn parse_port(s: &str) -> Result<u16, InvalidNetAddr> {
+    if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(InvalidNetAddr(()));
+    }
+    if s.len() > 1 && s.starts_with('0') {
+        return Err(InvalidNetAddr(()));
+    }
+    s.parse().map_err(|_| InvalidNetAddr(()))
+}
+
+/// An IP literal written in one, canonical way.
+fn canonical_ip(text: &str) -> Option<IpAddr> {
+    let ip = IpAddr::from_str(text).ok()?;
+    // Ipv4Addr's Display impl conforms to RFC 5952.
+    (ip.to_string() == text && ip.to_canonical() == ip).then_some(ip)
+}
+
 /// A network address.
 ///
 /// Either an IP address and port number or else a hostname and port number.
+///
+/// # Syntax
+///
+/// `host:port` where host = IPv4 literal | "[" IPv6 literal "]" | hostname
+///
+/// The port is decimal with no sign and no leading zeros. An IP literal is written the
+/// one way ([`canonical_ip`]). Brackets are for IPv6 and required, so bare `::1:8080` is
+/// rejected along with `[1.2.3.4]:5`, `[node.example.com]:8080` and an unclosed bracket.
+/// A hostname is a [`Hostname`].
+///
+/// # Printing
+///
+/// [`fmt::Display`] brackets an IPv6 literal, so printing and parsing are inverse:
+/// every address prints to a string that parses back to it, and every string this
+/// accepts prints back to itself.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NetAddr {
     Inet(IpAddr, u16),
-    Name(Cow<'static, str>, u16),
+    Name(Hostname, u16),
 }
 
 impl NetAddr {
+    /// The address `host:port`, where `host` is not bracketed.
+    ///
+    /// An IP literal gives [`NetAddr::Inet`] and a hostname gives [`NetAddr::Name`];
+    /// anything else is an error.
+    pub fn host_port(host: &str, port: u16) -> Result<Self, InvalidNetAddr> {
+        if IpAddr::from_str(host).is_ok() {
+            return canonical_ip(host)
+                .map(|ip| Self::Inet(ip, port))
+                .ok_or(InvalidNetAddr(()));
+        }
+        Hostname::new(host.to_string())
+            .map(|h| Self::Name(h, port))
+            .ok_or(InvalidNetAddr(()))
+    }
+
+    /// The address `name:port`, where `name` is a hostname.
+    ///
+    /// # Panics
+    ///
+    /// When `name` is not a hostname, which includes every IP literal.
     pub fn named<S>(name: S, port: u16) -> Self
     where
         S: Into<Cow<'static, str>>,
     {
-        Self::Name(name.into(), port)
+        Hostname::new(name)
+            .map(|h| Self::Name(h, port))
+            .expect("valid hostname")
     }
 
-    /// Get the port number of an address.
     pub fn port(&self) -> u16 {
         match self {
             Self::Inet(_, p) => *p,
@@ -32,7 +145,6 @@ impl NetAddr {
         }
     }
 
-    /// Set the address port.
     pub fn set_port(&mut self, p: u16) {
         match self {
             Self::Inet(_, o) => *o = p,
@@ -41,19 +153,14 @@ impl NetAddr {
     }
 
     pub fn with_port(mut self, p: u16) -> Self {
-        match self {
-            Self::Inet(ip, _) => self = Self::Inet(ip, p),
-            Self::Name(hn, _) => self = Self::Name(hn, p),
-        }
+        self.set_port(p);
         self
     }
 
     pub fn with_offset(mut self, o: u16) -> Self {
         debug_assert!(self.port().checked_add(o).is_some());
-        match self {
-            Self::Inet(ip, p) => self = Self::Inet(ip, p + o),
-            Self::Name(hn, p) => self = Self::Name(hn, p + o),
-        }
+        let p = self.port() + o;
+        self.set_port(p);
         self
     }
 
@@ -80,7 +187,7 @@ impl NetAddr {
             Self::Inet(IpAddr::V6(v6), _) => {
                 !(v6.is_loopback() || v6.is_unspecified() || v6.is_multicast())
             },
-            Self::Name(host, _) => !host.eq_ignore_ascii_case("localhost"),
+            Self::Name(host, _) => !host.as_str().eq_ignore_ascii_case("localhost"),
         }
     }
 }
@@ -88,27 +195,16 @@ impl NetAddr {
 impl fmt::Display for NetAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Inet(a @ IpAddr::V6(_), p) => write!(f, "[{a}]:{p}"),
             Self::Inet(a, p) => write!(f, "{a}:{p}"),
             Self::Name(h, p) => write!(f, "{h}:{p}"),
         }
     }
 }
 
-impl From<(&str, u16)> for NetAddr {
-    fn from((h, p): (&str, u16)) -> Self {
-        Self::Name(h.to_string().into(), p)
-    }
-}
-
-impl From<(String, u16)> for NetAddr {
-    fn from((h, p): (String, u16)) -> Self {
-        Self::Name(h.into(), p)
-    }
-}
-
 impl From<(IpAddr, u16)> for NetAddr {
     fn from((ip, p): (IpAddr, u16)) -> Self {
-        Self::Inet(ip, p)
+        Self::Inet(ip.to_canonical(), p)
     }
 }
 
@@ -120,52 +216,43 @@ impl From<(Ipv4Addr, u16)> for NetAddr {
 
 impl From<(Ipv6Addr, u16)> for NetAddr {
     fn from((ip, p): (Ipv6Addr, u16)) -> Self {
-        Self::Inet(IpAddr::V6(ip), p)
+        Self::from((IpAddr::V6(ip), p))
     }
 }
 
 impl From<SocketAddr> for NetAddr {
     fn from(a: SocketAddr) -> Self {
-        Self::Inet(a.ip(), a.port())
+        Self::from((a.ip(), a.port()))
     }
 }
 
-impl std::str::FromStr for NetAddr {
+impl TryFrom<(&str, u16)> for NetAddr {
+    type Error = InvalidNetAddr;
+
+    fn try_from((h, p): (&str, u16)) -> Result<Self, Self::Error> {
+        Self::host_port(h, p)
+    }
+}
+
+impl FromStr for NetAddr {
     type Err = InvalidNetAddr;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.is_empty() {
-            return Err(InvalidNetAddr(()));
-        }
-
-        let parse = |a: &str, p: Option<&str>| {
-            let p: u16 = if let Some(p) = p {
-                p.parse().map_err(|_| InvalidNetAddr(()))?
+        if let Some(rest) = s.strip_prefix('[') {
+            let i = rest.rfind("]:").ok_or(InvalidNetAddr(()))?;
+            let port = parse_port(&rest[i + 2..])?;
+            if let Some(ip @ IpAddr::V6(_)) = canonical_ip(&rest[..i]) {
+                Ok(Self::Inet(ip, port))
             } else {
-                0
-            };
-            // Strip brackets from IPv6 addresses like `[::1]`.
-            let a = if a.starts_with('[') && a.ends_with(']') {
-                &a[1..a.len() - 1]
-            } else {
-                a
-            };
-            IpAddr::from_str(a)
-                .map(|a| Self::Inet(a, p))
-                .or_else(|_| Ok(Self::Name(a.to_string().into(), p)))
-        };
-
-        // Handle bracketed IPv6 like `[::1]:8080` or `[::1]` (no port).
-        if s.starts_with('[') {
-            return match s.rfind("]:") {
-                Some(i) => parse(&s[..i + 1], Some(&s[i + 2..])),
-                None => parse(s, None),
-            };
-        }
-
-        match s.rsplit_once(':') {
-            None => parse(s, None),
-            Some((a, p)) => parse(a, Some(p)),
+                Err(InvalidNetAddr(()))
+            }
+        } else {
+            let (host, port) = s.rsplit_once(':').ok_or(InvalidNetAddr(()))?;
+            let port = parse_port(port)?;
+            if matches!(IpAddr::from_str(host), Ok(IpAddr::V6(_))) {
+                return Err(InvalidNetAddr(()));
+            }
+            Self::host_port(host, port)
         }
     }
 }
@@ -202,38 +289,224 @@ impl<'de> Deserialize<'de> for NetAddr {
 
 #[cfg(test)]
 mod tests {
-    use std::{iter::repeat_with, net::IpAddr};
+    use std::net::IpAddr;
 
     use quickcheck::{Arbitrary, Gen, quickcheck};
 
-    use super::NetAddr;
+    use super::{Hostname, NetAddr, is_hostname};
 
     impl Arbitrary for NetAddr {
         fn arbitrary(g: &mut Gen) -> Self {
             let port = u16::arbitrary(g);
             if bool::arbitrary(g) {
-                let len = u8::arbitrary(g);
-                let host: String = repeat_with(|| char::arbitrary(g))
-                    .filter(|c| !"[]".contains(*c))
-                    .take(len.into())
-                    .collect();
-                NetAddr::Name(host.into(), port)
+                NetAddr::Name(arbitrary_hostname(g), port)
             } else {
-                let ip = IpAddr::arbitrary(g);
-                NetAddr::Inet(ip, port)
+                NetAddr::from((IpAddr::arbitrary(g), port))
             }
         }
     }
 
+    /// A label: allowed characters, never empty, never hyphen-bounded.
+    fn arbitrary_label(g: &mut Gen) -> String {
+        const MID: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789-_";
+        const EDGE: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789_";
+        let mut l = String::new();
+        l.push(char::from(*g.choose(EDGE).expect("non-empty")));
+        for _ in 0..(u8::arbitrary(g) % 8) {
+            l.push(char::from(*g.choose(MID).expect("non-empty")));
+        }
+        l.push(char::from(*g.choose(EDGE).expect("non-empty")));
+        l
+    }
+
+    /// A hostname built to the rules, so that the properties below are about addresses
+    /// that exist rather than about strings that could never be one.
+    fn arbitrary_hostname(g: &mut Gen) -> Hostname {
+        let n = u8::arbitrary(g) % 3 + 1;
+        let mut labels: Vec<String> = (0..n).map(|_| arbitrary_label(g)).collect();
+        labels[0].insert(0, 'h');
+        let name = labels.join(".");
+        Hostname::new(name.clone()).unwrap_or_else(|| panic!("built a bad hostname: {name}"))
+    }
+
     quickcheck! {
+        /// Printing and parsing are inverse, with no side condition: every address
+        /// that can be built prints to a string that parses back to it.
         fn prop_to_string_parse_identity(a: NetAddr) -> bool {
             a.to_string().parse().ok() == Some(a)
+        }
+
+        /// And parsing then printing gives the string back, so an address has one
+        /// spelling.
+        fn prop_parse_to_string_identity(a: NetAddr) -> bool {
+            let s = a.to_string();
+            s.parse::<NetAddr>().ok().map(|b| b.to_string()) == Some(s)
+        }
+
+        /// No hostname is an IP literal, so a `Name` never prints as an address.
+        fn prop_hostname_is_not_a_literal(a: NetAddr) -> bool {
+            match a {
+                NetAddr::Name(h, _) => h.as_str().parse::<IpAddr>().is_err(),
+                NetAddr::Inet(..) => true,
+            }
         }
     }
 
     #[test]
-    fn empty_is_invalid() {
-        assert!("".parse::<NetAddr>().is_err())
+    fn accepted() {
+        let cases: &[(&str, &str)] = &[
+            // IPv4
+            ("1.2.3.4:8080", "1.2.3.4:8080"),
+            ("1.2.3.4:0", "1.2.3.4:0"),
+            ("1.2.3.4:65535", "1.2.3.4:65535"),
+            ("127.0.0.1:1", "127.0.0.1:1"),
+            // IPv6, always bracketed
+            ("[::1]:8080", "[::1]:8080"),
+            ("[2001:db8::1]:9000", "[2001:db8::1]:9000"),
+            ("[::]:80", "[::]:80"),
+            ("[2001:db8::]:5", "[2001:db8::]:5"),
+            // hostnames
+            ("localhost:1234", "localhost:1234"),
+            ("node.example.com:8080", "node.example.com:8080"),
+            ("a_b.example.com:80", "a_b.example.com:80"),
+            ("_svc.example.com:80", "_svc.example.com:80"),
+            ("a-b.c:80", "a-b.c:80"),
+            (
+                "crpk232f2b1uqepj3qmg.bdnodes.net:9977",
+                "crpk232f2b1uqepj3qmg.bdnodes.net:9977",
+            ),
+        ];
+        for (input, printed) in cases {
+            let a: NetAddr = input.parse().unwrap_or_else(|_| panic!("parse {input}"));
+            assert_eq!(a.to_string(), *printed, "printing {input}");
+            assert_eq!(
+                a.to_string().parse::<NetAddr>().ok(),
+                Some(a),
+                "round trip {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejected() {
+        let cases: &[&str] = &[
+            // nothing, and no port
+            "",
+            ":",
+            "a",
+            "a:",
+            "1.2.3.4",
+            "[::1]",
+            "[a]",
+            // an unclosed bracket
+            "[2001:db8::1:9000",
+            // an IPv6 literal not in brackets: `[::1]:8080` is the only spelling
+            "::1:8080",
+            "2001:db8::1:9000",
+            ":::80",
+            "2001:db8:::5",
+            "::ffff:1.2.3.4:80",
+            "[weird",
+            "[::1",
+            "[a]b:1",
+            // brackets are only for IPv6
+            "[1.2.3.4]:5",
+            "[node.example.com]:8080",
+            "[x]:5",
+            "[a]:5",
+            "[]:7",
+            "[[a]]:5",
+            "[::1]:80]:90",
+            // an IPv6 literal not written the way it prints
+            "[2001:0DB8::0001]:80",
+            "[::0001]:80",
+            // an IPv4-mapped IPv6 address: write the IPv4 one
+            "::ffff:1.2.3.4:80",
+            "[::ffff:1.2.3.4]:80",
+            // a host that is neither a literal nor a hostname
+            "x]:5",
+            "a]:5",
+            "a[:5",
+            "a:b:1",
+            "1:2:3",
+            "%:1",
+            "ä:1",
+            "a b:80",
+            "2606:4700:4700::1111",
+            "::1",
+            "::ffff:1.2.3.4",
+            "2001:db8::",
+            // a mistyped address is not a name
+            "01.2.3.4:80",
+            "127.1:1",
+            "1.2.3.4.5:80",
+            "12345:80",
+            // hostname labels
+            "example.com.:80",
+            "a..b:80",
+            "-a.b:80",
+            "a-.b:80",
+            ".a:80",
+            // the port
+            "a:65536",
+            "a:+80",
+            "a:080",
+            "a:00",
+            "a:+0",
+            "a:-1",
+            "a: 80",
+            "a:8_0",
+            "host:notaport",
+            "[::1]:bad",
+            "[::1]:",
+            "[a]:1:2",
+        ];
+        for s in cases {
+            assert!(s.parse::<NetAddr>().is_err(), "should be rejected: {s:?}");
+        }
+    }
+
+    #[test]
+    fn no_hostname_is_an_ip_literal() {
+        for s in [
+            "1.2.3.4",
+            "::1",
+            "::",
+            "2001:db8::1",
+            "255.255.255.255",
+            "0.0.0.0",
+        ] {
+            assert!(!is_hostname(s), "{s:?} must not be a hostname");
+        }
+    }
+
+    /// One host, one address, one string: the mapped spelling is refused, and an
+    /// address that arrives in that form is folded rather than kept.
+    #[test]
+    fn ipv4_mapped_is_the_ipv4_address() {
+        assert!("::ffff:1.2.3.4:80".parse::<NetAddr>().is_err());
+        assert!("[::ffff:1.2.3.4]:80".parse::<NetAddr>().is_err());
+        let v4: NetAddr = "1.2.3.4:80".parse().unwrap();
+        // However it arrives, it is the same value, and it prints as the IPv4 address.
+        let mapped: std::net::SocketAddr = "[::ffff:1.2.3.4]:80".parse().unwrap();
+        assert_eq!(NetAddr::from(mapped), v4);
+        assert_eq!(NetAddr::from(mapped).to_string(), "1.2.3.4:80");
+        let ip: IpAddr = "::ffff:1.2.3.4".parse().unwrap();
+        assert_eq!(NetAddr::from((ip, 80)), v4);
+        // An IPv4-translated address is not mapped, and stays IPv6.
+        let translated: NetAddr = "[::ffff:0:102:304]:80".parse().unwrap();
+        assert!(!translated.is_ip() || translated.to_string() == "[::ffff:0:102:304]:80");
+    }
+
+    #[test]
+    fn ipv6_prints_the_way_everything_else_reads_it() {
+        let a: NetAddr = "[::1]:8080".parse().unwrap();
+        assert_eq!(a.to_string(), "[::1]:8080");
+        assert!(a.to_string().parse::<std::net::SocketAddr>().is_ok());
+        // The form printed before, which `SocketAddr` rejects and so do we: an address
+        // has one spelling in both directions.
+        assert!("::1:8080".parse::<std::net::SocketAddr>().is_err());
+        assert!("::1:8080".parse::<NetAddr>().is_err());
     }
 
     #[test]
@@ -247,14 +520,14 @@ mod tests {
             ("169.254.0.1:1234", false),
             ("255.255.255.255:1234", false),
             ("192.0.2.1:1234", false),
-            ("::1:1234", false),
-            (":::1234", false),
-            ("ff00::1:1234", false),
+            ("[::1]:1234", false),
+            ("[::]:1234", false),
+            ("[ff00::1]:1234", false),
             ("localhost:1234", false),
             ("LOCALHOST:1234", false),
             ("8.8.8.8:1234", true),
             ("1.1.1.1:1234", true),
-            ("2606:4700:4700::1111:1234", true),
+            ("[2606:4700:4700::1111]:1234", true),
             ("example.com:1234", true),
             ("node.internal:1234", true),
         ];

--- a/crates/cliquenet-types/src/addr.rs
+++ b/crates/cliquenet-types/src/addr.rs
@@ -109,22 +109,29 @@ fn is_canonical(ip: IpAddr, text: &str) -> bool {
 /// every address prints to a string that parses back to it, and every string this
 /// accepts prints back to itself, up to the case of a hostname.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum NetAddr {
-    Inet(IpAddr, u16),
-    Name(Hostname, u16),
+pub struct NetAddr {
+    host: Host,
+    port: u16,
+}
+
+/// The host part of a [`NetAddr`], to match on.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Host {
+    Inet(IpAddr),
+    Name(Hostname),
 }
 
 impl NetAddr {
     /// The address `host:port`, where `host` is not bracketed.
     ///
-    /// An IP literal gives [`NetAddr::Inet`] and a hostname gives [`NetAddr::Name`];
+    /// An IP literal gives [`Host::Inet`] and a hostname gives [`Host::Name`];
     /// anything else is an error.
     pub fn host_port(host: &str, port: u16) -> Result<Self, InvalidNetAddr> {
         match IpAddr::from_str(host) {
-            Ok(ip) if is_canonical(ip, host) => Ok(Self::Inet(ip, port)),
+            Ok(ip) if is_canonical(ip, host) => Ok(Self::inet(ip, port)),
             Ok(_) => Err(InvalidNetAddr(())),
             Err(_) => Hostname::new(host.to_string())
-                .map(|h| Self::Name(h, port))
+                .map(|h| Self::name(h, port))
                 .ok_or(InvalidNetAddr(())),
         }
     }
@@ -139,22 +146,27 @@ impl NetAddr {
         S: Into<Cow<'static, str>>,
     {
         Hostname::new(name)
-            .map(|h| Self::Name(h, port))
+            .map(|h| Self::name(h, port))
             .expect("valid hostname")
     }
 
-    pub fn port(&self) -> u16 {
-        match self {
-            Self::Inet(_, p) => *p,
-            Self::Name(_, p) => *p,
+    pub fn host(&self) -> &Host {
+        &self.host
+    }
+
+    pub fn ip(&self) -> Option<IpAddr> {
+        match self.host {
+            Host::Inet(ip) => Some(ip),
+            Host::Name(_) => None,
         }
     }
 
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
     pub fn set_port(&mut self, p: u16) {
-        match self {
-            Self::Inet(_, o) => *o = p,
-            Self::Name(_, o) => *o = p,
-        }
+        self.port = p;
     }
 
     pub fn with_port(mut self, p: u16) -> Self {
@@ -170,7 +182,7 @@ impl NetAddr {
     }
 
     pub fn is_ip(&self) -> bool {
-        matches!(self, Self::Inet(..))
+        matches!(self.host, Host::Inet(_))
     }
 
     /// Whether this address is plausibly publicly routable. Returns `false` for IP literals
@@ -180,8 +192,8 @@ impl NetAddr {
     /// using stable predicates; the IPv6 surface is incomplete (`fe80::/10` link-local and
     /// `fc00::/7` unique-local addresses are treated as global here).
     pub fn is_probably_global(&self) -> bool {
-        match self {
-            Self::Inet(IpAddr::V4(v4), _) => {
+        match &self.host {
+            Host::Inet(IpAddr::V4(v4)) => {
                 !(v4.is_loopback()
                     || v4.is_unspecified()
                     || v4.is_private()
@@ -189,33 +201,48 @@ impl NetAddr {
                     || v4.is_broadcast()
                     || v4.is_documentation())
             },
-            Self::Inet(IpAddr::V6(v6), _) => {
+            Host::Inet(IpAddr::V6(v6)) => {
                 !(v6.is_loopback() || v6.is_unspecified() || v6.is_multicast())
             },
-            Self::Name(host, _) => host.as_str() != "localhost",
+            Host::Name(host) => host.as_str() != "localhost",
+        }
+    }
+
+    fn inet(ip: IpAddr, port: u16) -> Self {
+        Self {
+            host: Host::Inet(ip.to_canonical()),
+            port,
+        }
+    }
+
+    fn name(host: Hostname, port: u16) -> Self {
+        Self {
+            host: Host::Name(host),
+            port,
         }
     }
 }
 
 impl fmt::Display for NetAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Inet(a @ IpAddr::V6(_), p) => write!(f, "[{a}]:{p}"),
-            Self::Inet(a, p) => write!(f, "{a}:{p}"),
-            Self::Name(h, p) => write!(f, "{h}:{p}"),
+        let p = self.port;
+        match &self.host {
+            Host::Inet(a @ IpAddr::V6(_)) => write!(f, "[{a}]:{p}"),
+            Host::Inet(a) => write!(f, "{a}:{p}"),
+            Host::Name(h) => write!(f, "{h}:{p}"),
         }
     }
 }
 
 impl From<(IpAddr, u16)> for NetAddr {
     fn from((ip, p): (IpAddr, u16)) -> Self {
-        Self::Inet(ip.to_canonical(), p)
+        Self::inet(ip, p)
     }
 }
 
 impl From<(Ipv4Addr, u16)> for NetAddr {
     fn from((ip, p): (Ipv4Addr, u16)) -> Self {
-        Self::Inet(IpAddr::V4(ip), p)
+        Self::inet(IpAddr::V4(ip), p)
     }
 }
 
@@ -248,7 +275,7 @@ impl FromStr for NetAddr {
             let port = parse_port(&rest[i + 2..])?;
             let host = &rest[..i];
             match IpAddr::from_str(host) {
-                Ok(ip @ IpAddr::V6(_)) if is_canonical(ip, host) => Ok(Self::Inet(ip, port)),
+                Ok(ip @ IpAddr::V6(_)) if is_canonical(ip, host) => Ok(Self::inet(ip, port)),
                 _ => Err(InvalidNetAddr(())),
             }
         } else {
@@ -299,13 +326,13 @@ mod tests {
 
     use quickcheck::{Arbitrary, Gen, quickcheck};
 
-    use super::{Hostname, NetAddr, is_hostname};
+    use super::{Host, Hostname, NetAddr, is_hostname};
 
     impl Arbitrary for NetAddr {
         fn arbitrary(g: &mut Gen) -> Self {
             let port = u16::arbitrary(g);
             if bool::arbitrary(g) {
-                NetAddr::Name(arbitrary_hostname(g), port)
+                NetAddr::name(arbitrary_hostname(g), port)
             } else {
                 NetAddr::from((IpAddr::arbitrary(g), port))
             }
@@ -351,10 +378,15 @@ mod tests {
 
         /// No hostname is an IP literal, so a `Name` never prints as an address.
         fn prop_hostname_is_not_a_literal(a: NetAddr) -> bool {
-            match a {
-                NetAddr::Name(h, _) => h.parse::<IpAddr>().is_err(),
-                NetAddr::Inet(..) => true,
+            match a.host() {
+                Host::Name(h) => h.parse::<IpAddr>().is_err(),
+                Host::Inet(_) => true,
             }
+        }
+
+        /// Every address holds a canonical IP, however it was built.
+        fn prop_ip_is_canonical(a: NetAddr) -> bool {
+            a.ip().is_none_or(|ip| ip.to_canonical() == ip)
         }
     }
 

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -772,7 +772,7 @@ impl Party {
         let NetAddr::Inet(ip, _) = &self.addr else {
             return false;
         };
-        *ip != addr
+        ip.to_canonical() != addr.to_canonical()
     }
 }
 

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -769,10 +769,7 @@ impl Party {
     }
 
     fn ip_addr_mismatch(&self, addr: IpAddr) -> bool {
-        let NetAddr::Inet(ip, _) = &self.addr else {
-            return false;
-        };
-        ip.to_canonical() != addr.to_canonical()
+        self.addr.ip().is_some_and(|ip| ip != addr.to_canonical())
     }
 }
 

--- a/crates/espresso/node/src/api/state.rs
+++ b/crates/espresso/node/src/api/state.rs
@@ -416,27 +416,28 @@ where
         };
 
         let connect_info = peer.connect_info.as_ref().map(|info| {
-            let p2p_addr = match &info.p2p_addr {
-                hotshot_types::addr::NetAddr::Inet(ip, port) => v2::NetAddr {
-                    addr_type: Some(v2::net_addr::AddrType::Inet(v2::InetAddr {
-                        host: match ip {
-                            std::net::IpAddr::V4(_) => ip.to_string(),
-                            std::net::IpAddr::V6(_) => format!("[{ip}]"),
-                        },
-                        port: *port as u32,
-                    })),
-                },
-                hotshot_types::addr::NetAddr::Name(name, port) => v2::NetAddr {
-                    addr_type: Some(v2::net_addr::AddrType::Name(v2::NameAddr {
+            let port = info.p2p_addr.port() as u32;
+            let addr_type = match info.p2p_addr.host() {
+                hotshot_types::addr::Host::Inet(ip) => v2::net_addr::AddrType::Inet(v2::InetAddr {
+                    host: match ip {
+                        std::net::IpAddr::V4(_) => ip.to_string(),
+                        std::net::IpAddr::V6(_) => format!("[{ip}]"),
+                    },
+                    port,
+                }),
+                hotshot_types::addr::Host::Name(name) => {
+                    v2::net_addr::AddrType::Name(v2::NameAddr {
                         name: name.to_string(),
-                        port: *port as u32,
-                    })),
+                        port,
+                    })
                 },
             };
 
             v2::PeerConnectInfo {
                 x25519_key: info.x25519_key.to_string(),
-                p2p_addr: Some(p2p_addr),
+                p2p_addr: Some(v2::NetAddr {
+                    addr_type: Some(addr_type),
+                }),
             }
         });
 

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -1448,7 +1448,7 @@ pub mod testing {
                 .map(|_| {
                     let port =
                         reserve_tcp_port().expect("OS should have ephemeral ports available");
-                    NetAddr::Inet(Ipv4Addr::LOCALHOST.into(), port)
+                    NetAddr::from((Ipv4Addr::LOCALHOST, port))
                 })
                 .collect();
 

--- a/crates/hotshot/new-protocol/src/tests/common/harness.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/harness.rs
@@ -110,7 +110,7 @@ impl TestHarness {
             .expect("keypair derivation should succeed");
         let port =
             test_utils::reserve_tcp_port().expect("OS should have ephemeral ports available");
-        let addr = hotshot_types::addr::NetAddr::Inet(std::net::Ipv4Addr::LOCALHOST.into(), port);
+        let addr = hotshot_types::addr::NetAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
         let network = Cliquenet::create(
             "test-harness",
             public_key,

--- a/crates/hotshot/new-protocol/src/tests/common/runner.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/runner.rs
@@ -333,7 +333,7 @@ impl TestRunner {
                 let keypair = Keypair::derive_from::<BLSPubKey>(&private_key).unwrap();
                 let port = test_utils::reserve_tcp_port()
                     .expect("OS should have ephemeral ports available");
-                let addr = NetAddr::Inet(std::net::Ipv4Addr::LOCALHOST.into(), port);
+                let addr = NetAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
                 (keypair, public_key, addr)
             })
             .collect::<Vec<_>>();

--- a/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
@@ -179,7 +179,7 @@ fn build_parties(num_nodes: usize) -> Vec<(Keypair, BLSPubKey, NetAddr)> {
             let (pk, sk) = BLSPubKey::generated_from_seed_indexed([0u8; 32], i as u64);
             let kp = Keypair::derive_from::<BLSPubKey>(&sk).unwrap();
             let port = test_utils::reserve_tcp_port().expect("port");
-            let addr = NetAddr::Inet(Ipv4Addr::LOCALHOST.into(), port);
+            let addr = NetAddr::from((Ipv4Addr::LOCALHOST, port));
             (kp, pk, addr)
         })
         .collect()

--- a/crates/hotshot/types/src/addr.rs
+++ b/crates/hotshot/types/src/addr.rs
@@ -1,1 +1,1 @@
-pub use cliquenet_types::addr::{InvalidNetAddr, NetAddr};
+pub use cliquenet_types::addr::{Hostname, InvalidNetAddr, NetAddr};

--- a/crates/hotshot/types/src/addr.rs
+++ b/crates/hotshot/types/src/addr.rs
@@ -1,1 +1,1 @@
-pub use cliquenet_types::addr::{Hostname, InvalidNetAddr, NetAddr};
+pub use cliquenet_types::addr::{Host, Hostname, InvalidNetAddr, NetAddr};


### PR DESCRIPTION
The current `NetAddr` parsing accepts too many malformed inputs. Here we enforce the following format:

```
host:port where host = IPv4 literal | "[" IPv6 literal "]" | hostname
```

with `hostname` as dot-separated ASCII letters, digits, - and _ (not starting or ending with -).

We also require IP addresses to be given in one canonical format and reject them otherwise.

`NetAddr::named` will now check that the hostname matches the rules and panics otherwise.

Finally we change the IP address check to compare canonical IPs. This makes the comparison work for IPv4-mapped IPv6 addresses.