### PR TITLE
fix(stake-table): persist the epoch root header on both protocols

### DIFF
--- a/crates/espresso/node/src/persistence/fs.rs
+++ b/crates/espresso/node/src/persistence/fs.rs
@@ -1387,37 +1387,6 @@ impl SequencerPersistence for Persistence {
         )
     }
 
-    async fn store_epoch_root(
-        &self,
-        epoch: EpochNumber,
-        block_header: <SeqTypes as NodeType>::BlockHeader,
-    ) -> anyhow::Result<()> {
-        let mut inner = self.inner.write().await;
-        let dir_path = inner.epoch_root_block_header_dir_path();
-
-        fs::create_dir_all(dir_path.clone())
-            .context("failed to create epoch root block header dir")?;
-
-        let block_header_bytes =
-            bincode::serialize(&block_header).context("serialize block header")?;
-
-        let file_path = dir_path.join(epoch.to_string()).with_extension("txt");
-        inner
-            .replace(
-                &file_path,
-                |_| Ok(true),
-                |mut file| {
-                    file.write_all(&block_header_bytes)?;
-                    Ok(())
-                },
-            )
-            .context(format!(
-                "writing epoch root block header file for epoch {epoch:?}"
-            ))?;
-
-        Ok(())
-    }
-
     async fn add_state_cert(
         &self,
         state_cert: LightClientStateUpdateCertificateV2<SeqTypes>,
@@ -1680,6 +1649,37 @@ impl MembershipPersistence for Persistence {
             file_path.display()
         ))?;
         Ok(Some(header))
+    }
+
+    async fn store_epoch_root(
+        &self,
+        epoch: EpochNumber,
+        block_header: Header,
+    ) -> anyhow::Result<()> {
+        let mut inner = self.inner.write().await;
+        let dir_path = inner.epoch_root_block_header_dir_path();
+
+        fs::create_dir_all(dir_path.clone())
+            .context("failed to create epoch root block header dir")?;
+
+        let block_header_bytes =
+            bincode::serialize(&block_header).context("serialize block header")?;
+
+        let file_path = dir_path.join(epoch.to_string()).with_extension("txt");
+        inner
+            .replace(
+                &file_path,
+                |_| Ok(true),
+                |mut file| {
+                    file.write_all(&block_header_bytes)?;
+                    Ok(())
+                },
+            )
+            .context(format!(
+                "writing epoch root block header file for epoch {epoch:?}"
+            ))?;
+
+        Ok(())
     }
 
     async fn load_latest_stake(&self, limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>> {

--- a/crates/espresso/node/src/persistence/no_storage.rs
+++ b/crates/espresso/node/src/persistence/no_storage.rs
@@ -31,7 +31,7 @@ use hotshot_types::{
     vote::HasViewNumber,
 };
 
-use crate::{NodeType, SeqTypes, ViewNumber};
+use crate::{SeqTypes, ViewNumber};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Options;
@@ -237,14 +237,6 @@ impl SequencerPersistence for NoStorage {
         bail!("Cannot load from NoStorage")
     }
 
-    async fn store_epoch_root(
-        &self,
-        _epoch: EpochNumber,
-        _block_header: <SeqTypes as NodeType>::BlockHeader,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-
     async fn load_start_epoch_info(&self) -> anyhow::Result<Vec<InitializerEpochInfo<SeqTypes>>> {
         Ok(Vec::new())
     }
@@ -296,6 +288,14 @@ impl MembershipPersistence for NoStorage {
 
     async fn load_epoch_root(&self, _epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
         Ok(None)
+    }
+
+    async fn store_epoch_root(
+        &self,
+        _epoch: EpochNumber,
+        _block_header: Header,
+    ) -> anyhow::Result<()> {
+        Ok(())
     }
 
     async fn store_stake(

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -2193,29 +2193,6 @@ impl SequencerPersistence for Persistence {
         .await
     }
 
-    async fn store_epoch_root(
-        &self,
-        epoch: EpochNumber,
-        block_header: <SeqTypes as NodeType>::BlockHeader,
-    ) -> anyhow::Result<()> {
-        let epoch_i64 = epoch.u64() as i64;
-        let block_header_bytes =
-            bincode::serialize(&block_header).context("serializing block header")?;
-
-        serializable_retry!(self, || async {
-            let mut tx = self.db.write().await?;
-            tx.upsert(
-                "epoch_drb_and_root",
-                ["epoch", "block_header"],
-                ["epoch"],
-                [(epoch_i64, block_header_bytes.clone())],
-            )
-            .await?;
-            tx.commit().await
-        })
-        .await
-    }
-
     async fn store_drb_input(&self, drb_input: DrbInput) -> anyhow::Result<()> {
         if let Ok(loaded_drb_input) = self.load_drb_input(drb_input.epoch).await {
             if loaded_drb_input.difficulty_level != drb_input.difficulty_level {
@@ -2547,6 +2524,29 @@ impl MembershipPersistence for Persistence {
                 bincode::deserialize(&bytes).context("deserializing block header")
             })
             .transpose()
+    }
+
+    async fn store_epoch_root(
+        &self,
+        epoch: EpochNumber,
+        block_header: Header,
+    ) -> anyhow::Result<()> {
+        let epoch_i64 = epoch.u64() as i64;
+        let block_header_bytes =
+            bincode::serialize(&block_header).context("serializing block header")?;
+
+        serializable_retry!(self, || async {
+            let mut tx = self.db.write().await?;
+            tx.upsert(
+                "epoch_drb_and_root",
+                ["epoch", "block_header"],
+                ["epoch"],
+                [(epoch_i64, block_header_bytes.clone())],
+            )
+            .await?;
+            tx.commit().await
+        })
+        .await
     }
 
     async fn load_latest_stake(&self, limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>> {

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -941,6 +941,15 @@ impl Membership<SeqTypes> for EpochCommittees {
 
         let persistence_lock = self.fetcher.persistence.lock().await;
 
+        // Keyed by `epoch`, unlike the previous-epoch stake table stored below; not
+        // gated behind the stake table consistency check, which doesn't apply here.
+        if let Err(e) = persistence_lock
+            .store_epoch_root(epoch, block_header.clone())
+            .await
+        {
+            error!(?e, ?epoch, "`add_epoch_root`, error storing epoch root");
+        }
+
         let decided_hash = block_header.next_stake_table_hash();
 
         // we store the information from the previous epoch's in-memory committeee
@@ -1577,10 +1586,13 @@ mod tests {
     }
 
     /// Persistence stub holding stake tables for epochs 7 and 8, plus a DRB
-    /// result and an epoch root header for epoch 7 only.
+    /// result and an epoch root header for epoch 7 only. `stored_headers`
+    /// records headers written via `store_epoch_root`, independent of
+    /// `header`.
     #[derive(Debug)]
     struct MockStakeStore {
         header: Header,
+        stored_headers: std::sync::Mutex<HashMap<EpochNumber, Header>>,
     }
 
     #[async_trait::async_trait]
@@ -1604,7 +1616,22 @@ mod tests {
         }
 
         async fn load_epoch_root(&self, epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
+            if let Some(header) = self.stored_headers.lock().unwrap().get(&epoch) {
+                return Ok(Some(header.clone()));
+            }
             Ok((*epoch == 7).then(|| self.header.clone()))
+        }
+
+        async fn store_epoch_root(
+            &self,
+            epoch: EpochNumber,
+            block_header: Header,
+        ) -> anyhow::Result<()> {
+            self.stored_headers
+                .lock()
+                .unwrap()
+                .insert(epoch, block_header);
+            Ok(())
         }
 
         async fn store_stake(
@@ -1666,6 +1693,7 @@ mod tests {
     async fn restore_stake_table_from_persistence() {
         let store = MockStakeStore {
             header: build_epoch_root_header().await,
+            stored_headers: Default::default(),
         };
         let fetcher = Fetcher::new(
             Arc::new(crate::mock::MockStateCatchup::default()),
@@ -2173,6 +2201,64 @@ mod tests {
             round += 1;
         }
         assert!(round > 0, "test loop never executed a round");
+    }
+
+    // `add_epoch_root` is the only path by which a V0_6-native node (which
+    // never calls the legacy `decide_epoch_root`/`Storage::store_epoch_root`)
+    // persists the epoch root header. Regression test for that header being
+    // silently dropped.
+    #[tokio::test]
+    async fn add_epoch_root_persists_epoch_root_header() {
+        let header = build_epoch_root_header().await;
+        let epoch_height = 100u64;
+        let epoch = EpochNumber::new(epoch_from_block_number(header.height(), epoch_height) + 2);
+
+        let store = MockStakeStore {
+            header: header.clone(),
+            stored_headers: Default::default(),
+        };
+        let fetcher = Fetcher::new(
+            Arc::new(crate::mock::MockStateCatchup::default()),
+            Arc::new(AsyncMutex::new(store)),
+            crate::L1Client::new(vec!["http://localhost:3331".parse().unwrap()])
+                .expect("Failed to create L1 client"),
+            crate::ChainConfig::default(),
+        );
+        let committees = build_committees_with_fetcher(4, fetcher);
+
+        // Prefill so `add_epoch_root` reuses the cached validators and skips the L1 fetch.
+        {
+            let mut inner = committees.inner.write();
+            let template = inner
+                .epoch_committee(EpochNumber::genesis())
+                .expect("genesis committee exists");
+            let prefilled = EpochCommittee {
+                block_reward: Some(RewardAmount::default()),
+                stake_table_hash: Some(StakeTableState::default().commit()),
+                header: None,
+                eligible_leaders: template.eligible_leaders.clone(),
+                stake_table: template.stake_table.clone(),
+                validators: template.validators.clone(),
+                address_mapping: template.address_mapping.clone(),
+            };
+            inner.put_epoch_committee(epoch, Arc::new(prefilled));
+        }
+
+        let coordinator = EpochMembershipCoordinator::<SeqTypes>::new(
+            committees.clone(),
+            *committees.epoch_height(),
+            &hotshot_example_types::storage_types::TestStorage::default(),
+        );
+        coordinator
+            .add_epoch_root(header.clone())
+            .await
+            .expect("add_epoch_root should succeed for the prefilled state");
+
+        let persistence = committees.fetcher.persistence.lock().await;
+        assert_eq!(
+            persistence.load_epoch_root(epoch).await.unwrap(),
+            Some(header)
+        );
     }
 
     // `add_da_committee` updates the per-epoch `da_committees` map and

--- a/crates/espresso/types/src/v0/impls/instance_state.rs
+++ b/crates/espresso/types/src/v0/impls/instance_state.rs
@@ -186,6 +186,14 @@ impl MembershipPersistence for NoStorage {
         Ok(None)
     }
 
+    async fn store_epoch_root(
+        &self,
+        _epoch: EpochNumber,
+        _block_header: Header,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn store_stake(
         &self,
         _epoch: EpochNumber,

--- a/crates/espresso/types/src/v0/traits.rs
+++ b/crates/espresso/types/src/v0/traits.rs
@@ -528,6 +528,13 @@ pub trait MembershipPersistence: Send + Sync + 'static {
     /// Load the epoch root block header for `epoch`.
     async fn load_epoch_root(&self, epoch: EpochNumber) -> anyhow::Result<Option<Header>>;
 
+    /// Store the epoch root block header for `epoch`.
+    async fn store_epoch_root(
+        &self,
+        epoch: EpochNumber,
+        block_header: Header,
+    ) -> anyhow::Result<()>;
+
     /// Store stake table at `epoch` in the persistence layer
     async fn store_stake(
         &self,
@@ -1085,11 +1092,6 @@ pub trait SequencerPersistence:
     ) -> anyhow::Result<()>;
     async fn store_drb_input(&self, drb_input: DrbInput) -> anyhow::Result<()>;
     async fn load_drb_input(&self, epoch: u64) -> anyhow::Result<DrbInput>;
-    async fn store_epoch_root(
-        &self,
-        epoch: EpochNumber,
-        block_header: <SeqTypes as NodeType>::BlockHeader,
-    ) -> anyhow::Result<()>;
     async fn add_state_cert(
         &self,
         state_cert: LightClientStateUpdateCertificateV2<SeqTypes>,


### PR DESCRIPTION
`Storage::store_epoch_root` only fires on the legacy decide path, in `decide_epoch_root`. Once a node cuts over to the V0_6 stack that path is torn down, so the new protocol reaches epoch roots through `EpochManager::handle_leaf_decided` -> `add_epoch_root` and never persists the header. `epoch_drb_and_root.block_header` stays NULL forever on a V0_6-native node, so `load_epoch_root` always returns None.

Nothing breaks outright, because every consumer falls back to fetching from peers, but restart recovery and dynamic block reward calculation quietly gain a hard dependency on reachable peers, and `load_start_epoch_info`'s header branch becomes dead code.

Introduced by df7a0ccdf34 (#4456), which replicated the membership half of `decide_epoch_root` and dropped the storage half.

`MembershipPersistence` already declared `load_epoch_root` with no matching store, which is the asymmetry that allowed this. Move `store_epoch_root` down beside it and call it from `add_epoch_root`, the one function both protocols funnel through, which already computes the same `+ 2` epoch key. On legacy nodes this is a second write of an identical header to the same key, which both the SQL upsert and the FS replace handle idempotently.
