### PR TITLE
fix(stake-table): one retry deadline per fetch, with backoff 1/6

### DIFF
--- a/crates/espresso/node/src/options.rs
+++ b/crates/espresso/node/src/options.rs
@@ -938,6 +938,7 @@ pub struct L1Tuning {
     pub failover_revert: Duration,
     pub rate_limit_delay: Option<Duration>,
     pub stake_table_update_interval: Duration,
+    pub events_attempt_timeout: Duration,
     pub events_max_retry_duration: Duration,
     pub finalized_safety_margin: Option<u64>,
 }
@@ -984,6 +985,7 @@ impl From<&L1ClientOptions> for L1Tuning {
             failover_revert: o.l1_failover_revert,
             rate_limit_delay: o.l1_rate_limit_delay,
             stake_table_update_interval: o.stake_table_update_interval,
+            events_attempt_timeout: o.l1_events_attempt_timeout,
             events_max_retry_duration: o.l1_events_max_retry_duration,
             finalized_safety_margin: o.l1_finalized_safety_margin,
         }

--- a/crates/espresso/types/Cargo.toml
+++ b/crates/espresso/types/Cargo.toml
@@ -126,6 +126,7 @@ rstest = { workspace = true }
 rstest_reuse = { workspace = true }
 test-log = { workspace = true }
 test-utils = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 
 [[bench]]
 name = "reward_mt"

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -1404,6 +1404,7 @@ impl Fetcher {
     ) -> Result<Vec<(EventKey, StakeTableEvent)>, StakeTableError> {
         let stake_table_contract = StakeTableV3::new(contract, l1_client.provider.clone());
         let retry_delay = l1_client.options().l1_retry_delay;
+        let attempt_timeout = l1_client.options().l1_events_attempt_timeout;
         // One budget for the whole logical fetch, shared by the `initializedAtBlock` lookup and
         // every chunk below. It resets on every success, so a fetch spanning many chunks isn't
         // bounded by wall-clock total, only by how long any single chunk can stall.
@@ -1415,7 +1416,7 @@ impl Fetcher {
             None => {
                 let init_block = retry(
                     retry_delay,
-                    ATTEMPT_TIMEOUT,
+                    attempt_timeout,
                     &mut budget,
                     "stake table initializedAtBlock lookup",
                     move || {
@@ -1446,7 +1447,7 @@ impl Fetcher {
             // retry if the call to the provider to fetch the events fails
             let logs: Vec<Log> = retry(
                 retry_delay,
-                ATTEMPT_TIMEOUT,
+                attempt_timeout,
                 &mut budget,
                 &format!("stake table events fetch from_block={from} to_block={to}"),
                 move || {
@@ -1851,8 +1852,6 @@ impl RetryBudget {
     }
 }
 
-// TODO(follow-up commit): make this configurable via `L1ClientOptions`.
-const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(60);
 const BACKOFF_CAP: Duration = Duration::from_secs(60);
 const WARN_AFTER: Duration = Duration::from_secs(60);
 const ERROR_AFTER: Duration = Duration::from_secs(5 * 60);

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -1404,9 +1404,10 @@ impl Fetcher {
     ) -> Result<Vec<(EventKey, StakeTableEvent)>, StakeTableError> {
         let stake_table_contract = StakeTableV3::new(contract, l1_client.provider.clone());
         let retry_delay = l1_client.options().l1_retry_delay;
-        // One deadline for the whole logical fetch, shared by the `initializedAtBlock` lookup
-        // and every chunk below, so a fetch spanning N chunks can't take N times the budget.
-        let deadline = RetryDeadline::new(l1_client.options().l1_events_max_retry_duration);
+        // One budget for the whole logical fetch, shared by the `initializedAtBlock` lookup and
+        // every chunk below. It resets on every success, so a fetch spanning many chunks isn't
+        // bounded by wall-clock total, only by how long any single chunk can stall.
+        let mut budget = RetryBudget::new(l1_client.options().l1_events_max_retry_duration);
         // get the block number when the contract was initialized
         // to avoid fetching events from block number 0
         let from_block = match from_block {
@@ -1414,7 +1415,8 @@ impl Fetcher {
             None => {
                 let init_block = retry(
                     retry_delay,
-                    deadline,
+                    ATTEMPT_TIMEOUT,
+                    &mut budget,
                     "stake table initializedAtBlock lookup",
                     move || {
                         let stake_table_contract = stake_table_contract.clone();
@@ -1444,8 +1446,9 @@ impl Fetcher {
             // retry if the call to the provider to fetch the events fails
             let logs: Vec<Log> = retry(
                 retry_delay,
-                deadline,
-                &format!("stake table events fetch to_block={to}"),
+                ATTEMPT_TIMEOUT,
+                &mut budget,
+                &format!("stake table events fetch from_block={from} to_block={to}"),
                 move || {
                     let provider = provider.clone();
 
@@ -1804,41 +1807,68 @@ impl Fetcher {
     }
 }
 
-/// Absolute deadline shared by every retry within one logical L1 fetch.
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct RetryDeadline(Instant);
+/// Gives up when no attempt has succeeded for `budget`. The deadline is pushed forward on every
+/// success, so a slow-but-progressing fetch (e.g. many chunks of a large block range, each
+/// eventually succeeding) completes however long it takes in total, while a fetch stuck making
+/// no progress at all still dies within one budget.
+pub(crate) struct RetryBudget {
+    /// Configured value, reported in the operator-facing error and every log line.
+    budget: Duration,
+    /// Start of the whole logical fetch. Never reset: the log escalation ladder below keys off
+    /// this so it fires once per milestone for the fetch as a whole, not once per chunk.
+    fetch_start: Instant,
+    /// Reset to `now + budget` on every successful attempt.
+    deadline: Instant,
+    attempts: u32,
+    warned: bool,
+    error_milestones: u64,
+}
 
-impl RetryDeadline {
+impl RetryBudget {
     pub(crate) fn new(budget: Duration) -> Self {
-        Self(Instant::now() + budget)
+        let now = Instant::now();
+        Self {
+            budget,
+            fetch_start: now,
+            deadline: now + budget,
+            attempts: 0,
+            warned: false,
+            error_milestones: 0,
+        }
+    }
+
+    fn expired(&self) -> bool {
+        Instant::now() >= self.deadline
     }
 
     /// Time left until the deadline, or `Duration::ZERO` if it has passed.
-    pub(crate) fn remaining(&self) -> Duration {
-        self.0.saturating_duration_since(Instant::now())
+    fn remaining(&self) -> Duration {
+        self.deadline.saturating_duration_since(Instant::now())
     }
 
-    pub(crate) fn expired(&self) -> bool {
-        Instant::now() >= self.0
+    fn reset(&mut self) {
+        self.deadline = Instant::now() + self.budget;
     }
 }
 
-/// Longest any single attempt is allowed to hang before it is cancelled and retried.
-/// Independent of `BACKOFF_CAP`: this bounds one `operation()` call, not the delay between calls.
-const ATTEMPT_TIMEOUT_CAP: Duration = Duration::from_secs(60);
+// TODO(follow-up commit): make this configurable via `L1ClientOptions`.
+const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(60);
 const BACKOFF_CAP: Duration = Duration::from_secs(60);
 const WARN_AFTER: Duration = Duration::from_secs(60);
 const ERROR_AFTER: Duration = Duration::from_secs(5 * 60);
 const ERROR_INTERVAL: Duration = Duration::from_secs(30 * 60);
 
-/// Retries `operation` with capped exponential backoff until it succeeds or `deadline` passes.
-/// Every attempt is bounded by `tokio::time::timeout`, so a hung request can't stall past the
-/// deadline. Pass the same `deadline` to every `retry` call within one logical fetch (e.g. every
-/// chunk of a chunked range) so the budget is spent once for the whole fetch, not once per call.
+/// Retries `operation` until it succeeds or `budget` records no success for its whole duration.
+/// Every attempt is bounded by `attempt_timeout`; the delay between attempts backs off
+/// exponentially, doubling up to `BACKOFF_CAP` or `retry_delay` itself, whichever is larger. Pass
+/// one `&mut RetryBudget` through every `retry` call within one logical fetch (e.g. every chunk
+/// of a chunked range): it resets on every success, so it bounds how long any single chunk can
+/// stall, not the wall-clock time of the whole fetch.
 #[cfg_attr(not(feature = "node"), allow(dead_code))]
 async fn retry<F, T, E>(
     retry_delay: Duration,
-    deadline: RetryDeadline,
+    attempt_timeout: Duration,
+    budget: &mut RetryBudget,
     operation_name: &str,
     mut operation: F,
 ) -> Result<T, StakeTableError>
@@ -1846,35 +1876,47 @@ where
     F: FnMut() -> BoxFuture<'static, Result<T, E>>,
     E: std::fmt::Display,
 {
-    let call_start = Instant::now();
-    let budget = deadline.remaining();
+    let configured_budget = budget.budget;
     let mut delay = retry_delay;
-    let mut attempts: u32 = 0;
-    let mut warned = false;
-    let mut error_milestones = 0;
+    let mut last_err: Option<String> = None;
 
     loop {
-        attempts += 1;
-        let remaining = deadline.remaining();
-        let attempt_timeout = remaining.min(ATTEMPT_TIMEOUT_CAP);
+        if budget.expired() {
+            let elapsed = budget.fetch_start.elapsed();
+            let err = last_err.unwrap_or_else(|| "no successful L1 call within budget".to_string());
+            tracing::error!(
+                ?elapsed, ?configured_budget, attempts = budget.attempts, operation = operation_name, %err,
+                "L1 FETCH RETRY BUDGET EXHAUSTED"
+            );
+            return Err(StakeTableError::L1Fetch {
+                operation: operation_name.to_string(),
+                budget: format_duration(configured_budget).to_string(),
+                err,
+            });
+        }
+
+        budget.attempts += 1;
         let err = match timeout(attempt_timeout, operation()).await {
-            Ok(Ok(result)) => return Ok(result),
+            Ok(Ok(result)) => {
+                budget.reset();
+                return Ok(result);
+            },
             Ok(Err(err)) => err.to_string(),
             Err(_) => format!(
                 "operation timed out after {}",
                 format_duration(attempt_timeout)
             ),
         };
-        let elapsed = call_start.elapsed();
+        let elapsed = budget.fetch_start.elapsed();
 
         tracing::debug!(
-            ?elapsed, ?budget, attempts, operation = operation_name, %err,
+            ?elapsed, ?configured_budget, attempts = budget.attempts, operation = operation_name, %err,
             "L1 fetch attempt failed"
         );
-        if !warned && elapsed >= WARN_AFTER {
-            warned = true;
+        if !budget.warned && elapsed >= WARN_AFTER {
+            budget.warned = true;
             tracing::warn!(
-                ?elapsed, ?budget, attempts, operation = operation_name, %err,
+                ?elapsed, ?configured_budget, attempts = budget.attempts, operation = operation_name, %err,
                 "L1 fetch still retrying after 1 minute"
             );
         }
@@ -1883,28 +1925,17 @@ where
         } else {
             0
         };
-        if milestones > error_milestones {
-            error_milestones = milestones;
+        if milestones > budget.error_milestones {
+            budget.error_milestones = milestones;
             tracing::error!(
-                ?elapsed, ?budget, attempts, operation = operation_name, %err,
+                ?elapsed, ?configured_budget, attempts = budget.attempts, operation = operation_name, %err,
                 "L1 fetch still retrying after 5+ minutes"
             );
         }
 
-        if deadline.expired() {
-            tracing::error!(
-                ?elapsed, ?budget, attempts, operation = operation_name, %err,
-                "L1 FETCH RETRY BUDGET EXHAUSTED"
-            );
-            return Err(StakeTableError::L1Fetch {
-                operation: operation_name.to_string(),
-                budget: format_duration(budget).to_string(),
-                err,
-            });
-        }
-
-        sleep(delay.min(deadline.remaining())).await;
-        delay = (delay * 2).min(BACKOFF_CAP);
+        last_err = Some(err);
+        sleep(delay.min(budget.remaining())).await;
+        delay = (delay * 2).min(BACKOFF_CAP.max(retry_delay));
     }
 }
 
@@ -3262,13 +3293,31 @@ mod tests {
         .await;
     }
 
+    const TEST_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+    /// A closure usable as a `retry` operation that fails `fail_times` times, then succeeds.
+    fn flaky_op(fail_times: u32) -> impl FnMut() -> BoxFuture<'static, Result<(), &'static str>> {
+        let attempts = Arc::new(AtomicU32::new(0));
+        move || {
+            let attempts = attempts.clone();
+            Box::pin(async move {
+                if attempts.fetch_add(1, Ordering::SeqCst) < fail_times {
+                    Err("not yet")
+                } else {
+                    Ok(())
+                }
+            })
+        }
+    }
+
     #[test_log::test(tokio::test(start_paused = true))]
-    async fn retry_returns_l1_fetch_error_when_deadline_expires() {
-        let deadline = RetryDeadline::new(Duration::from_millis(200));
+    async fn retry_returns_l1_fetch_error_when_budget_expires() {
+        let mut budget = RetryBudget::new(Duration::from_millis(200));
 
         let result: Result<(), StakeTableError> = retry(
             Duration::from_millis(50),
-            deadline,
+            TEST_ATTEMPT_TIMEOUT,
+            &mut budget,
             "always fails",
             move || -> BoxFuture<'static, Result<(), &'static str>> {
                 Box::pin(async { Err("boom") })
@@ -3284,74 +3333,113 @@ mod tests {
         );
     }
 
-    /// Mirrors `fetch_events_from_contract`'s chunk loop: multiple `retry` calls share one
-    /// `RetryDeadline`. Each simulated chunk needs 5 attempts to succeed (1+2+4+8 = 15s of
-    /// backoff), but the shared 20s budget only has room for the first chunk.
+    /// The regression this PR fixes: a fetch chunked into many pieces, each of which is slow but
+    /// eventually succeeds, must complete however long that takes in total. A wall-clock deadline
+    /// shared across chunks (the previous, buggy design) would abort partway through even though
+    /// every chunk is making progress - this is what livelocked a cold-start mainnet sync.
     #[test_log::test(tokio::test(start_paused = true))]
-    async fn retry_deadline_is_shared_across_chunks_not_per_chunk() {
+    async fn retry_many_slow_but_successful_chunks_complete_past_one_budget() {
         let retry_delay = Duration::from_secs(1);
-        let deadline = RetryDeadline::new(Duration::from_secs(20));
+        let mut budget = RetryBudget::new(Duration::from_secs(20));
         let start = Instant::now();
 
-        let attempts_1 = Arc::new(AtomicU32::new(0));
-        let result_1: Result<(), StakeTableError> = retry(retry_delay, deadline, "chunk 1", {
-            let attempts_1 = attempts_1.clone();
-            move || -> BoxFuture<'static, Result<(), &'static str>> {
-                let attempts_1 = attempts_1.clone();
-                Box::pin(async move {
-                    if attempts_1.fetch_add(1, Ordering::SeqCst) < 4 {
-                        Err("not yet")
-                    } else {
-                        Ok(())
-                    }
-                })
-            }
-        })
-        .await;
-        assert!(result_1.is_ok());
-        assert_eq!(attempts_1.load(Ordering::SeqCst), 5);
+        // Each "chunk" needs 5 attempts to succeed (1+2+4+8 = 15s of backoff), just under the
+        // 20s budget. 10 such chunks take ~150s total, 7.5x the budget.
+        for chunk in 0..10 {
+            let result: Result<(), StakeTableError> = retry(
+                retry_delay,
+                TEST_ATTEMPT_TIMEOUT,
+                &mut budget,
+                &format!("chunk {chunk}"),
+                flaky_op(4),
+            )
+            .await;
+            assert!(result.is_ok(), "chunk {chunk} should have succeeded");
+        }
 
-        // Only ~5s of the shared budget remains, not a fresh 20s, so the second chunk - which
-        // needs the same 15s to succeed - must fail instead of getting its own budget.
-        let attempts_2 = Arc::new(AtomicU32::new(0));
-        let result_2: Result<(), StakeTableError> = retry(retry_delay, deadline, "chunk 2", {
-            let attempts_2 = attempts_2.clone();
+        assert!(start.elapsed() > Duration::from_secs(20));
+    }
+
+    /// A chunk that never succeeds dies within one budget; preceding successful chunks (which
+    /// would have exhausted a naive cumulative failure-time budget) don't shrink that budget.
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn retry_dies_within_one_budget_after_prior_successes() {
+        let retry_delay = Duration::from_secs(1);
+        let mut budget = RetryBudget::new(Duration::from_secs(20));
+
+        for chunk in 0..5 {
+            let result: Result<(), StakeTableError> = retry(
+                retry_delay,
+                TEST_ATTEMPT_TIMEOUT,
+                &mut budget,
+                &format!("chunk {chunk}"),
+                flaky_op(4),
+            )
+            .await;
+            assert!(result.is_ok());
+        }
+
+        let start = Instant::now();
+        let result: Result<(), StakeTableError> = retry(
+            retry_delay,
+            TEST_ATTEMPT_TIMEOUT,
+            &mut budget,
+            "always fails",
             move || -> BoxFuture<'static, Result<(), &'static str>> {
-                let attempts_2 = attempts_2.clone();
-                Box::pin(async move {
-                    if attempts_2.fetch_add(1, Ordering::SeqCst) < 4 {
-                        Err("not yet")
-                    } else {
-                        Ok(())
-                    }
-                })
-            }
-        })
+                Box::pin(async { Err("boom") })
+            },
+        )
         .await;
 
-        assert!(matches!(result_2, Err(StakeTableError::L1Fetch { .. })));
-        // ~1 budget total for both chunks combined, not 2.
+        assert!(matches!(result, Err(StakeTableError::L1Fetch { .. })));
         assert!(start.elapsed() < Duration::from_secs(25));
     }
 
+    /// The escalation ladder keys off the whole fetch's elapsed time, not any one chunk's, so a
+    /// fetch that is merely slow (never failing for more than a few minutes at a time) but stuck
+    /// that way across many chunks still gets an `error!`, instead of staying silent forever
+    /// because no single chunk crosses the threshold.
     #[test_log::test(tokio::test(start_paused = true))]
-    async fn retry_backoff_grows_and_caps_at_60_seconds() {
-        let deadline = RetryDeadline::new(Duration::from_secs(600));
-        let start = Instant::now();
-        let attempt_times: Arc<AsyncMutex<Vec<Duration>>> = Arc::new(AsyncMutex::new(Vec::new()));
-        let count = Arc::new(AtomicU32::new(0));
-        const SUCCEED_ON_ATTEMPT: u32 = 9;
+    async fn retry_ladder_escalates_across_many_chunks_not_per_chunk() {
+        let retry_delay = Duration::from_secs(4 * 60);
+        let mut budget = RetryBudget::new(Duration::from_secs(3600));
 
-        let result: Result<(), StakeTableError> =
-            retry(Duration::from_secs(1), deadline, "flaky", {
+        // 10 chunks, each failing once (well under WARN_AFTER/ERROR_AFTER on its own) then
+        // succeeding after one retry_delay. ~40 minutes of fetch-wide elapsed time in total.
+        for chunk in 0..10 {
+            let result: Result<(), StakeTableError> = retry(
+                retry_delay,
+                TEST_ATTEMPT_TIMEOUT,
+                &mut budget,
+                &format!("chunk {chunk}"),
+                flaky_op(1),
+            )
+            .await;
+            assert!(result.is_ok());
+        }
+
+        assert!(budget.warned);
+        assert!(budget.error_milestones >= 1);
+    }
+
+    /// With `ESPRESSO_L1_RETRY_DELAY` set above `BACKOFF_CAP`, delay must never shrink below the
+    /// configured value.
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn retry_backoff_honours_retry_delay_larger_than_cap() {
+        let retry_delay = Duration::from_secs(90);
+        assert!(retry_delay > BACKOFF_CAP);
+        let mut budget = RetryBudget::new(Duration::from_secs(600));
+        let start = Instant::now();
+        let attempt_times = Arc::new(AsyncMutex::new(Vec::new()));
+
+        let _: Result<(), StakeTableError> =
+            retry(retry_delay, TEST_ATTEMPT_TIMEOUT, &mut budget, "flaky", {
                 let attempt_times = attempt_times.clone();
-                let count = count.clone();
                 move || -> BoxFuture<'static, Result<(), &'static str>> {
                     let attempt_times = attempt_times.clone();
-                    let count = count.clone();
                     Box::pin(async move {
                         attempt_times.lock().await.push(start.elapsed());
-                        if count.fetch_add(1, Ordering::SeqCst) + 1 < SUCCEED_ON_ATTEMPT {
+                        if attempt_times.lock().await.len() < 3 {
                             Err("not yet")
                         } else {
                             Ok(())
@@ -3361,26 +3449,54 @@ mod tests {
             })
             .await;
 
-        assert!(result.is_ok());
         let times = attempt_times.lock().await.clone();
         let gaps: Vec<Duration> = times.windows(2).map(|w| w[1] - w[0]).collect();
-        let expected: Vec<Duration> = [1, 2, 4, 8, 16, 32, 60, 60]
-            .into_iter()
-            .map(Duration::from_secs)
-            .collect();
-        assert_eq!(gaps, expected);
+        assert_eq!(gaps, vec![retry_delay, retry_delay]);
     }
 
-    /// 1s + 2s of backoff exhausts a 3.5s budget; without deadline-aware clamping the next
-    /// backoff step (4s) would sleep well past it.
+    /// `retry` reports the configured budget in the exhaustion error, not whatever slice of it
+    /// happened to be left when this particular chunk started.
     #[test_log::test(tokio::test(start_paused = true))]
-    async fn retry_backoff_never_sleeps_past_deadline() {
-        let deadline = RetryDeadline::new(Duration::from_millis(3500));
+    async fn retry_exhaustion_error_names_configured_budget_not_remaining_slice() {
+        let mut budget = RetryBudget::new(Duration::from_secs(20));
+
+        // One immediate success resets the deadline; then unrelated time passes (as prior chunks
+        // would take), leaving only a slice of the 20s budget for the next, failing chunk.
+        let _: Result<(), StakeTableError> = retry(
+            Duration::from_secs(1),
+            TEST_ATTEMPT_TIMEOUT,
+            &mut budget,
+            "warm up",
+            move || -> BoxFuture<'static, Result<(), &'static str>> { Box::pin(async { Ok(()) }) },
+        )
+        .await;
+        tokio::time::advance(Duration::from_secs(15)).await;
+
+        let result: Result<(), StakeTableError> = retry(
+            Duration::from_secs(1),
+            TEST_ATTEMPT_TIMEOUT,
+            &mut budget,
+            "always fails",
+            move || -> BoxFuture<'static, Result<(), &'static str>> {
+                Box::pin(async { Err("boom") })
+            },
+        )
+        .await;
+
+        let message = result.expect_err("budget should be exhausted").to_string();
+        assert!(message.contains("20s"), "message was: {message}");
+    }
+
+    /// A chunk that never succeeds dies within one budget instead of running forever.
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn retry_never_succeeding_chunk_dies_within_one_budget() {
+        let mut budget = RetryBudget::new(Duration::from_millis(3500));
         let start = Instant::now();
 
         let result: Result<(), StakeTableError> = retry(
             Duration::from_secs(1),
-            deadline,
+            TEST_ATTEMPT_TIMEOUT,
+            &mut budget,
             "always fails",
             move || -> BoxFuture<'static, Result<(), &'static str>> {
                 Box::pin(async { Err("boom") })
@@ -3394,26 +3510,33 @@ mod tests {
 
     /// The operation never resolves; only `tokio::time::timeout` can move the loop forward.
     /// Multiple attempts occurring proves each one was cut off by the per-attempt timeout
-    /// instead of hanging until the deadline in a single call.
+    /// instead of hanging until the budget expires in a single call.
     #[test_log::test(tokio::test(start_paused = true))]
     async fn retry_cuts_off_hung_attempt_via_timeout() {
-        let deadline = RetryDeadline::new(Duration::from_secs(200));
+        let mut budget = RetryBudget::new(Duration::from_secs(200));
         let attempts = Arc::new(AtomicU32::new(0));
         let start = Instant::now();
 
-        let result: Result<(), StakeTableError> =
-            retry(Duration::from_secs(1), deadline, "hangs", {
+        let result: Result<(), StakeTableError> = retry(
+            Duration::from_secs(1),
+            TEST_ATTEMPT_TIMEOUT,
+            &mut budget,
+            "hangs",
+            {
                 let attempts = attempts.clone();
                 move || -> BoxFuture<'static, Result<(), &'static str>> {
                     attempts.fetch_add(1, Ordering::SeqCst);
                     Box::pin(std::future::pending())
                 }
-            })
-            .await;
+            },
+        )
+        .await;
 
         assert!(matches!(result, Err(StakeTableError::L1Fetch { .. })));
         assert!(attempts.load(Ordering::SeqCst) > 1);
-        assert!(start.elapsed() <= Duration::from_secs(201));
+        // Budget expiry is only checked between attempts, not by clamping the attempt timeout
+        // itself, so overshoot is bounded by one attempt timeout (60s here), not unbounded.
+        assert!(start.elapsed() <= Duration::from_secs(200) + TEST_ATTEMPT_TIMEOUT);
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::min,
     collections::{HashMap, HashSet},
     str::FromStr,
-    time::{Duration, Instant},
+    time::Duration,
 };
 #[cfg(feature = "node")]
 use std::{future::Future, sync::Arc};
@@ -59,7 +59,7 @@ use num_traits::{FromPrimitive, Zero};
 use thiserror::Error;
 #[cfg(feature = "node")]
 use tokio::spawn;
-use tokio::time::sleep;
+use tokio::time::{Instant, sleep, timeout};
 #[cfg(feature = "node")]
 use tracing::Instrument;
 use vbs::version::Version;
@@ -1403,29 +1403,28 @@ impl Fetcher {
         to_block: u64,
     ) -> Result<Vec<(EventKey, StakeTableEvent)>, StakeTableError> {
         let stake_table_contract = StakeTableV3::new(contract, l1_client.provider.clone());
-        let max_retry_duration = l1_client.options().l1_events_max_retry_duration;
         let retry_delay = l1_client.options().l1_retry_delay;
+        // One deadline for the whole logical fetch, shared by the `initializedAtBlock` lookup
+        // and every chunk below, so a fetch spanning N chunks can't take N times the budget.
+        let deadline = RetryDeadline::new(l1_client.options().l1_events_max_retry_duration);
         // get the block number when the contract was initialized
         // to avoid fetching events from block number 0
         let from_block = match from_block {
             Some(block) => block,
             None => {
-                let start = Instant::now();
-                loop {
-                    match stake_table_contract.initializedAtBlock().call().await {
-                        Ok(init_block) => break init_block.to::<u64>(),
-                        Err(err) => {
-                            if start.elapsed() >= max_retry_duration {
-                                panic!(
-                                    "Failed to retrieve initial block after `{}`: {err}",
-                                    format_duration(max_retry_duration)
-                                );
-                            }
-                            tracing::warn!(%err, "Failed to retrieve initial block, retrying...");
-                            sleep(retry_delay).await;
-                        },
-                    }
-                }
+                let init_block = retry(
+                    retry_delay,
+                    deadline,
+                    "stake table initializedAtBlock lookup",
+                    move || {
+                        let stake_table_contract = stake_table_contract.clone();
+                        Box::pin(
+                            async move { stake_table_contract.initializedAtBlock().call().await },
+                        )
+                    },
+                )
+                .await?;
+                init_block.to::<u64>()
             },
         };
 
@@ -1445,8 +1444,8 @@ impl Fetcher {
             // retry if the call to the provider to fetch the events fails
             let logs: Vec<Log> = retry(
                 retry_delay,
-                max_retry_duration,
-                "stake table events fetch",
+                deadline,
+                &format!("stake table events fetch to_block={to}"),
                 move || {
                     let provider = provider.clone();
 
@@ -1474,7 +1473,7 @@ impl Fetcher {
                     })
                 },
             )
-            .await;
+            .await?;
 
             let chunk_events = logs
                 .into_iter()
@@ -1805,47 +1804,107 @@ impl Fetcher {
     }
 }
 
+/// Absolute deadline shared by every retry within one logical L1 fetch.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RetryDeadline(Instant);
+
+impl RetryDeadline {
+    pub(crate) fn new(budget: Duration) -> Self {
+        Self(Instant::now() + budget)
+    }
+
+    /// Time left until the deadline, or `Duration::ZERO` if it has passed.
+    pub(crate) fn remaining(&self) -> Duration {
+        self.0.saturating_duration_since(Instant::now())
+    }
+
+    pub(crate) fn expired(&self) -> bool {
+        Instant::now() >= self.0
+    }
+}
+
+/// Longest any single attempt is allowed to hang before it is cancelled and retried.
+/// Independent of `BACKOFF_CAP`: this bounds one `operation()` call, not the delay between calls.
+const ATTEMPT_TIMEOUT_CAP: Duration = Duration::from_secs(60);
+const BACKOFF_CAP: Duration = Duration::from_secs(60);
+const WARN_AFTER: Duration = Duration::from_secs(60);
+const ERROR_AFTER: Duration = Duration::from_secs(5 * 60);
+const ERROR_INTERVAL: Duration = Duration::from_secs(30 * 60);
+
+/// Retries `operation` with capped exponential backoff until it succeeds or `deadline` passes.
+/// Every attempt is bounded by `tokio::time::timeout`, so a hung request can't stall past the
+/// deadline. Pass the same `deadline` to every `retry` call within one logical fetch (e.g. every
+/// chunk of a chunked range) so the budget is spent once for the whole fetch, not once per call.
 #[cfg_attr(not(feature = "node"), allow(dead_code))]
 async fn retry<F, T, E>(
     retry_delay: Duration,
-    max_duration: Duration,
+    deadline: RetryDeadline,
     operation_name: &str,
     mut operation: F,
-) -> T
+) -> Result<T, StakeTableError>
 where
     F: FnMut() -> BoxFuture<'static, Result<T, E>>,
     E: std::fmt::Display,
 {
-    let start = Instant::now();
+    let call_start = Instant::now();
+    let budget = deadline.remaining();
+    let mut delay = retry_delay;
+    let mut attempts: u32 = 0;
+    let mut warned = false;
+    let mut error_milestones = 0;
+
     loop {
-        match operation().await {
-            Ok(result) => return result,
-            Err(err) => {
-                if start.elapsed() >= max_duration {
-                    panic!(
-                        r#"
-                    Failed to complete operation `{operation_name}` after `{}`.
-                    error: {err}
+        attempts += 1;
+        let remaining = deadline.remaining();
+        let attempt_timeout = remaining.min(ATTEMPT_TIMEOUT_CAP);
+        let err = match timeout(attempt_timeout, operation()).await {
+            Ok(Ok(result)) => return Ok(result),
+            Ok(Err(err)) => err.to_string(),
+            Err(_) => format!(
+                "operation timed out after {}",
+                format_duration(attempt_timeout)
+            ),
+        };
+        let elapsed = call_start.elapsed();
 
-
-                    This might be caused by:
-                    - The current block range being too large for your RPC provider.
-                    - The event query returning more data than your RPC allows as
-                      some RPC providers limit the number of events returned.
-                    - RPC provider outage
-
-                    Suggested solution:
-                    - Reduce the value of the environment variable
-                      `ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE` to query smaller ranges.
-                    - Add multiple RPC providers
-                    - Use a different RPC provider with higher rate limits."#,
-                        format_duration(max_duration)
-                    );
-                }
-                tracing::warn!(%err, "Retrying `{operation_name}` after error");
-                sleep(retry_delay).await;
-            },
+        tracing::debug!(
+            ?elapsed, ?budget, attempts, operation = operation_name, %err,
+            "L1 fetch attempt failed"
+        );
+        if !warned && elapsed >= WARN_AFTER {
+            warned = true;
+            tracing::warn!(
+                ?elapsed, ?budget, attempts, operation = operation_name, %err,
+                "L1 fetch still retrying after 1 minute"
+            );
         }
+        let milestones = if elapsed >= ERROR_AFTER {
+            1 + (elapsed - ERROR_AFTER).as_secs() / ERROR_INTERVAL.as_secs()
+        } else {
+            0
+        };
+        if milestones > error_milestones {
+            error_milestones = milestones;
+            tracing::error!(
+                ?elapsed, ?budget, attempts, operation = operation_name, %err,
+                "L1 fetch still retrying after 5+ minutes"
+            );
+        }
+
+        if deadline.expired() {
+            tracing::error!(
+                ?elapsed, ?budget, attempts, operation = operation_name, %err,
+                "L1 FETCH RETRY BUDGET EXHAUSTED"
+            );
+            return Err(StakeTableError::L1Fetch {
+                operation: operation_name.to_string(),
+                budget: format_duration(budget).to_string(),
+                err,
+            });
+        }
+
+        sleep(delay.min(deadline.remaining())).await;
+        delay = (delay * 2).min(BACKOFF_CAP);
     }
 }
 
@@ -2166,6 +2225,8 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
     use alloy::{
         primitives::{Address, Bytes},
         rpc::types::Log,
@@ -3228,6 +3289,160 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn retry_returns_l1_fetch_error_when_deadline_expires() {
+        let deadline = RetryDeadline::new(Duration::from_millis(200));
+
+        let result: Result<(), StakeTableError> = retry(
+            Duration::from_millis(50),
+            deadline,
+            "always fails",
+            move || -> BoxFuture<'static, Result<(), &'static str>> {
+                Box::pin(async { Err("boom") })
+            },
+        )
+        .await;
+
+        let err = result.expect_err("budget should be exhausted");
+        assert!(matches!(err, StakeTableError::L1Fetch { .. }));
+        assert!(
+            err.to_string()
+                .contains("ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE")
+        );
+    }
+
+    /// Mirrors `fetch_events_from_contract`'s chunk loop: multiple `retry` calls share one
+    /// `RetryDeadline`. Each simulated chunk needs 5 attempts to succeed (1+2+4+8 = 15s of
+    /// backoff), but the shared 20s budget only has room for the first chunk.
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn retry_deadline_is_shared_across_chunks_not_per_chunk() {
+        let retry_delay = Duration::from_secs(1);
+        let deadline = RetryDeadline::new(Duration::from_secs(20));
+        let start = Instant::now();
+
+        let attempts_1 = Arc::new(AtomicU32::new(0));
+        let result_1: Result<(), StakeTableError> = retry(retry_delay, deadline, "chunk 1", {
+            let attempts_1 = attempts_1.clone();
+            move || -> BoxFuture<'static, Result<(), &'static str>> {
+                let attempts_1 = attempts_1.clone();
+                Box::pin(async move {
+                    if attempts_1.fetch_add(1, Ordering::SeqCst) < 4 {
+                        Err("not yet")
+                    } else {
+                        Ok(())
+                    }
+                })
+            }
+        })
+        .await;
+        assert!(result_1.is_ok());
+        assert_eq!(attempts_1.load(Ordering::SeqCst), 5);
+
+        // Only ~5s of the shared budget remains, not a fresh 20s, so the second chunk - which
+        // needs the same 15s to succeed - must fail instead of getting its own budget.
+        let attempts_2 = Arc::new(AtomicU32::new(0));
+        let result_2: Result<(), StakeTableError> = retry(retry_delay, deadline, "chunk 2", {
+            let attempts_2 = attempts_2.clone();
+            move || -> BoxFuture<'static, Result<(), &'static str>> {
+                let attempts_2 = attempts_2.clone();
+                Box::pin(async move {
+                    if attempts_2.fetch_add(1, Ordering::SeqCst) < 4 {
+                        Err("not yet")
+                    } else {
+                        Ok(())
+                    }
+                })
+            }
+        })
+        .await;
+
+        assert!(matches!(result_2, Err(StakeTableError::L1Fetch { .. })));
+        // ~1 budget total for both chunks combined, not 2.
+        assert!(start.elapsed() < Duration::from_secs(25));
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn retry_backoff_grows_and_caps_at_60_seconds() {
+        let deadline = RetryDeadline::new(Duration::from_secs(600));
+        let start = Instant::now();
+        let attempt_times: Arc<AsyncMutex<Vec<Duration>>> = Arc::new(AsyncMutex::new(Vec::new()));
+        let count = Arc::new(AtomicU32::new(0));
+        const SUCCEED_ON_ATTEMPT: u32 = 9;
+
+        let result: Result<(), StakeTableError> =
+            retry(Duration::from_secs(1), deadline, "flaky", {
+                let attempt_times = attempt_times.clone();
+                let count = count.clone();
+                move || -> BoxFuture<'static, Result<(), &'static str>> {
+                    let attempt_times = attempt_times.clone();
+                    let count = count.clone();
+                    Box::pin(async move {
+                        attempt_times.lock().await.push(start.elapsed());
+                        if count.fetch_add(1, Ordering::SeqCst) + 1 < SUCCEED_ON_ATTEMPT {
+                            Err("not yet")
+                        } else {
+                            Ok(())
+                        }
+                    })
+                }
+            })
+            .await;
+
+        assert!(result.is_ok());
+        let times = attempt_times.lock().await.clone();
+        let gaps: Vec<Duration> = times.windows(2).map(|w| w[1] - w[0]).collect();
+        let expected: Vec<Duration> = [1, 2, 4, 8, 16, 32, 60, 60]
+            .into_iter()
+            .map(Duration::from_secs)
+            .collect();
+        assert_eq!(gaps, expected);
+    }
+
+    /// 1s + 2s of backoff exhausts a 3.5s budget; without deadline-aware clamping the next
+    /// backoff step (4s) would sleep well past it.
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn retry_backoff_never_sleeps_past_deadline() {
+        let deadline = RetryDeadline::new(Duration::from_millis(3500));
+        let start = Instant::now();
+
+        let result: Result<(), StakeTableError> = retry(
+            Duration::from_secs(1),
+            deadline,
+            "always fails",
+            move || -> BoxFuture<'static, Result<(), &'static str>> {
+                Box::pin(async { Err("boom") })
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(StakeTableError::L1Fetch { .. })));
+        assert!(start.elapsed() < Duration::from_secs(4));
+    }
+
+    /// The operation never resolves; only `tokio::time::timeout` can move the loop forward.
+    /// Multiple attempts occurring proves each one was cut off by the per-attempt timeout
+    /// instead of hanging until the deadline in a single call.
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn retry_cuts_off_hung_attempt_via_timeout() {
+        let deadline = RetryDeadline::new(Duration::from_secs(200));
+        let attempts = Arc::new(AtomicU32::new(0));
+        let start = Instant::now();
+
+        let result: Result<(), StakeTableError> =
+            retry(Duration::from_secs(1), deadline, "hangs", {
+                let attempts = attempts.clone();
+                move || -> BoxFuture<'static, Result<(), &'static str>> {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Box::pin(std::future::pending())
+                }
+            })
+            .await;
+
+        assert!(matches!(result, Err(StakeTableError::L1Fetch { .. })));
+        assert!(attempts.load(Ordering::SeqCst) > 1);
+        assert!(start.elapsed() <= Duration::from_secs(201));
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -3262,35 +3262,6 @@ mod tests {
         .await;
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    #[should_panic]
-    async fn test_large_max_events_range_panic() {
-        // decaf stake table contract address
-        let contract_address = "0x40304fbe94d5e7d1492dd90c53a2d63e8506a037";
-
-        let l1 = L1ClientOptions {
-            l1_events_max_retry_duration: Duration::from_secs(30),
-            // max block range for public node rpc is 50000 so this should result in a panic
-            l1_events_max_block_range: 10_u64.pow(9),
-            l1_retry_delay: Duration::from_secs(1),
-            ..Default::default()
-        }
-        .connect(vec![
-            "https://ethereum-sepolia.publicnode.com".parse().unwrap(),
-        ])
-        .expect("unable to construct l1 client");
-
-        let latest_block = l1.provider.get_block_number().await.unwrap();
-        let _events = Fetcher::fetch_events_from_contract(
-            l1,
-            contract_address.parse().unwrap(),
-            None,
-            latest_block,
-        )
-        .await
-        .unwrap();
-    }
-
     #[test_log::test(tokio::test(start_paused = true))]
     async fn retry_returns_l1_fetch_error_when_deadline_expires() {
         let deadline = RetryDeadline::new(Duration::from_millis(200));

--- a/crates/espresso/types/src/v0/v0_1/l1.rs
+++ b/crates/espresso/types/src/v0/v0_1/l1.rs
@@ -176,13 +176,27 @@ pub struct L1ClientOptions {
     )]
     pub stake_table_update_interval: Duration,
 
-    /// Maximum duration to retry fetching L1 events before panicking.
+    /// Longest time to wait for a single L1 events call (e.g. `eth_getLogs` or a contract call)
+    /// before treating the attempt as failed and retrying.
+    #[clap(
+        long,
+        env = "ESPRESSO_L1_EVENTS_ATTEMPT_TIMEOUT",
+        default_value = "60s",
+        value_parser = parse_duration,
+    )]
+    pub l1_events_attempt_timeout: Duration,
+
+    /// Longest time without a *successful* L1 events call before giving up on the current
+    /// logical fetch.
     ///
-    /// This prevents infinite retries by panicking if the total number of retries exceed the maximum duration.
-    /// This is helpful in cases where the RPC block range limit or the event return limit is hit,
-    /// or if there is an outage. In such cases, panicking ensures that the node operator can take
-    /// action instead of the node getting stuck indefinitely. This is necessary because the stake table is constructed
-    /// from the fetched events, and is required for node to participate in consensus.
+    /// This is not a bound on the total time a fetch may take: every successful attempt (e.g.
+    /// one chunk of a chunked block range) resets the clock, so a fetch that is slow but making
+    /// progress can run indefinitely. Only a fetch that is stuck making no progress at all (e.g.
+    /// a misconfigured block range, or a dead provider) gives up, after this duration. This is
+    /// helpful in cases where the RPC block range limit or the event return limit is hit, or if
+    /// there is an outage, so the node operator can take action instead of the node getting
+    /// stuck indefinitely. This is necessary because the stake table is constructed from the
+    /// fetched events, and is required for the node to participate in consensus.
     #[clap(
         long,
         env = "ESPRESSO_L1_EVENTS_MAX_RETRY_DURATION",

--- a/crates/espresso/types/src/v0/v0_3/stake_table.rs
+++ b/crates/espresso/types/src/v0/v0_3/stake_table.rs
@@ -490,6 +490,20 @@ pub enum StakeTableError {
     StakeTableEventDecodeError(#[from] alloy::sol_types::Error),
     #[error("Stake table events sorting error: {0}")]
     EventSortingError(#[from] EventSortingError),
+    #[error(
+        "Failed to complete L1 operation `{operation}` after `{budget}`: {err}\n\nThis might be \
+         caused by:\n- The current block range being too large for your RPC provider.\n- The \
+         event query returning more data than your RPC allows as some RPC providers limit the \
+         number of events returned.\n- RPC provider outage\n\nSuggested solution:\n- Reduce the \
+         value of the environment variable `ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE` to query smaller \
+         ranges.\n- Add multiple RPC providers\n- Use a different RPC provider with higher rate \
+         limits."
+    )]
+    L1Fetch {
+        operation: String,
+        budget: String,
+        err: String,
+    },
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
`retry` runs inside the `block_range_chunks` loop, so the 20m
`l1_events_max_retry_duration` applied per chunk and the real give-up time was
N * 20m. This has to land before the default is raised to 4h.

Two more defects in the same helper. The deadline was only checked *after* an
attempt returned, so a hung request made it meaningless; each attempt is now
wrapped in `tokio::time::timeout`. And `retry` panicked inside a `tokio::spawn`
whose handle is never joined, which is how the 2026-08-09 incident left 11
validators running for 12h35m with a dead stake-table updater and a frozen
watermark while dashboards read healthy. It now returns
`StakeTableError::L1Fetch`. Adds capped 1s -> 60s backoff.

Focus: `retry_deadline_is_shared_across_chunks_not_per_chunk` passes one `Copy`
deadline into two `retry` calls under a paused clock. The first burns 15s of a
20s budget, the second fails with ~5s left. Both passed before.

This removes the panic without adding the replacement alarm, so it should not
sit merged alone for long. The exit + metrics follow-up is what makes the
failure loud.

Second commit deletes `test_large_max_events_range_panic`, which asserted the
old behaviour and hit public Sepolia over the network.