### PR TITLE
refactor(l1): make l1_events_max_block_range NonZeroU64 2/6

### DIFF
--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -3489,6 +3489,7 @@ mod api_tests {
 mod test {
     use std::{
         collections::{HashMap, HashSet},
+        num::NonZeroU64,
         time::{Duration, Instant},
     };
 
@@ -7697,7 +7698,7 @@ mod test {
         let l1_client = L1ClientOptions {
             stake_table_update_interval: Duration::from_secs(7),
             l1_retry_delay: Duration::from_millis(10),
-            l1_events_max_block_range: 10000,
+            l1_events_max_block_range: NonZeroU64::new(10000).unwrap(),
             ..Default::default()
         }
         .connect(vec![l1_url])

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -957,6 +957,7 @@ pub mod testing {
         cmp::max,
         collections::{BTreeMap, HashMap, HashSet},
         net::Ipv4Addr,
+        num::NonZeroU64,
         time::Duration,
     };
 
@@ -1527,7 +1528,7 @@ pub mod testing {
                 l1_url: anvil_provider.anvil().endpoint().parse().unwrap(),
                 l1_opt: L1ClientOptions {
                     stake_table_update_interval: Duration::from_secs(5),
-                    l1_events_max_block_range: 1000,
+                    l1_events_max_block_range: NonZeroU64::new(1000).unwrap(),
                     l1_polling_interval: Duration::from_secs(1),
                     subscription_timeout: Duration::from_secs(5),
                     ..Default::default()

--- a/crates/espresso/node/src/options.rs
+++ b/crates/espresso/node/src/options.rs
@@ -977,7 +977,7 @@ impl From<&L1ClientOptions> for L1Tuning {
             polling_interval: o.l1_polling_interval,
             blocks_cache_size: o.l1_blocks_cache_size.get(),
             events_channel_capacity: o.l1_events_channel_capacity,
-            events_max_block_range: o.l1_events_max_block_range,
+            events_max_block_range: o.l1_events_max_block_range.get(),
             subscription_timeout: o.subscription_timeout,
             frequent_failure_tolerance: o.l1_frequent_failure_tolerance,
             consecutive_failure_tolerance: o.l1_consecutive_failure_tolerance,

--- a/crates/espresso/node/src/persistence.rs
+++ b/crates/espresso/node/src/persistence.rs
@@ -198,7 +198,10 @@ pub trait ChainConfigPersistence: Sized + Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use std::{cmp::max, collections::BTreeMap, marker::PhantomData, sync::Arc, time::Duration};
+    use std::{
+        cmp::max, collections::BTreeMap, marker::PhantomData, num::NonZeroU64, sync::Arc,
+        time::Duration,
+    };
 
     use alloy::{
         network::EthereumWallet,
@@ -2541,7 +2544,7 @@ mod tests {
         let l1_client = L1ClientOptions {
             stake_table_update_interval: Duration::from_secs(7),
             l1_retry_delay: Duration::from_millis(10),
-            l1_events_max_block_range: 10000,
+            l1_events_max_block_range: NonZeroU64::new(10000).unwrap(),
             ..Default::default()
         }
         .connect(vec![l1_url])

--- a/crates/espresso/types/src/v0/impls/l1.rs
+++ b/crates/espresso/types/src/v0/impls/l1.rs
@@ -977,18 +977,21 @@ impl L1Client {
 
         // Divide the range `prev_finalized..=new_finalized` into chunks of size
         // `events_max_block_range`.
-        let mut start = prev;
-        let end = new_finalized;
         let chunk_size = opt.l1_events_max_block_range;
+        // `start = None` marks exhaustion, distinct from a chunk ending at `u64::MAX`.
+        let mut start = Some(prev);
         let chunks = std::iter::from_fn(move || {
-            let chunk_end = min(start + chunk_size - 1, end);
-            if chunk_end < start {
+            let chunk_start = start?;
+            if chunk_start > new_finalized {
                 return None;
             }
 
-            let chunk = (start, chunk_end);
-            start = chunk_end + 1;
-            Some(chunk)
+            let chunk_end = min(
+                chunk_start.saturating_add(chunk_size.get() - 1),
+                new_finalized,
+            );
+            start = chunk_end.checked_add(1);
+            Some((chunk_start, chunk_end))
         });
 
         // Fetch events for each chunk.
@@ -1134,7 +1137,7 @@ async fn fetch_finalized_block_from_rpc(
 
 #[cfg(test)]
 mod test {
-    use std::{ops::Add, time::Duration};
+    use std::{num::NonZeroU64, ops::Add, time::Duration};
 
     use alloy::{
         eips::BlockNumberOrTag,
@@ -1152,7 +1155,7 @@ mod test {
         f: impl FnOnce(&mut L1ClientOptions),
     ) -> L1Client {
         let mut opt = L1ClientOptions {
-            l1_events_max_block_range: 1,
+            l1_events_max_block_range: NonZeroU64::MIN,
             l1_polling_interval: Duration::from_secs(1),
             subscription_timeout: Duration::from_secs(5),
             ..Default::default()
@@ -1174,6 +1177,16 @@ mod test {
             }
         })
         .await
+    }
+
+    #[test]
+    fn test_l1_events_max_block_range_rejects_zero() {
+        let err = L1ClientOptions::try_parse_from(["test", "--l1-events-max-block-range", "0"])
+            .expect_err("a block range of 0 should be rejected");
+        assert!(
+            err.to_string().contains("l1-events-max-block-range"),
+            "error should reference the offending flag: {err}"
+        );
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::min,
     collections::{HashMap, HashSet},
+    num::NonZeroU64,
     str::FromStr,
     time::{Duration, Instant},
 };
@@ -1379,18 +1380,18 @@ impl Fetcher {
     fn block_range_chunks(
         from_block: u64,
         to_block: u64,
-        chunk_size: u64,
+        chunk_size: NonZeroU64,
     ) -> impl Iterator<Item = (u64, u64)> {
-        let mut start = from_block;
-        let end = to_block;
+        // `start = None` marks exhaustion, distinct from a chunk ending at `u64::MAX`.
+        let mut start = Some(from_block);
         std::iter::from_fn(move || {
-            let chunk_end = min(start + chunk_size - 1, end);
-            if chunk_end < start {
+            let chunk_start = start?;
+            if chunk_start > to_block {
                 return None;
             }
-            let chunk = (start, chunk_end);
-            start = chunk_end + 1;
-            Some(chunk)
+            let chunk_end = min(chunk_start.saturating_add(chunk_size.get() - 1), to_block);
+            start = chunk_end.checked_add(1);
+            Some((chunk_start, chunk_end))
         })
     }
 
@@ -1678,7 +1679,7 @@ impl Fetcher {
         stake_table_init_block: u64,
         token: EspTokenInstance<L1Provider>,
     ) -> Result<Log, FetchRewardError> {
-        let max_events_range = self.l1_client.options().l1_events_max_block_range;
+        let max_events_range = self.l1_client.options().l1_events_max_block_range.get();
         const MAX_BLOCKS_SCANNED: u64 = 200_000;
         let mut total_scanned = 0;
 
@@ -3129,7 +3130,7 @@ mod tests {
     ) {
         let l1 = L1ClientOptions {
             l1_events_max_retry_duration: Duration::from_secs(120),
-            l1_events_max_block_range: 10_000,
+            l1_events_max_block_range: NonZeroU64::new(10_000).unwrap(),
             l1_retry_delay: Duration::from_secs(2),
             ..Default::default()
         }
@@ -3210,7 +3211,7 @@ mod tests {
         let l1 = L1ClientOptions {
             l1_events_max_retry_duration: Duration::from_secs(30),
             // max block range for public node rpc is 50000 so this should result in a panic
-            l1_events_max_block_range: 10_u64.pow(9),
+            l1_events_max_block_range: NonZeroU64::new(10_u64.pow(9)).unwrap(),
             l1_retry_delay: Duration::from_secs(1),
             ..Default::default()
         }
@@ -4805,6 +4806,24 @@ mod tests {
                 .unwrap()
                 .stake_table_key,
             prior_v2
+        );
+    }
+
+    #[test]
+    fn test_block_range_chunks_near_u64_max() {
+        let chunk_size = NonZeroU64::new(100).unwrap();
+        let from = u64::MAX - 250;
+        let to = u64::MAX;
+
+        let chunks: Vec<_> = Fetcher::block_range_chunks(from, to, chunk_size).collect();
+
+        assert_eq!(
+            chunks,
+            vec![
+                (u64::MAX - 250, u64::MAX - 151),
+                (u64::MAX - 150, u64::MAX - 51),
+                (u64::MAX - 50, u64::MAX),
+            ]
         );
     }
 }

--- a/crates/espresso/types/src/v0/v0_1/l1.rs
+++ b/crates/espresso/types/src/v0/v0_1/l1.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "node")]
 use std::time::Instant;
-use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{
+    num::{NonZeroU64, NonZeroUsize},
+    sync::Arc,
+    time::Duration,
+};
 
 use alloy::primitives::{B256, U256};
 #[cfg(feature = "node")]
@@ -111,7 +115,7 @@ pub struct L1ClientOptions {
         env = "ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE",
         default_value = "10000"
     )]
-    pub l1_events_max_block_range: u64,
+    pub l1_events_max_block_range: NonZeroU64,
 
     /// Maximum time to wait for new heads before considering a stream invalid and reconnecting.
     #[clap(


### PR DESCRIPTION
Both block-range chunkers compute `start + chunk_size - 1`, which underflows to
`u64::MAX` when the chunk size is 0, and nothing rejected
`ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE=0`. Make the invariant a type.

Type change only, no behaviour change. `L1Tuning` keeps `u64` via `.get()` so
the reflected-config JSON shape is unchanged.

Conflicts trivially with 1/6, which deletes a test this PR converts a literal
in. Merge 1/6 first.