### PR TITLE
fix(l1): classify RPC error flavors and count them per provider 4/6

### DIFF
--- a/crates/espresso/types/src/v0/impls/l1.rs
+++ b/crates/espresso/types/src/v0/impls/l1.rs
@@ -53,6 +53,7 @@ use super::{L1BlockInfo, v0_1::L1BlockInfoWithParent};
 #[cfg(feature = "node")]
 use super::{
     L1ClientMetrics, L1State, L1UpdateTask,
+    l1_error::{RpcErrorKind, classify},
     v0_1::{SingleTransport, SingleTransportStatus, SwitchingTransport},
 };
 use crate::L1ClientOptions;
@@ -173,6 +174,13 @@ impl L1ClientMetrics {
             failure_metrics.push(failures.create(vec![url_index.to_string()]));
         }
 
+        // No provider label here; a separate PR owns that dimension.
+        let error_family = metrics.counter_family("errors".into(), vec!["kind".into()]);
+        let errors = RpcErrorKind::ALL_LABELS
+            .into_iter()
+            .map(|label| (label, error_family.create(vec![label.to_string()])))
+            .collect();
+
         Self {
             head: metrics.create_gauge("head".into(), None).into(),
             finalized: metrics.create_gauge("finalized".into(), None).into(),
@@ -181,6 +189,7 @@ impl L1ClientMetrics {
                 .into(),
             failovers: metrics.create_counter("failovers".into(), None).into(),
             failures: Arc::new(failure_metrics),
+            errors: Arc::new(errors),
         }
     }
 }
@@ -376,16 +385,22 @@ impl Service<RequestPacket> for SwitchingTransport {
                         f.add(1);
                     }
 
+                    let kind = classify(&err);
+                    if let Some(counter) = self_clone.metrics.errors.get(kind.label()) {
+                        counter.add(1);
+                    }
+
                     // Treat rate limited errors specially; these should not cause failover, but instead
                     // should only cause us to temporarily back off on making requests to the RPC
-                    // server.
-                    if let RpcError::ErrorResp(e) = &err {
-                        // 429 == Too Many Requests
-                        if e.code == 429 {
-                            current_transport.status.write().rate_limited_until =
-                                Some(Instant::now() + self_clone.opt.rate_limit_delay());
-                            return Err(err);
-                        }
+                    // server. The JSON-RPC code for a rate limit varies by provider (infura
+                    // -32005, quicknode -32007, ...) and is never the HTTP 429 status, so
+                    // `classify` looks at the message rather than a single code.
+                    if let RpcErrorKind::RateLimited { retry_after } = kind {
+                        let delay =
+                            retry_after.unwrap_or_else(|| self_clone.opt.rate_limit_delay());
+                        current_transport.status.write().rate_limited_until =
+                            Some(Instant::now() + delay);
+                        return Err(err);
                     }
 
                     // Log the error and indicate a failure
@@ -1144,6 +1159,10 @@ mod test {
     };
     use espresso_contract_deployer::{Contracts, deploy_fee_contract_proxy};
     use time::OffsetDateTime;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
 
     use super::*;
 
@@ -1699,6 +1718,58 @@ mod test {
         // Eventually we revert back to the primary and requests fail again.
         sleep(Duration::from_millis(2100)).await;
         provider.get_block_number().await.unwrap_err();
+    }
+
+    /// Spawns a server that always returns HTTP 429 with the given JSON-RPC error body, just
+    /// enough to drive alloy's HTTP transport for one negative-path assertion.
+    async fn spawn_rate_limited_server(code: i64, message: &'static str) -> Url {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 4096];
+                    let _ = socket.read(&mut buf).await;
+                    let body = format!(
+                        r#"{{"jsonrpc":"2.0","id":1,"error":{{"code":{code},"message":"{message}"}}}}"#
+                    );
+                    let response = format!(
+                        "HTTP/1.1 429 Too Many Requests\r\nContent-Type: \
+                         application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        format!("http://{addr}").parse().unwrap()
+    }
+
+    // Regression test for the bug fixed alongside `classify`: `e.code` is the JSON-RPC code, not
+    // the HTTP status, so infura's -32005 rate limit was never recognized by the old `e.code ==
+    // 429` check and caused a failover instead of a backoff.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_rate_limited_error_does_not_trigger_failover() {
+        let anvil = Anvil::new().block_time(1).spawn();
+        let rate_limited_url =
+            spawn_rate_limited_server(-32005, "daily request count exceeded, request rate limited")
+                .await;
+
+        let provider = L1ClientOptions {
+            l1_consecutive_failure_tolerance: 1,
+            ..Default::default()
+        }
+        .connect(vec![rate_limited_url, anvil.endpoint_url()])
+        .expect("Failed to create L1 client");
+
+        // A tolerance of 1 would fail over on any ordinary failure. The rate-limited error must
+        // instead be recognized and handled without switching providers.
+        provider.get_block_number().await.unwrap_err();
+        assert_eq!(get_failover_index(&provider), 0);
     }
 
     // Checks that the L1 client initialized the state on startup even

--- a/crates/espresso/types/src/v0/impls/l1_error.rs
+++ b/crates/espresso/types/src/v0/impls/l1_error.rs
@@ -15,7 +15,7 @@ use alloy::transports::{HttpError, RpcError, TransportErrorKind};
 /// free-tier `eth_getLogs` cap) and [`Self::AuthFailed`] (alchemy's inactive-key rejection), so the
 /// message content, not the code alone, drives the decision.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum RpcErrorKind {
+pub(crate) enum RpcErrorKind {
     /// The requested block range exceeds a provider-side cap. `suggested` is the cap the
     /// provider's message names, when it names one.
     RangeTooLarge { suggested: Option<u64> },
@@ -35,7 +35,7 @@ pub enum RpcErrorKind {
 
 impl RpcErrorKind {
     /// Every label `label()` can return, for pre-registering one metric per kind.
-    pub const ALL_LABELS: [&'static str; 6] = [
+    pub(crate) const ALL_LABELS: [&'static str; 6] = [
         "range_too_large",
         "too_many_results",
         "rate_limited",
@@ -45,7 +45,7 @@ impl RpcErrorKind {
     ];
 
     /// Stable label used as the `kind` value of the `consensus_l1_errors` metric.
-    pub fn label(&self) -> &'static str {
+    pub(crate) fn label(&self) -> &'static str {
         match self {
             Self::RangeTooLarge { .. } => "range_too_large",
             Self::TooManyResults => "too_many_results",
@@ -59,7 +59,7 @@ impl RpcErrorKind {
 
 /// Classify an L1 RPC error. Pure: no network access, no allocation beyond the small string
 /// searches needed to inspect the provider's message.
-pub fn classify(err: &RpcError<TransportErrorKind>) -> RpcErrorKind {
+pub(crate) fn classify(err: &RpcError<TransportErrorKind>) -> RpcErrorKind {
     match err {
         RpcError::ErrorResp(e) => classify_json_rpc(e.code, &e.message),
         RpcError::Transport(kind) => classify_transport(kind),

--- a/crates/espresso/types/src/v0/impls/l1_error.rs
+++ b/crates/espresso/types/src/v0/impls/l1_error.rs
@@ -1,0 +1,257 @@
+//! Classification of L1 RPC errors into flavors that later stages can react to.
+//!
+//! Providers reject `eth_getLogs` calls in ways that are deterministic (a range or result-count
+//! cap, an inactive API key) and will never succeed no matter how many times the node retries.
+//! `classify` turns the opaque [`RpcError`] into an [`RpcErrorKind`] so callers can stop retrying
+//! the impossible instead of burning their retry budget on it.
+
+use std::time::Duration;
+
+use alloy::transports::{HttpError, RpcError, TransportErrorKind};
+
+/// The flavor of an L1 RPC error, as distinguished by JSON-RPC code and message content.
+///
+/// `-32600` (Invalid Request) is reused by providers for both [`Self::RangeTooLarge`] (alchemy's
+/// free-tier `eth_getLogs` cap) and [`Self::AuthFailed`] (alchemy's inactive-key rejection), so the
+/// message content, not the code alone, drives the decision.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RpcErrorKind {
+    /// The requested block range exceeds a provider-side cap. `suggested` is the cap the
+    /// provider's message names, when it names one.
+    RangeTooLarge { suggested: Option<u64> },
+    /// The query matched more results than the provider will return, independent of block range.
+    TooManyResults,
+    /// The provider is throttling this key. `retry_after` is the provider's hinted backoff.
+    RateLimited { retry_after: Option<Duration> },
+    /// The provider rejected the request because the API key/app is disabled. Never transient:
+    /// alchemy's `App is inactive` is 50,358 of the observed fleet failures and none of them
+    /// ever succeeded on retry.
+    AuthFailed,
+    /// A generic, presumably short-lived, server or gateway failure worth retrying.
+    Transient,
+    /// Recognized as an error but not classifiable into any of the above.
+    Unknown,
+}
+
+impl RpcErrorKind {
+    /// Every label `label()` can return, for pre-registering one metric per kind.
+    pub const ALL_LABELS: [&'static str; 6] = [
+        "range_too_large",
+        "too_many_results",
+        "rate_limited",
+        "auth_failed",
+        "transient",
+        "unknown",
+    ];
+
+    /// Stable label used as the `kind` value of the `consensus_l1_errors` metric.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::RangeTooLarge { .. } => "range_too_large",
+            Self::TooManyResults => "too_many_results",
+            Self::RateLimited { .. } => "rate_limited",
+            Self::AuthFailed => "auth_failed",
+            Self::Transient => "transient",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Classify an L1 RPC error. Pure: no network access, no allocation beyond the small string
+/// searches needed to inspect the provider's message.
+pub fn classify(err: &RpcError<TransportErrorKind>) -> RpcErrorKind {
+    match err {
+        RpcError::ErrorResp(e) => classify_json_rpc(e.code, &e.message),
+        RpcError::Transport(kind) => classify_transport(kind),
+        _ => RpcErrorKind::Unknown,
+    }
+}
+
+/// Providers commonly reject non-2xx `eth_getLogs` calls with the JSON-RPC error object embedded
+/// in the HTTP body rather than in a parsed [`RpcError::ErrorResp`], since alloy's HTTP transport
+/// only produces `ErrorResp` for 2xx responses. Recover the same code/message pair from the body
+/// when possible, and fall back to the HTTP status alone otherwise.
+fn classify_transport(kind: &TransportErrorKind) -> RpcErrorKind {
+    let TransportErrorKind::HttpError(http_err) = kind else {
+        return RpcErrorKind::Transient;
+    };
+    match extract_json_rpc_error(http_err) {
+        Some((code, message)) => classify_json_rpc(code, &message),
+        None => classify_http_status(http_err.status),
+    }
+}
+
+/// Parses `{"error": {"code": ..., "message": ...}}` or a bare `{"code": ..., "message": ...}`
+/// out of an HTTP error body.
+fn extract_json_rpc_error(http_err: &HttpError) -> Option<(i64, String)> {
+    let value: serde_json::Value = serde_json::from_str(&http_err.body).ok()?;
+    let error = value.get("error").unwrap_or(&value);
+    let code = error.get("code")?.as_i64()?;
+    let message = error.get("message")?.as_str()?.to_owned();
+    Some((code, message))
+}
+
+fn classify_http_status(status: u16) -> RpcErrorKind {
+    match status {
+        429 => RpcErrorKind::RateLimited { retry_after: None },
+        403 => RpcErrorKind::AuthFailed,
+        408 | 502 | 503 | 504 => RpcErrorKind::Transient,
+        _ => RpcErrorKind::Unknown,
+    }
+}
+
+fn classify_json_rpc(code: i64, message: &str) -> RpcErrorKind {
+    let lower = message.to_ascii_lowercase();
+
+    if lower.contains("block range") {
+        return RpcErrorKind::RangeTooLarge {
+            suggested: suggested_range(&lower),
+        };
+    }
+    if lower.contains("app is inactive") {
+        return RpcErrorKind::AuthFailed;
+    }
+    if lower.contains("too many requests")
+        || lower.contains("request limit reached")
+        || matches!(code, 429 | -32005 | -32007)
+    {
+        return RpcErrorKind::RateLimited {
+            retry_after: parse_retry_after(&lower),
+        };
+    }
+    if lower.contains("more than") && lower.contains("results") {
+        return RpcErrorKind::TooManyResults;
+    }
+    if lower.contains("temporarily unavailable")
+        || lower.contains("timed out")
+        || lower.contains("no available upstreams")
+        || code == -32603
+    {
+        return RpcErrorKind::Transient;
+    }
+    RpcErrorKind::Unknown
+}
+
+/// Extracts the block-range hint a provider embeds in its own message, e.g. "up to a 10 block
+/// range" -> `Some(10)`. Providers that only say the range is "too large" give no number.
+fn suggested_range(lower_message: &str) -> Option<u64> {
+    let before = &lower_message[..lower_message.find("block range")?];
+    before.split_whitespace().last()?.parse().ok()
+}
+
+/// Parses a provider-supplied backoff hint, e.g. "try again in 4ms" or "try again in 2s".
+fn parse_retry_after(lower_message: &str) -> Option<Duration> {
+    let after = lower_message.split_once("try again in ")?.1.trim_start();
+    let digits_len = after.bytes().take_while(u8::is_ascii_digit).count();
+    let (digits, unit) = after.split_at(digits_len);
+    let value: u64 = digits.parse().ok()?;
+    match unit
+        .trim()
+        .trim_end_matches(|c: char| c.is_ascii_punctuation())
+    {
+        "ms" => Some(Duration::from_millis(value)),
+        "s" => Some(Duration::from_secs(value)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloy::rpc::json_rpc::ErrorPayload;
+
+    use super::*;
+
+    /// A `RpcError::ErrorResp`, as produced for a 2xx response whose body carries a JSON-RPC
+    /// error object.
+    fn error_resp(code: i64, message: &str) -> RpcError<TransportErrorKind> {
+        RpcError::ErrorResp(ErrorPayload {
+            code,
+            message: message.to_owned().into(),
+            data: None,
+        })
+    }
+
+    /// A `RpcError::Transport(HttpError)`, as produced for a non-2xx response. `body` is the raw
+    /// HTTP response body, which providers commonly fill with a JSON-RPC error object even though
+    /// alloy does not parse it as one at this status.
+    fn http_error(status: u16, body: impl Into<String>) -> RpcError<TransportErrorKind> {
+        TransportErrorKind::http_error(status, body.into())
+    }
+
+    fn json_rpc_body(code: i64, message: &str) -> String {
+        format!(r#"{{"jsonrpc":"2.0","id":1,"error":{{"code":{code},"message":"{message}"}}}}"#)
+    }
+
+    // Verbatim fleet telemetry, see doc/l1-robustness.md A2.3.
+    #[test]
+    fn classify_alchemy_free_tier_range() {
+        let msg = "Under the Free tier plan, you can make eth_getLogs requests with up to a 10 \
+                   block range";
+        let err = http_error(400, json_rpc_body(-32600, msg));
+        assert_eq!(
+            classify(&err),
+            RpcErrorKind::RangeTooLarge {
+                suggested: Some(10)
+            }
+        );
+    }
+
+    #[test]
+    fn classify_getblock_range_too_large() {
+        let err = error_resp(-32062, "Block range is too large");
+        assert_eq!(
+            classify(&err),
+            RpcErrorKind::RangeTooLarge { suggested: None }
+        );
+    }
+
+    #[test]
+    fn classify_alchemy_app_inactive() {
+        let msg = "App is inactive. Please create a new app";
+        let err = http_error(403, json_rpc_body(-32600, msg));
+        assert_eq!(classify(&err), RpcErrorKind::AuthFailed);
+    }
+
+    #[test]
+    fn classify_infura_too_many_requests() {
+        let err = http_error(429, json_rpc_body(-32005, "Too Many Requests"));
+        assert!(matches!(classify(&err), RpcErrorKind::RateLimited { .. }));
+    }
+
+    #[test]
+    fn classify_quicknode_request_limit() {
+        let msg = "50/second request limit reached";
+        let err = http_error(429, json_rpc_body(-32007, msg));
+        assert!(matches!(classify(&err), RpcErrorKind::RateLimited { .. }));
+    }
+
+    #[test]
+    fn classify_infura_service_unavailable() {
+        let err = error_resp(-32603, "service temporarily unavailable");
+        assert_eq!(classify(&err), RpcErrorKind::Transient);
+    }
+
+    #[test]
+    fn classify_request_timed_out() {
+        let err = http_error(408, json_rpc_body(-32009, "Request timed out"));
+        assert_eq!(classify(&err), RpcErrorKind::Transient);
+    }
+
+    #[test]
+    fn classify_no_available_upstreams() {
+        let err = error_resp(1, "no available upstreams to process a request");
+        assert_eq!(classify(&err), RpcErrorKind::Transient);
+    }
+
+    #[test]
+    fn classify_bad_gateway() {
+        let err = http_error(502, "Bad Gateway");
+        assert_eq!(classify(&err), RpcErrorKind::Transient);
+    }
+
+    #[test]
+    fn classify_unknown_block() {
+        let err = http_error(400, json_rpc_body(26, "Unknown block"));
+        assert_eq!(classify(&err), RpcErrorKind::Unknown);
+    }
+}

--- a/crates/espresso/types/src/v0/impls/mod.rs
+++ b/crates/espresso/types/src/v0/impls/mod.rs
@@ -7,6 +7,8 @@ mod fee_info;
 mod header;
 mod instance_state;
 mod l1;
+#[cfg(feature = "node")]
+mod l1_error;
 pub mod reward;
 mod stake_table;
 mod state;
@@ -20,6 +22,8 @@ pub use fee_info::{FeeError, retain_accounts};
 #[cfg(any(test, feature = "testing"))]
 pub use instance_state::mock;
 pub use instance_state::{NodeState, UpgradeMap};
+#[cfg(feature = "node")]
+pub use l1_error::{RpcErrorKind, classify};
 pub use reward::*;
 pub use stake_table::*;
 pub use state::{

--- a/crates/espresso/types/src/v0/impls/mod.rs
+++ b/crates/espresso/types/src/v0/impls/mod.rs
@@ -22,8 +22,6 @@ pub use fee_info::{FeeError, retain_accounts};
 #[cfg(any(test, feature = "testing"))]
 pub use instance_state::mock;
 pub use instance_state::{NodeState, UpgradeMap};
-#[cfg(feature = "node")]
-pub use l1_error::{RpcErrorKind, classify};
 pub use reward::*;
 pub use stake_table::*;
 pub use state::{

--- a/crates/espresso/types/src/v0/mod.rs
+++ b/crates/espresso/types/src/v0/mod.rs
@@ -176,6 +176,8 @@ pub type NetworkConfig = hotshot_types::network::NetworkConfig<SeqTypes>;
 pub use self::impls::{
     AuthenticatedValidatorMap, NodeState, RegisteredValidatorMap, UpgradeMap, ValidatedState,
 };
+#[cfg(feature = "node")]
+pub use self::impls::{RpcErrorKind, classify};
 pub use crate::{
     v0::impls::{
         StakeTableHash, StakeTableState, calculate_proportion_staked_and_reward_rate,

--- a/crates/espresso/types/src/v0/mod.rs
+++ b/crates/espresso/types/src/v0/mod.rs
@@ -176,8 +176,6 @@ pub type NetworkConfig = hotshot_types::network::NetworkConfig<SeqTypes>;
 pub use self::impls::{
     AuthenticatedValidatorMap, NodeState, RegisteredValidatorMap, UpgradeMap, ValidatedState,
 };
-#[cfg(feature = "node")]
-pub use self::impls::{RpcErrorKind, classify};
 pub use crate::{
     v0::impls::{
         StakeTableHash, StakeTableState, calculate_proportion_staked_and_reward_rate,

--- a/crates/espresso/types/src/v0/v0_1/l1.rs
+++ b/crates/espresso/types/src/v0/v0_1/l1.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "node")]
-use std::time::Instant;
+use std::{collections::HashMap, time::Instant};
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use alloy::primitives::{B256, U256};
@@ -279,6 +279,8 @@ pub(crate) struct L1ClientMetrics {
     pub(crate) reconnects: Arc<dyn Counter>,
     pub(crate) failovers: Arc<dyn Counter>,
     pub(crate) failures: Arc<Vec<Box<dyn Counter>>>,
+    /// Count of L1 errors by `RpcErrorKind::label()`, independent of provider.
+    pub(crate) errors: Arc<HashMap<&'static str, Box<dyn Counter>>>,
 }
 
 /// An RPC client with multiple remote (HTTP) providers.


### PR DESCRIPTION
The rate-limit branch never fired. It checked `e.code == 429` on
`RpcError::ErrorResp`, but 429 is an HTTP status, not a JSON-RPC code (infura
sends -32005, quicknode -32007), and alloy only produces `ErrorResp` for 2xx
responses -- a 429 arrives as `TransportErrorKind::HttpError`. So rate-limited
errors fell through to the ordinary failure path and counted toward failover
tolerance, which is the opposite of what the comment above them says.

Adds `classify()` plus a `consensus_l1_errors{kind}` counter so the fleet
reports error flavors. The largest observed classes are deterministic and
unretryable: alchemy's 10-block free-tier `eth_getLogs` cap, and "App is
inactive" (50,358 occurrences in 14.3h, zero successes on retry).

Behaviour change, not just instrumentation: failover timing on rate-limited
providers changes.