### PR TITLE
fix(catchup): retry V2 reward merkle tree fetches and stop latching failed epoch reward calculations

### DIFF
--- a/crates/espresso/node/src/catchup.rs
+++ b/crates/espresso/node/src/catchup.rs
@@ -1579,6 +1579,51 @@ impl StateCatchup for ParallelStateCatchup {
         .await
     }
 
+    async fn fetch_reward_merkle_tree_v2(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        reward_merkle_tree_root: RewardMerkleCommitmentV2,
+        accounts: Arc<Vec<RewardAccountV2>>,
+    ) -> anyhow::Result<PermittedRewardMerkleTreeV2> {
+        // Try to get the tree from local providers first
+        let local_result = self
+            .on_local_providers(clone! {(accounts) move |provider| {
+                clone! {(accounts) async move {
+                    provider
+                        .try_fetch_reward_merkle_tree_v2(
+                            0,
+                            height,
+                            view,
+                            reward_merkle_tree_root,
+                            accounts,
+                        )
+                        .await
+                }}
+            }})
+            .await;
+
+        // Check if we were successful locally
+        match &local_result {
+            Ok(_) => return local_result,
+            Err(err) => tracing::debug!("{err:#}"),
+        }
+
+        // If that fails, try the remote ones (with retry)
+        self.on_remote_providers(clone! {(accounts) move |provider| {
+            clone!{(accounts) async move {
+                provider
+                .fetch_reward_merkle_tree_v2(
+                    height,
+                    view,
+                    reward_merkle_tree_root,
+                    accounts,
+                ).await
+            }}
+        }})
+        .await
+    }
+
     async fn fetch_reward_accounts_v1(
         &self,
         instance: &NodeState,
@@ -1873,7 +1918,136 @@ where
 
 #[cfg(test)]
 mod test {
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    use espresso_types::v0_4::REWARD_MERKLE_TREE_V2_HEIGHT;
+
     use super::*;
+
+    /// A remote catchup provider whose reward merkle tree fetch fails a fixed
+    /// number of times before succeeding, for testing retry behavior.
+    #[derive(Debug)]
+    struct FlakyRewardTreeProvider {
+        attempts: AtomicUsize,
+        failures_before_success: usize,
+        backoff: BackoffParams,
+    }
+
+    #[async_trait]
+    impl StateCatchup for FlakyRewardTreeProvider {
+        async fn try_fetch_leaf(
+            &self,
+            _retry: usize,
+            _coordinator: EpochMembershipCoordinator<SeqTypes>,
+            _height: u64,
+        ) -> anyhow::Result<Leaf2> {
+            bail!("not implemented");
+        }
+
+        async fn try_fetch_accounts(
+            &self,
+            _retry: usize,
+            _instance: &NodeState,
+            _height: u64,
+            _view: ViewNumber,
+            _fee_merkle_tree_root: FeeMerkleCommitment,
+            _accounts: &[FeeAccount],
+        ) -> anyhow::Result<Vec<FeeAccountProof>> {
+            bail!("not implemented");
+        }
+
+        async fn try_remember_blocks_merkle_tree(
+            &self,
+            _retry: usize,
+            _instance: &NodeState,
+            _height: u64,
+            _view: ViewNumber,
+            _mt: &mut BlockMerkleTree,
+        ) -> anyhow::Result<()> {
+            bail!("not implemented");
+        }
+
+        async fn try_fetch_chain_config(
+            &self,
+            _retry: usize,
+            _commitment: Commitment<ChainConfig>,
+        ) -> anyhow::Result<ChainConfig> {
+            bail!("not implemented");
+        }
+
+        async fn try_fetch_reward_merkle_tree_v2(
+            &self,
+            _retry: usize,
+            _height: u64,
+            _view: ViewNumber,
+            _reward_merkle_tree_root: RewardMerkleCommitmentV2,
+            _accounts: Arc<Vec<RewardAccountV2>>,
+        ) -> anyhow::Result<PermittedRewardMerkleTreeV2> {
+            let attempt = self.attempts.fetch_add(1, AtomicOrdering::SeqCst);
+            ensure!(
+                attempt >= self.failures_before_success,
+                "transient failure on attempt {attempt}"
+            );
+            PermittedRewardMerkleTreeV2::try_from_kv_set(vec![]).await
+        }
+
+        async fn try_fetch_reward_accounts_v1(
+            &self,
+            _retry: usize,
+            _instance: &NodeState,
+            _height: u64,
+            _view: ViewNumber,
+            _reward_merkle_tree_root: RewardMerkleCommitmentV1,
+            _accounts: &[RewardAccountV1],
+        ) -> anyhow::Result<Vec<RewardAccountProofV1>> {
+            bail!("not implemented");
+        }
+
+        async fn try_fetch_state_cert(
+            &self,
+            _retry: usize,
+            _epoch: u64,
+        ) -> anyhow::Result<LightClientStateUpdateCertificateV2<SeqTypes>> {
+            bail!("not implemented");
+        }
+
+        fn backoff(&self) -> &BackoffParams {
+            &self.backoff
+        }
+
+        fn name(&self) -> String {
+            "FlakyRewardTreeProvider".into()
+        }
+
+        fn is_local(&self) -> bool {
+            false
+        }
+    }
+
+    /// Regression test: `ParallelStateCatchup` must retry reward merkle tree
+    /// fetches on remote providers. It has backoff disabled itself, so without
+    /// a `fetch_reward_merkle_tree_v2` override delegating to the provider's
+    /// own retrying fetch, a single transient failure is fatal.
+    #[tokio::test]
+    async fn test_reward_merkle_tree_v2_fetch_retries() {
+        let provider = Arc::new(FlakyRewardTreeProvider {
+            attempts: AtomicUsize::new(0),
+            failures_before_success: 1,
+            backoff: BackoffParams::default(),
+        });
+        let catchup = ParallelStateCatchup::new(
+            &[provider.clone() as Arc<dyn StateCatchup>],
+            Duration::from_secs(1),
+        );
+
+        let root = RewardMerkleTreeV2::new(REWARD_MERKLE_TREE_V2_HEIGHT).commitment();
+        catchup
+            .fetch_reward_merkle_tree_v2(1, ViewNumber::new(0), root, Arc::new(vec![]))
+            .await
+            .expect("fetch should succeed after a transient failure");
+
+        assert_eq!(provider.attempts.load(AtomicOrdering::SeqCst), 2);
+    }
 
     #[test]
     fn test_peer_priority() {

--- a/crates/espresso/types/src/v0/impls/header.rs
+++ b/crates/espresso/types/src/v0/impls/header.rs
@@ -866,10 +866,10 @@ impl Header {
     ///   validation.
     ///
     /// If the previous epoch's result is missing at the boundary (e.g. after a
-    /// restart), the function spawns the calculation and awaits it before
-    /// applying. The background task fetches the epoch's leaf and recovers the
-    /// leader counts and stake table itself, returning zero rewards for epochs
-    /// whose header version is < V5
+    /// restart) or the background attempt failed, the function spawns a fresh
+    /// calculation and awaits it before applying. The background task fetches
+    /// the epoch's leaf and recovers the leader counts and stake table itself,
+    /// returning zero rewards for epochs whose header version is < V5
     ///
     /// # Returns
     /// `(total_rewards_applied, changed_accounts)` — the total reward amount
@@ -902,16 +902,28 @@ impl Header {
 
         // Eagerly start the previous epoch's reward calculation if it hasn't
         // been kicked off yet, so the result is ready by the epoch boundary.
-        if epoch > first_epoch + 2 && !reward_calculator.is_calculating(prev_epoch) {
-            tracing::info!(%epoch, %prev_epoch, "triggering catchup reward calculation");
-            reward_calculator.spawn_background_task(
-                prev_epoch,
-                epoch_height,
-                validated_state.reward_merkle_tree_v2.clone(),
-                instance_state.clone(),
-                coordinator.clone(),
-                None,
-            );
+        // A background attempt that already failed is cleared here so it is
+        // retried on the next block instead of staying latched until the
+        // boundary.
+        if epoch > first_epoch + 2 {
+            if let Some(err) = reward_calculator.reap_finished_task(prev_epoch).await {
+                tracing::warn!(
+                    %epoch,
+                    %prev_epoch,
+                    "background epoch rewards calculation failed, respawning: {err:#}"
+                );
+            }
+            if !reward_calculator.is_calculating(prev_epoch) {
+                tracing::info!(%epoch, %prev_epoch, "triggering catchup reward calculation");
+                reward_calculator.spawn_background_task(
+                    prev_epoch,
+                    epoch_height,
+                    validated_state.reward_merkle_tree_v2.clone(),
+                    instance_state.clone(),
+                    coordinator.clone(),
+                    None,
+                );
+            }
         }
 
         if !is_last_block(height, epoch_height) {
@@ -920,9 +932,21 @@ impl Header {
 
         tracing::info!(%height, %epoch, %prev_epoch, "epoch boundary: applying rewards");
 
-        // Take the result. A failed task propagates its
-        // error here rather than retrying
-        let result = reward_calculator.get_result(prev_epoch).await.transpose()?;
+        // Take the result. A background task that failed is treated as missing
+        // so the fallback below recalculates fresh, instead of failing
+        // validation on an error latched earlier in the epoch.
+        let result = match reward_calculator.get_result(prev_epoch).await {
+            Some(Ok(result)) => Some(result),
+            Some(Err(err)) => {
+                tracing::warn!(
+                    %epoch,
+                    %prev_epoch,
+                    "background epoch rewards calculation failed, recalculating: {err:#}"
+                );
+                None
+            },
+            None => None,
+        };
 
         let (epoch_rewards_applied, changed_accounts) = if let Some(result) = result {
             tracing::info!(

--- a/crates/espresso/types/src/v0/impls/reward.rs
+++ b/crates/espresso/types/src/v0/impls/reward.rs
@@ -1069,12 +1069,21 @@ pub struct EpochRewardsResult {
     pub changed_accounts: HashSet<RewardAccountV2>,
 }
 
+/// A background epoch reward calculation: either still running, or already
+/// reaped by [`EpochRewardsCalculator::reap_finished_task`] with its result
+/// cached until [`EpochRewardsCalculator::get_result`] consumes it.
+#[derive(Debug)]
+enum CalcTask {
+    Running(JoinHandle<anyhow::Result<EpochRewardsResult>>),
+    Ready(EpochRewardsResult),
+}
+
 /// Manages a single background epoch reward calculation.
 /// Each consumer (consensus and state loop) should have its own instance.
 #[derive(Debug, Default)]
 pub struct EpochRewardsCalculator {
     /// The currently pending calculation, if any.
-    pending: Option<(EpochNumber, JoinHandle<anyhow::Result<EpochRewardsResult>>)>,
+    pending: Option<(EpochNumber, CalcTask)>,
 }
 
 impl EpochRewardsCalculator {
@@ -1096,12 +1105,17 @@ impl EpochRewardsCalculator {
         &mut self,
         epoch: EpochNumber,
     ) -> Option<anyhow::Result<EpochRewardsResult>> {
-        let (pending_epoch, handle) = self.pending.take()?;
+        let (pending_epoch, task) = self.pending.take()?;
         if pending_epoch != epoch {
             // Not the epoch we're looking for — put the task back.
-            self.pending = Some((pending_epoch, handle));
+            self.pending = Some((pending_epoch, task));
             return None;
         }
+
+        let handle = match task {
+            CalcTask::Ready(result) => return Some(Ok(result)),
+            CalcTask::Running(handle) => handle,
+        };
 
         let result = match handle.await {
             Ok(Ok(result)) => {
@@ -1118,6 +1132,37 @@ impl EpochRewardsCalculator {
             },
         };
         Some(result)
+    }
+
+    /// Consume the outcome of the background task for `epoch` if it has
+    /// already finished: cache a success for a later [`get_result`](Self::get_result),
+    /// or clear a failure — returning the error — so a fresh task can be
+    /// spawned. Unlike `get_result`, this never blocks on a running task.
+    ///
+    /// Without this, a task that failed early in the epoch would stay latched
+    /// until the boundary and fail validation there with a stale error.
+    pub async fn reap_finished_task(&mut self, epoch: EpochNumber) -> Option<anyhow::Error> {
+        let finished = matches!(
+            &self.pending,
+            Some((e, CalcTask::Running(handle))) if *e == epoch && handle.is_finished()
+        );
+        if !finished {
+            return None;
+        }
+
+        let Some((pending_epoch, CalcTask::Running(handle))) = self.pending.take() else {
+            unreachable!("pending was just matched as a finished running task");
+        };
+        // The task is finished, so this await returns immediately.
+        match handle.await {
+            Ok(Ok(result)) => {
+                tracing::info!(%epoch, total = %result.total_distributed.0, "epoch rewards calculation completed");
+                self.pending = Some((pending_epoch, CalcTask::Ready(result)));
+                None
+            },
+            Ok(Err(e)) => Some(e),
+            Err(e) => Some(anyhow::Error::new(e).context("epoch rewards task panicked")),
+        }
     }
 
     /// Start a background task that calculates epoch rewards.
@@ -1138,9 +1183,11 @@ impl EpochRewardsCalculator {
         }
 
         // Abort any stale pending task.
-        if let Some((stale_epoch, handle)) = self.pending.take() {
+        if let Some((stale_epoch, task)) = self.pending.take() {
             tracing::info!(%stale_epoch, %epoch, "aborting stale epoch rewards task");
-            handle.abort();
+            if let CalcTask::Running(handle) = task {
+                handle.abort();
+            }
         }
 
         tracing::info!(
@@ -1160,7 +1207,7 @@ impl EpochRewardsCalculator {
             )
             .await
         });
-        self.pending = Some((epoch, handle));
+        self.pending = Some((epoch, CalcTask::Running(handle)));
     }
 
     async fn fetch_and_calculate(
@@ -1456,5 +1503,71 @@ pub mod tests {
         let rewards = distributor.compute_rewards().unwrap();
         let leader_commission = rewards.leader_commission();
         assert_eq!(*leader_commission, distributor.block_reward);
+    }
+
+    /// Spawn a task with the given outcome and wait for it to finish.
+    async fn finished_task(
+        outcome: anyhow::Result<EpochRewardsResult>,
+    ) -> JoinHandle<anyhow::Result<EpochRewardsResult>> {
+        let handle = tokio::spawn(async move { outcome });
+        while !handle.is_finished() {
+            tokio::task::yield_now().await;
+        }
+        handle
+    }
+
+    #[tokio::test]
+    async fn test_reap_finished_task_clears_failure() {
+        let epoch = EpochNumber::new(3);
+        let handle = finished_task(Err(anyhow::anyhow!("boom"))).await;
+
+        let mut calc = EpochRewardsCalculator::new();
+        calc.pending = Some((epoch, CalcTask::Running(handle)));
+
+        let err = calc
+            .reap_finished_task(epoch)
+            .await
+            .expect("failure should be reaped");
+        assert!(err.to_string().contains("boom"));
+        // The failed task is cleared so a fresh one can be spawned.
+        assert!(!calc.is_calculating(epoch));
+    }
+
+    #[tokio::test]
+    async fn test_reap_finished_task_caches_success() {
+        let epoch = EpochNumber::new(3);
+        let result = EpochRewardsResult {
+            epoch,
+            reward_tree: RewardMerkleTreeV2::new(REWARD_MERKLE_TREE_V2_HEIGHT),
+            total_distributed: RewardAmount(U256::from(42)),
+            changed_accounts: HashSet::new(),
+        };
+        let handle = finished_task(Ok(result)).await;
+
+        let mut calc = EpochRewardsCalculator::new();
+        calc.pending = Some((epoch, CalcTask::Running(handle)));
+
+        assert!(calc.reap_finished_task(epoch).await.is_none());
+        // The cached success still counts as pending and is returned by
+        // `get_result` at the boundary.
+        assert!(calc.is_calculating(epoch));
+        let result = calc
+            .get_result(epoch)
+            .await
+            .expect("result should be pending")
+            .expect("cached result should be a success");
+        assert_eq!(result.total_distributed.0, U256::from(42));
+    }
+
+    #[tokio::test]
+    async fn test_reap_finished_task_ignores_running_task() {
+        let epoch = EpochNumber::new(3);
+        let handle = tokio::spawn(std::future::pending::<anyhow::Result<EpochRewardsResult>>());
+
+        let mut calc = EpochRewardsCalculator::new();
+        calc.pending = Some((epoch, CalcTask::Running(handle)));
+
+        assert!(calc.reap_finished_task(epoch).await.is_none());
+        assert!(calc.is_calculating(epoch), "running task must stay pending");
     }
 }


### PR DESCRIPTION
## Problem

Consensus catchup of the V2 reward merkle tree — the only catchup path used by V5/V6 epoch-boundary reward calculation — effectively had **no retries**, and a failed background rewards calculation **latched its error** until the epoch boundary. Together these meant a single transient failure (a 2s per-peer timeout on the largest catchup payload, a peer that hadn't persisted the boundary tree yet, semaphore contention) could fail header validation at an epoch boundary. Nodes with sparse reward trees (recently restarted or caught-up) would then miss the boundary vote every epoch; with many such nodes at once (rolling restart/upgrade), this could stall consensus at the boundary.

## Changes

**Commit 1 — `fix(catchup): retry reward merkle tree v2 fetches from remote peers`**

`ParallelStateCatchup` overrides every retrying `fetch_*` method *except* `fetch_reward_merkle_tree_v2`, so the trait default ran with the parallel provider's disabled backoff: exactly one attempt, `retry` pinned at 0, per-peer timeout stuck at the 2s base. Add the missing override, matching `fetch_accounts` / `fetch_reward_accounts_v1`: one local attempt, then delegate to the remote providers' own retrying fetch (StatePeers retries with the configured `catchup_backoff` and an escalating per-peer timeout; the request/response protocol retries via `request_indefinitely`).

**Commit 2 — `fix(rewards): recalculate failed epoch rewards instead of latching the error`**

A background epoch rewards task that failed stayed parked in `EpochRewardsCalculator` until the boundary: `is_calculating()` treated the dead task as in-progress so it was never respawned, and at the boundary `get_result()` propagated the stale error, failing validation even when a fresh calculation would succeed. Now:

- `pending` holds `Running(JoinHandle)` / `Ready(result)`; new `reap_finished_task()` consumes a finished task's outcome without blocking — caching a success for the boundary, clearing a failure so it can be respawned.
- The eager per-block spawn in `handle_epoch_rewards` reaps first, so a failed attempt is retried on the next block instead of latching all epoch.
- At the boundary, a failed result is treated as missing and falls into the existing respawn-and-await fallback.

## Where to focus

- The new `ParallelStateCatchup::fetch_reward_merkle_tree_v2` override is line-for-line parallel to `fetch_reward_accounts_v1` directly below it.
- `reap_finished_task` in `reward.rs`: the `Running`/`Ready` split exists because a `JoinHandle` outcome can only be consumed once — confirm the caching semantics (a reaped success still counts as `is_calculating` and is delivered by `get_result`).
- Boundary error handling in `header.rs::handle_epoch_rewards`: `Some(Err)` → warn + fall through to the respawn branch.

## Testing

- New regression test `test_reward_merkle_tree_v2_fetch_retries`: a mock remote provider fails once then succeeds; verified the test fails without the override (one attempt, fatal) and passes with it.
- New unit tests for the calculator: reaped failure is cleared and respawnable; reaped success is cached and returned by `get_result`; a running task is left untouched.
- `espresso-types` suite: 256 passed; the 2 failing `l1::test::test_failover_*` tests also fail on a clean `main` checkout in this environment (need real network access) — unrelated.

## Follow-ups (not in this PR)

- Peer scoring: `StatePeers::try_fetch_reward_merkle_tree_v2` verifies the response outside the per-peer loop, so a peer serving a stale tree is scored as a success and retries keep hitting it first.
- The epoch path requests the tree with `ViewNumber::new(0)`, so the consensus-memory endpoint on peers always misses and only the storage fallback can serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)