### PR TITLE
fix(new-protocol): retry missing-proposal fetches instead of blocking

### DIFF
--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -3,7 +3,7 @@ pub(crate) mod metrics;
 pub mod timer;
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -78,6 +78,13 @@ pub(crate) const VID_RECONSTRUCT_GC_MARGIN: u64 = 5;
 /// storage writes for recent views aren't aborted before they persist.
 const STORAGE_GC_MARGIN: u64 = 5;
 
+/// Views to wait before re-broadcasting a fetch request for a proposal that
+/// is still missing. The network GCs un-ACKed sends once the sender advances
+/// two views past the slot they were stamped with, so a request (or its
+/// responses) can be silently lost; conversely, within that margin the
+/// previous round may still answer, so re-requesting sooner is wasted.
+pub(crate) const PROPOSAL_FETCH_RETRY_VIEWS: u64 = 2;
+
 /// Epoch changes claiming an epoch further ahead than this are dropped at
 /// intake. We could not verify them anyway: an epoch's stake table only
 /// materializes by walking the DRB chain, so parking such a message and
@@ -123,7 +130,7 @@ pub struct Coordinator<T: NodeType, S> {
     #[builder(skip)]
     pending_proposal_fetches: PendingProposalFetches<T>,
     #[builder(skip)]
-    requested_missing_proposals: HashSet<ProposalFetchKey<T>>,
+    requested_missing_proposals: MissingProposalRequests<T>,
     #[builder(skip)]
     da_payloads: BTreeMap<(ViewNumber, VidCommitment2), PendingDa<T>>,
     metrics: Option<metrics::Metrics>,
@@ -1770,14 +1777,22 @@ where
             .map_err(|err| CoordinatorError::from(err).context("broadcast proposal request"))
     }
 
+    /// Broadcast a fetch request for a proposal consensus reported missing.
+    ///
+    /// Deduplicates requests for the same proposal, but re-broadcasts every
+    /// [`PROPOSAL_FETCH_RETRY_VIEWS`] views while it stays missing: the
+    /// network silently drops un-ACKed messages once its GC lower bound
+    /// passes the slot they were sent with, so a single broadcast (or all
+    /// of its responses) can be lost without a trace.
     fn request_missing_proposal(
         &mut self,
         view: ViewNumber,
         leaf_commit: Commitment<Leaf2<T>>,
     ) -> Result<(), CoordinatorError> {
+        let current_view = self.consensus.current_view();
         if !self
             .requested_missing_proposals
-            .insert(ProposalFetchKey::new(view, leaf_commit))
+            .try_begin(view, leaf_commit, current_view)
         {
             return Ok(());
         }
@@ -1786,8 +1801,10 @@ where
 
     fn maybe_validate_fetched_proposal(&mut self, proposal: SignedProposal<T, Proposal<T>>) {
         let view = proposal.data.view_number;
-        let key = ProposalFetchKey::new(view, proposal_commitment(&proposal.data));
-        if !self.requested_missing_proposals.remove(&key) {
+        if !self
+            .requested_missing_proposals
+            .resolve(view, proposal_commitment(&proposal.data))
+        {
             return;
         }
         if self.consensus.proposal_at(view).is_some() {
@@ -1819,8 +1836,7 @@ where
                 self.epoch_root_collector.gc(view);
                 self.cert_verifiers.gc(decide_floor, epoch);
                 self.pending_proposal_fetches.gc(view);
-                self.requested_missing_proposals
-                    .retain(|key| key.view > view);
+                self.requested_missing_proposals.gc(view);
                 self.state_manager.gc(view);
                 self.storage
                     .gc(view.saturating_sub(STORAGE_GC_MARGIN).into());
@@ -2052,5 +2068,52 @@ impl<T: NodeType> PendingProposalFetches<T> {
                 let _ = respond.send(Ok(proposal.clone()));
             }
         }
+    }
+}
+
+/// Fetch requests broadcast for proposals consensus reported missing, keyed
+/// by proposal and recording the view of the last broadcast so a request
+/// whose responses were lost is retried instead of blocked forever.
+#[derive(Default)]
+pub(crate) struct MissingProposalRequests<T: NodeType> {
+    requested: HashMap<ProposalFetchKey<T>, ViewNumber>,
+}
+
+impl<T: NodeType> MissingProposalRequests<T> {
+    /// Record a request attempt for the proposal at `current_view` and
+    /// return whether the caller should broadcast it: `false` while a
+    /// request broadcast fewer than [`PROPOSAL_FETCH_RETRY_VIEWS`] views
+    /// ago is still outstanding.
+    pub(crate) fn try_begin(
+        &mut self,
+        view: ViewNumber,
+        leaf_commitment: Commitment<Leaf2<T>>,
+        current_view: ViewNumber,
+    ) -> bool {
+        let key = ProposalFetchKey::new(view, leaf_commitment);
+        if let Some(requested_at) = self.requested.get(&key)
+            && *current_view < requested_at.saturating_add(PROPOSAL_FETCH_RETRY_VIEWS)
+        {
+            return false;
+        }
+        self.requested.insert(key, current_view);
+        true
+    }
+
+    /// Forget the request for the proposal, returning whether one was
+    /// outstanding.
+    pub(crate) fn resolve(
+        &mut self,
+        view: ViewNumber,
+        leaf_commitment: Commitment<Leaf2<T>>,
+    ) -> bool {
+        self.requested
+            .remove(&ProposalFetchKey::new(view, leaf_commitment))
+            .is_some()
+    }
+
+    /// Drop requests for views at or below the decided `view`.
+    pub(crate) fn gc(&mut self, view: ViewNumber) {
+        self.requested.retain(|key, _| key.view > view);
     }
 }

--- a/crates/hotshot/new-protocol/src/tests.rs
+++ b/crates/hotshot/new-protocol/src/tests.rs
@@ -3,6 +3,7 @@ pub(crate) mod common;
 mod block;
 mod cliquenet;
 mod consensus;
+mod coordinator;
 mod cutover;
 mod epoch_change;
 mod failures;

--- a/crates/hotshot/new-protocol/src/tests/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/tests/coordinator.rs
@@ -1,0 +1,71 @@
+use committable::Commitment;
+use hotshot_example_types::node_types::TestTypes;
+use hotshot_types::data::{Leaf2, ViewNumber};
+
+use crate::coordinator::{MissingProposalRequests, PROPOSAL_FETCH_RETRY_VIEWS};
+
+fn leaf_commit(byte: u8) -> Commitment<Leaf2<TestTypes>> {
+    Commitment::from_raw([byte; 32])
+}
+
+/// A first request broadcasts; repeating it within the retry margin does not.
+#[test]
+fn test_missing_proposal_request_dedup() {
+    let mut requests = MissingProposalRequests::<TestTypes>::default();
+    let view = ViewNumber::new(10);
+    let current = ViewNumber::new(12);
+
+    assert!(requests.try_begin(view, leaf_commit(1), current));
+    assert!(!requests.try_begin(view, leaf_commit(1), current));
+    assert!(!requests.try_begin(view, leaf_commit(1), current + 1));
+
+    // A different leaf commitment for the same view is a separate request.
+    assert!(requests.try_begin(view, leaf_commit(2), current));
+}
+
+/// A request whose responses were lost re-broadcasts once the current view
+/// has advanced past the retry margin, and then dedups again.
+#[test]
+fn test_missing_proposal_request_retries() {
+    let mut requests = MissingProposalRequests::<TestTypes>::default();
+    let view = ViewNumber::new(10);
+    let current = ViewNumber::new(12);
+
+    assert!(requests.try_begin(view, leaf_commit(1), current));
+    let retry_view = current + PROPOSAL_FETCH_RETRY_VIEWS;
+    assert!(!requests.try_begin(view, leaf_commit(1), retry_view - 1));
+    assert!(requests.try_begin(view, leaf_commit(1), retry_view));
+    assert!(!requests.try_begin(view, leaf_commit(1), retry_view));
+}
+
+/// Resolving forgets the request; a later request for the same proposal
+/// broadcasts again immediately.
+#[test]
+fn test_missing_proposal_request_resolve() {
+    let mut requests = MissingProposalRequests::<TestTypes>::default();
+    let view = ViewNumber::new(10);
+    let current = ViewNumber::new(12);
+
+    assert!(!requests.resolve(view, leaf_commit(1)));
+    assert!(requests.try_begin(view, leaf_commit(1), current));
+    assert!(requests.resolve(view, leaf_commit(1)));
+    assert!(!requests.resolve(view, leaf_commit(1)));
+    assert!(requests.try_begin(view, leaf_commit(1), current));
+}
+
+/// GC drops requests at or below the decided view and keeps the rest.
+#[test]
+fn test_missing_proposal_request_gc() {
+    let mut requests = MissingProposalRequests::<TestTypes>::default();
+    let current = ViewNumber::new(12);
+
+    assert!(requests.try_begin(ViewNumber::new(9), leaf_commit(1), current));
+    assert!(requests.try_begin(ViewNumber::new(10), leaf_commit(2), current));
+    assert!(requests.try_begin(ViewNumber::new(11), leaf_commit(3), current));
+
+    requests.gc(ViewNumber::new(10));
+
+    assert!(requests.try_begin(ViewNumber::new(9), leaf_commit(1), current));
+    assert!(requests.try_begin(ViewNumber::new(10), leaf_commit(2), current));
+    assert!(!requests.try_begin(ViewNumber::new(11), leaf_commit(3), current));
+}


### PR DESCRIPTION
## What

`request_missing_proposal` deduplicated fetch broadcasts with a `HashSet` that was only cleared by a decide GC past the requested view or by a response arriving. Cliquenet silently drops un-ACKed messages once its GC lower bound passes the slot they were stamped with (the coordinator advances that bound to `current_view - 1` on every view change), so a lost broadcast — or all of its responses, e.g. while the requester is briefly partitioned — left the internal fetch blocked with no retry until a decide passed that view.

This replaces the set with `MissingProposalRequests`, which records the view of the last broadcast per `(view, leaf_commitment)` and allows a re-broadcast once the current view advances `PROPOSAL_FETCH_RETRY_VIEWS` (= 2) past it. No timer is needed: consensus already re-emits `RequestMissingProposal` on every proposal or cert2 that references the missing parent, so the guard expires instead of blocking forever.

In the espresso node this gap is mostly masked by the external proposal fetcher's own retry loop, but new-protocol shouldn't depend on an embedder running a separate fetcher for its own liveness.

## Where to focus

- The retry margin in `MissingProposalRequests::try_begin` and its relationship to cliquenet's slot GC: un-ACKed sends survive roughly two view advances past their slot, so within that margin the previous round may still answer; the constant's doc comment captures this.
- Semantics are otherwise unchanged: `resolve()` and `gc()` mirror the old `remove`/`retain` behavior.

## Testing

- Regression test: `tests::coordinator::test_missing_proposal_request_retries`, plus dedup/resolve/gc coverage in `src/tests/coordinator.rs`.
- Full `hotshot-new-protocol` suite passes (209 tests). One run showed a flake in `restarts::restart_all_nodes_at_epoch_boundary`; it passes standalone, on a clean tree, and on a repeat full-suite run with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)