### PR TITLE
chore(audit): ignore RUSTSEC-2026-0258, h2 0.3 has no patched release

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -24,4 +24,8 @@ ignore = [
     # rkyv OOB read, only fixed in 0.8 while Push-CDN pins 0.7. Needs unsized `Rc`/`Arc` pointees,
     # which the CDN archived types don't have.
     "RUSTSEC-2026-0235",
+    # h2 queues unbounded empty DATA frames (low severity DoS), fixed only in 0.4.16, which the
+    # hyper 1.x stack here already uses. The vulnerable 0.3 copy comes via Push-CDN -> warp ->
+    # hyper 0.14 and serves only the CDN metrics endpoint; no patched 0.3.x release exists.
+    "RUSTSEC-2026-0258",
 ]


### PR DESCRIPTION
`security_audit` has been red on every push since 2026-08-17, when RUSTSEC-2026-0258 (h2 queues unbounded empty DATA frames, low severity DoS) was published.

The advisory is fixed only in h2 0.4.16, which the hyper 1.x stack in this workspace already uses. The vulnerable 0.3.27 copy comes via Push-CDN -> warp -> hyper 0.14, where it serves only the CDN `/metrics` endpoint. The 0.3 line is end-of-life with no patched release, so there is nothing to bump until Push-CDN moves off warp; same situation as the existing RUSTSEC-2026-0235 (rkyv) entry.

Verified A/B with `cargo audit` on this lockfile: fails with the advisory before the entry, exits clean after.