### PR TITLE
Fixes builder health check probe and events API error logging

### DIFF
--- a/crates/hotshot-builder/shared/src/utils/event_service_wrapper.rs
+++ b/crates/hotshot-builder/shared/src/utils/event_service_wrapper.rs
@@ -42,7 +42,9 @@ impl<Types: NodeType, ApiVer: StaticVersionType + 'static> EventServiceStream<Ty
         let mut last_err = None;
         let health = timeout(Self::CONNECTION_TIMEOUT, async {
             loop {
-                match client.healthcheck::<HealthStatus>().await {
+                // Absolute path: the base URL may include a version prefix (e.g. `/v1`), which
+                // serves the event stream but has no healthcheck route of its own.
+                match client.get::<HealthStatus>("/healthcheck").send().await {
                     Ok(_) => break,
                     Err(err) => {
                         tracing::debug!(%err, "Healthcheck failed, retrying");

--- a/crates/hotshot-builder/shared/src/utils/event_service_wrapper.rs
+++ b/crates/hotshot-builder/shared/src/utils/event_service_wrapper.rs
@@ -39,21 +39,30 @@ impl<Types: NodeType, ApiVer: StaticVersionType + 'static> EventServiceStream<Ty
     > {
         let client = Client::<hotshot_events_service::events::Error, ApiVer>::new(url.clone());
 
-        timeout(Self::CONNECTION_TIMEOUT, async {
+        let mut last_err = None;
+        let health = timeout(Self::CONNECTION_TIMEOUT, async {
             loop {
                 match client.healthcheck::<HealthStatus>().await {
                     Ok(_) => break,
                     Err(err) => {
-                        tracing::debug!(?err, "Healthcheck failed, retrying");
+                        tracing::debug!(%err, "Healthcheck failed, retrying");
+                        last_err = Some(err);
                     },
                 }
                 sleep(Self::RETRY_PERIOD).await;
             }
         })
-        .await
-        .context("Couldn't connect to hotshot events API")?;
+        .await;
+        health.with_context(|| {
+            format!(
+                "Couldn't connect to hotshot events API at {url}: no successful healthcheck \
+                 within {:?}: {}",
+                Self::CONNECTION_TIMEOUT,
+                last_err.map_or_else(|| "no response".to_string(), |err| err.to_string()),
+            )
+        })?;
 
-        tracing::info!("Builder client connected to the hotshot events API");
+        tracing::info!(%url, "Builder events API healthcheck passed");
 
         // Create a new [`WebSocketConfig`]. We trust the events service on our nodes to not
         // send us malicious messages.
@@ -61,10 +70,14 @@ impl<Types: NodeType, ApiVer: StaticVersionType + 'static> EventServiceStream<Ty
             .max_message_size(None)
             .max_frame_size(None);
 
-        Ok(client
+        let connection = client
             .socket_with_config("hotshot-events/events", websocket_config)
             .subscribe::<Event<Types>>()
-            .await?)
+            .await
+            .with_context(|| format!("failed to subscribe to hotshot events stream at {url}"))?;
+
+        tracing::info!(%url, "Builder client connected to the hotshot events API");
+        Ok(connection)
     }
 
     /// Establish initial connection to the events service at `api_url`
@@ -85,7 +98,7 @@ impl<Types: NodeType, ApiVer: StaticVersionType + 'static> EventServiceStream<Ty
                                 return Some((event, this));
                             },
                             Ok(Some(Err(err))) => {
-                                warn!(?err, "Error in event stream");
+                                warn!(%err, "Error in event stream");
                                 let fut = Self::connect_inner(this.api_url.clone());
                                 let _ =
                                     std::mem::replace(&mut this.connection, Right(Box::pin(fut)));
@@ -114,7 +127,7 @@ impl<Types: NodeType, ApiVer: StaticVersionType + 'static> EventServiceStream<Ty
                             continue;
                         },
                         Err(err) => {
-                            error!(?err, "Error while reconnecting, will retry in a while");
+                            error!(err = %format!("{err:#}"), "Error while reconnecting, will retry in a while");
                             sleep(Self::RETRY_PERIOD).await;
                             let fut = Self::connect_inner(this.api_url.clone());
                             let _ = std::mem::replace(&mut this.connection, Right(Box::pin(fut)));

--- a/crates/http-client/src/socket.rs
+++ b/crates/http-client/src/socket.rs
@@ -108,10 +108,18 @@ impl<E: ClientError, VER: StaticVersionType> SocketRequest<E, VER> {
                 self.url.set_path(location);
                 continue;
             }
-            return Err(E::catch_all(
-                reqwest::StatusCode::BAD_REQUEST,
-                err.to_string(),
-            ));
+            return Err(match err {
+                WsError::Http(res) => {
+                    let status = reqwest::StatusCode::from_u16(res.status().as_u16())
+                        .unwrap_or(reqwest::StatusCode::BAD_REQUEST);
+                    let reason = match res.body().as_deref().filter(|body| !body.is_empty()) {
+                        Some(body) => String::from_utf8_lossy(body).into_owned(),
+                        None => status.to_string(),
+                    };
+                    E::catch_all(status, format!("WS handshake rejected: {reason}"))
+                },
+                err => E::catch_all(reqwest::StatusCode::BAD_REQUEST, err.to_string()),
+            });
         }
         Err(E::catch_all(
             reqwest::StatusCode::BAD_REQUEST,

--- a/hotshot-events-service/src/events.rs
+++ b/hotshot-events-service/src/events.rs
@@ -55,6 +55,7 @@ pub enum Error {
         source: EventError,
         resource: String,
     },
+    #[snafu(display("{status}: {message}"))]
     Custom {
         message: String,
         status: StatusCode,


### PR DESCRIPTION
The builder could not connect to the events API through a version-prefixed URL (e.g. `/v1`): the healthcheck probe joined `healthcheck` relative to the base URL, hitting a route that does not exist, and gave up after 60s. It now probes the top-level `/healthcheck`, matching `Client::connect`.

Connection failures also reported only `Error: Custom` with no detail. WS handshake rejections now carry the real status and response body, and both failure paths name the URL.

