### PR TITLE
fix(go-sdk): bound every HTTP request and share the caller's deadline across nodes

### DIFF
--- a/sdks/go/client-dev-node/client.go
+++ b/sdks/go/client-dev-node/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 type Client struct {
@@ -20,7 +21,9 @@ func NewClient(url string) *Client {
 	}
 	return &Client{
 		baseUrl: url,
-		client:  http.DefaultClient,
+		// Bounded so that a node that accepts the connection and never answers
+		// cannot park a caller whose context has no deadline.
+		client: &http.Client{Timeout: 30 * time.Second},
 	}
 }
 

--- a/sdks/go/client-dev-node/client.go
+++ b/sdks/go/client-dev-node/client.go
@@ -15,15 +15,16 @@ type Client struct {
 	client  *http.Client
 }
 
+// Mirrors client.requestTimeout; see there for why requests are bounded.
+const requestTimeout = 30 * time.Second
+
 func NewClient(url string) *Client {
 	if !strings.HasSuffix(url, "/") {
 		url += "/"
 	}
 	return &Client{
 		baseUrl: url,
-		// Bounded so that a node that accepts the connection and never answers
-		// cannot park a caller whose context has no deadline.
-		client: &http.Client{Timeout: 30 * time.Second},
+		client:  &http.Client{Timeout: requestTimeout},
 	}
 }
 

--- a/sdks/go/client-dev-node/client.go
+++ b/sdks/go/client-dev-node/client.go
@@ -7,7 +7,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
+
+	"github.com/EspressoSystems/espresso-network/sdks/go/internal/httpclient"
 )
 
 type Client struct {
@@ -15,16 +16,13 @@ type Client struct {
 	client  *http.Client
 }
 
-// Mirrors client.requestTimeout; see there for why requests are bounded.
-const requestTimeout = 30 * time.Second
-
 func NewClient(url string) *Client {
 	if !strings.HasSuffix(url, "/") {
 		url += "/"
 	}
 	return &Client{
 		baseUrl: url,
-		client:  &http.Client{Timeout: requestTimeout},
+		client:  httpclient.New(),
 	}
 }
 

--- a/sdks/go/client-dev-node/client_test.go
+++ b/sdks/go/client-dev-node/client_test.go
@@ -47,5 +47,5 @@ func TestFetchDevInfo(t *testing.T) {
 }
 
 func TestNewClientBoundsItsHTTPClient(t *testing.T) {
-	require.Equal(t, httpclient.Timeout, NewClient("http://localhost:1").client.Timeout)
+	require.Same(t, httpclient.Transport, NewClient("http://localhost:1").client.Transport)
 }

--- a/sdks/go/client-dev-node/client_test.go
+++ b/sdks/go/client-dev-node/client_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/EspressoSystems/espresso-network/sdks/go/internal/devnode"
+	"github.com/EspressoSystems/espresso-network/sdks/go/internal/httpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,4 +44,8 @@ func TestFetchDevInfo(t *testing.T) {
 	assert.Equal(t, ports.SequencerAPI, int(devInfo.SequencerApiPort))
 	// This serves as a reminder that the L1 light client address has changed when it breaks.
 	assert.Equal(t, "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", devInfo.L1LightClientAddress)
+}
+
+func TestNewClientBoundsItsHTTPClient(t *testing.T) {
+	require.Equal(t, httpclient.Timeout, NewClient("http://localhost:1").client.Timeout)
 }

--- a/sdks/go/client/builder_submitter.go
+++ b/sdks/go/client/builder_submitter.go
@@ -62,37 +62,39 @@ var ErrAllBuildersFailed = errors.New("submission to all builders failed, check 
 func (c *BuilderSubmitter) SubmitTransaction(ctx context.Context, tx types.Transaction) (*types.TaggedBase64, error) {
 	c.previousSubmitErrors = make([]error, 0)
 	for clientIdx, url := range c.builderUrls {
-		response, err := c.tryPostRequest(ctx, url, clientIdx, tx)
-
+		hash, err := c.submitToBuilder(ctx, url, clientIdx, tx)
 		if err != nil {
 			c.previousSubmitErrors = append(c.previousSubmitErrors, err)
 			continue
 		}
-
-		defer response.Body.Close()
-		if response.StatusCode != http.StatusOK {
-			c.previousSubmitErrors = append(c.previousSubmitErrors, fmt.Errorf("%w: %v", ErrEphemeral, response.Status))
-			response.Body.Close()
-			continue
-		}
-
-		body, err := io.ReadAll(response.Body)
-		if err != nil {
-			c.previousSubmitErrors = append(c.previousSubmitErrors, fmt.Errorf("%w: %v", ErrEphemeral, err))
-			response.Body.Close()
-			continue
-		}
-
-		var hash types.TaggedBase64
-		if err := json.Unmarshal(body, &hash); err != nil {
-			c.previousSubmitErrors = append(c.previousSubmitErrors, fmt.Errorf("%w: %v", ErrEphemeral, err))
-			response.Body.Close()
-			continue
-		}
 		// If we receive a successful submission from the builder, we can exit as we don't need to send to other builders.
-		return &hash, nil
+		return hash, nil
 	}
 	return nil, ErrAllBuildersFailed
+}
+
+// Submits the transaction to a single builder and decodes its response.
+func (c *BuilderSubmitter) submitToBuilder(ctx context.Context, baseUrl string, clientIndex int, tx types.Transaction) (*types.TaggedBase64, error) {
+	response, err := c.tryPostRequest(ctx, baseUrl, clientIndex, tx)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: %v", ErrEphemeral, response.Status)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrEphemeral, err)
+	}
+
+	var hash types.TaggedBase64
+	if err := json.Unmarshal(body, &hash); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrEphemeral, err)
+	}
+	return &hash, nil
 }
 
 // post request handler for the builder submitter.

--- a/sdks/go/client/builder_submitter.go
+++ b/sdks/go/client/builder_submitter.go
@@ -62,7 +62,9 @@ var ErrAllBuildersFailed = errors.New("submission to all builders failed, check 
 func (c *BuilderSubmitter) SubmitTransaction(ctx context.Context, tx types.Transaction) (*types.TaggedBase64, error) {
 	c.previousSubmitErrors = make([]error, 0)
 	for clientIdx, url := range c.builderUrls {
-		hash, err := c.submitToBuilder(ctx, url, clientIdx, tx)
+		builderCtx, cancel := shareRemainingBudget(ctx, len(c.builderUrls)-clientIdx)
+		hash, err := c.submitToBuilder(builderCtx, url, clientIdx, tx)
+		cancel()
 		if err != nil {
 			c.previousSubmitErrors = append(c.previousSubmitErrors, err)
 			continue

--- a/sdks/go/client/builder_submitter.go
+++ b/sdks/go/client/builder_submitter.go
@@ -31,7 +31,7 @@ func NewBuilderSubmitter(builderUrls []string) (*BuilderSubmitter, error) {
 	formattedUrls := make([]string, len(builderUrls))
 	for i, url := range builderUrls {
 		formattedUrls[i] = formatUrl(url)
-		builderClients[i] = http.DefaultClient
+		builderClients[i] = newHTTPClient()
 	}
 
 	return &BuilderSubmitter{

--- a/sdks/go/client/builder_submitter.go
+++ b/sdks/go/client/builder_submitter.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
@@ -17,7 +16,7 @@ var _ EspressoBuilderSubmitter = (*BuilderSubmitter)(nil)
 
 type BuilderSubmitter struct {
 	builderUrls          []string
-	builderClients       []*http.Client
+	client               *http.Client
 	previousSubmitErrors []error
 }
 
@@ -27,16 +26,14 @@ func NewBuilderSubmitter(builderUrls []string) (*BuilderSubmitter, error) {
 		return nil, fmt.Errorf("One or more builder url's is required for the builder submitter")
 	}
 
-	builderClients := make([]*http.Client, len(builderUrls))
 	formattedUrls := make([]string, len(builderUrls))
 	for i, url := range builderUrls {
 		formattedUrls[i] = formatUrl(url)
-		builderClients[i] = newHTTPClient()
 	}
 
 	return &BuilderSubmitter{
-		builderUrls:    formattedUrls,
-		builderClients: builderClients,
+		builderUrls: formattedUrls,
+		client:      newHTTPClient(),
 	}, nil
 }
 
@@ -61,46 +58,31 @@ var ErrAllBuildersFailed = errors.New("submission to all builders failed, check 
 // If all builders fail, this function will return an error. Otherwise, err will be nil.
 func (c *BuilderSubmitter) SubmitTransaction(ctx context.Context, tx types.Transaction) (*types.TaggedBase64, error) {
 	c.previousSubmitErrors = make([]error, 0)
-	for clientIdx, url := range c.builderUrls {
-		builderCtx, cancel := shareRemainingBudget(ctx, len(c.builderUrls)-clientIdx)
-		hash, err := c.submitToBuilder(builderCtx, url, clientIdx, tx)
+	for i, url := range c.builderUrls {
+		builderCtx, cancel := shareRemainingBudget(ctx, len(c.builderUrls)-i)
+		hash, err := c.submitToBuilder(builderCtx, url, tx)
 		cancel()
 		if err != nil {
 			c.previousSubmitErrors = append(c.previousSubmitErrors, err)
 			continue
 		}
-		// If we receive a successful submission from the builder, we can exit as we don't need to send to other builders.
 		return hash, nil
 	}
 	return nil, ErrAllBuildersFailed
 }
 
-// Submits the transaction to a single builder and decodes its response.
-func (c *BuilderSubmitter) submitToBuilder(ctx context.Context, baseUrl string, clientIndex int, tx types.Transaction) (*types.TaggedBase64, error) {
-	response, err := c.tryPostRequest(ctx, baseUrl, clientIndex, tx)
+// Reads the response to completion before returning, so that the caller can
+// cancel the request's context as soon as this returns.
+func (c *BuilderSubmitter) submitToBuilder(ctx context.Context, baseUrl string, tx types.Transaction) (*types.TaggedBase64, error) {
+	response, err := c.tryPostRequest(ctx, baseUrl, tx)
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%w: %v", ErrEphemeral, response.Status)
-	}
-
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrEphemeral, err)
-	}
-
-	var hash types.TaggedBase64
-	if err := json.Unmarshal(body, &hash); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrEphemeral, err)
-	}
-	return &hash, nil
+	return decodeSubmitResponse(response)
 }
 
 // post request handler for the builder submitter.
-func (c *BuilderSubmitter) tryPostRequest(ctx context.Context, baseUrl string, clientIndex int, tx types.Transaction) (*http.Response, error) {
+func (c *BuilderSubmitter) tryPostRequest(ctx context.Context, baseUrl string, tx types.Transaction) (*http.Response, error) {
 	marshalled, err := json.Marshal(tx)
 	if err != nil {
 		return nil, err
@@ -111,7 +93,7 @@ func (c *BuilderSubmitter) tryPostRequest(ctx context.Context, baseUrl string, c
 		return nil, err
 	}
 	request.Header.Set("Content-Type", "application/json")
-	return c.builderClients[clientIndex].Do(request)
+	return c.client.Do(request)
 }
 
 func (c *BuilderSubmitter) GetPreviousSubmissionErrors() []error {

--- a/sdks/go/client/builder_submitter.go
+++ b/sdks/go/client/builder_submitter.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/EspressoSystems/espresso-network/sdks/go/internal/httpclient"
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 )
 
@@ -33,7 +34,7 @@ func NewBuilderSubmitter(builderUrls []string) (*BuilderSubmitter, error) {
 
 	return &BuilderSubmitter{
 		builderUrls: formattedUrls,
-		client:      newHTTPClient(),
+		client:      httpclient.New(),
 	}, nil
 }
 

--- a/sdks/go/client/client.go
+++ b/sdks/go/client/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 	common "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
@@ -58,6 +59,17 @@ type Client struct {
 	transactionSubmitter SubmitAPI
 }
 
+// Bounds each HTTP request end to end: connect, response headers and body read.
+// Without it a node that accepts the connection and never answers parks a caller
+// whose context has no deadline forever. A tighter deadline on the caller's
+// context still wins. For the streaming endpoints coder/websocket applies this
+// timeout to the handshake only, so an open stream is not cut short by it.
+const requestTimeout = 30 * time.Second
+
+func newHTTPClient() *http.Client {
+	return &http.Client{Timeout: requestTimeout}
+}
+
 // NewClientFromOptions:
 // This function allows SDK users to construct an EspressoClient with any transaction submitter that implements
 // the SubmitAPI. This is the preferred method of constructing an EspressoClient.
@@ -72,7 +84,7 @@ func NewClientFromOptions(options ...EspressoClientConfigOption) (*Client, error
 	}
 	return &Client{
 		baseUrl:              config.BaseUrl,
-		client:               http.DefaultClient,
+		client:               newHTTPClient(),
 		transactionSubmitter: config.TransactionSubmitter,
 	}, nil
 }
@@ -85,7 +97,7 @@ func NewClient(baseUrl string) *Client {
 	url := formatUrl(baseUrl)
 	return &Client{
 		baseUrl:              url,
-		client:               http.DefaultClient,
+		client:               newHTTPClient(),
 		transactionSubmitter: NewQuerySubmitter(url),
 	}
 }

--- a/sdks/go/client/client.go
+++ b/sdks/go/client/client.go
@@ -70,6 +70,20 @@ func newHTTPClient() *http.Client {
 	return &http.Client{Timeout: requestTimeout}
 }
 
+// Bounds one attempt of a sequential walk over the `remaining` endpoints still
+// to try to an even share of what is left of the caller's deadline. Without it
+// an endpoint that never answers consumes the whole deadline and hands its
+// successors an already-expired context, which defeats the point of holding
+// several URLs. A caller without a deadline is left alone: each attempt is
+// then bounded by requestTimeout only.
+func shareRemainingBudget(ctx context.Context, remaining int) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok || remaining <= 1 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, time.Until(deadline)/time.Duration(remaining))
+}
+
 // NewClientFromOptions:
 // This function allows SDK users to construct an EspressoClient with any transaction submitter that implements
 // the SubmitAPI. This is the preferred method of constructing an EspressoClient.

--- a/sdks/go/client/client.go
+++ b/sdks/go/client/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/EspressoSystems/espresso-network/sdks/go/internal/httpclient"
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 	common "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
 	"github.com/coder/websocket"
@@ -59,15 +60,6 @@ type Client struct {
 	transactionSubmitter SubmitAPI
 }
 
-// Bounds a request whose caller supplied no deadline: a node that accepts the
-// connection and never answers would otherwise park it forever. coder/websocket
-// applies this to the handshake only, so open streams survive it.
-const requestTimeout = 30 * time.Second
-
-func newHTTPClient() *http.Client {
-	return &http.Client{Timeout: requestTimeout}
-}
-
 // Gives one attempt of a sequential walk an even share of what is left of the
 // caller's deadline, so an endpoint that never answers cannot spend the budget
 // of the endpoints after it.
@@ -93,7 +85,7 @@ func NewClientFromOptions(options ...EspressoClientConfigOption) (*Client, error
 	}
 	return &Client{
 		baseUrl:              config.BaseUrl,
-		client:               newHTTPClient(),
+		client:               httpclient.New(),
 		transactionSubmitter: config.TransactionSubmitter,
 	}, nil
 }
@@ -106,7 +98,7 @@ func NewClient(baseUrl string) *Client {
 	url := formatUrl(baseUrl)
 	return &Client{
 		baseUrl:              url,
-		client:               newHTTPClient(),
+		client:               httpclient.New(),
 		transactionSubmitter: NewQuerySubmitter(url),
 	}
 }

--- a/sdks/go/client/client.go
+++ b/sdks/go/client/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/EspressoSystems/espresso-network/sdks/go/internal/httpclient"
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
@@ -58,17 +57,6 @@ type Client struct {
 	baseUrl              string
 	client               *http.Client
 	transactionSubmitter SubmitAPI
-}
-
-// Gives one attempt of a sequential walk an even share of what is left of the
-// caller's deadline, so an endpoint that never answers cannot spend the budget
-// of the endpoints after it.
-func shareRemainingBudget(ctx context.Context, remaining int) (context.Context, context.CancelFunc) {
-	deadline, ok := ctx.Deadline()
-	if !ok || remaining <= 1 {
-		return ctx, func() {}
-	}
-	return context.WithTimeout(ctx, time.Until(deadline)/time.Duration(remaining))
 }
 
 // NewClientFromOptions:

--- a/sdks/go/client/client.go
+++ b/sdks/go/client/client.go
@@ -59,23 +59,18 @@ type Client struct {
 	transactionSubmitter SubmitAPI
 }
 
-// Bounds each HTTP request end to end: connect, response headers and body read.
-// Without it a node that accepts the connection and never answers parks a caller
-// whose context has no deadline forever. A tighter deadline on the caller's
-// context still wins. For the streaming endpoints coder/websocket applies this
-// timeout to the handshake only, so an open stream is not cut short by it.
+// Bounds a request whose caller supplied no deadline: a node that accepts the
+// connection and never answers would otherwise park it forever. coder/websocket
+// applies this to the handshake only, so open streams survive it.
 const requestTimeout = 30 * time.Second
 
 func newHTTPClient() *http.Client {
 	return &http.Client{Timeout: requestTimeout}
 }
 
-// Bounds one attempt of a sequential walk over the `remaining` endpoints still
-// to try to an even share of what is left of the caller's deadline. Without it
-// an endpoint that never answers consumes the whole deadline and hands its
-// successors an already-expired context, which defeats the point of holding
-// several URLs. A caller without a deadline is left alone: each attempt is
-// then bounded by requestTimeout only.
+// Gives one attempt of a sequential walk an even share of what is left of the
+// caller's deadline, so an endpoint that never answers cannot spend the budget
+// of the endpoints after it.
 func shareRemainingBudget(ctx context.Context, remaining int) (context.Context, context.CancelFunc) {
 	deadline, ok := ctx.Deadline()
 	if !ok || remaining <= 1 {

--- a/sdks/go/client/multiple_nodes_client.go
+++ b/sdks/go/client/multiple_nodes_client.go
@@ -37,8 +37,10 @@ func NewMultipleNodesClient(urls []string) (*MultipleNodesClient, error) {
 
 func (c *MultipleNodesClient) FetchLatestBlockHeight(ctx context.Context) (uint64, error) {
 	var errs []error
-	for _, node := range c.nodes {
-		height, err := node.FetchLatestBlockHeight(ctx)
+	for i, node := range c.nodes {
+		nodeCtx, cancel := shareRemainingBudget(ctx, len(c.nodes)-i)
+		height, err := node.FetchLatestBlockHeight(nodeCtx)
+		cancel()
 		if err == nil {
 			return height, nil
 		} else {
@@ -159,8 +161,10 @@ func (c *MultipleNodesClient) SubmitTransaction(ctx context.Context, tx common.T
 
 	// Check if one node is successfully able to submit the transaction
 	var errs []error
-	for _, node := range c.nodes {
-		hash, err := node.SubmitTransaction(ctx, tx)
+	for i, node := range c.nodes {
+		nodeCtx, cancel := shareRemainingBudget(ctx, len(c.nodes)-i)
+		hash, err := node.SubmitTransaction(nodeCtx, tx)
+		cancel()
 		if err == nil {
 			return hash, nil
 		} else {

--- a/sdks/go/client/multiple_nodes_client.go
+++ b/sdks/go/client/multiple_nodes_client.go
@@ -40,6 +40,7 @@ func (c *MultipleNodesClient) FetchLatestBlockHeight(ctx context.Context) (uint6
 	for i, node := range c.nodes {
 		nodeCtx, cancel := shareRemainingBudget(ctx, len(c.nodes)-i)
 		height, err := node.FetchLatestBlockHeight(nodeCtx)
+		// Safe because the node method reads the whole response before returning.
 		cancel()
 		if err == nil {
 			return height, nil
@@ -164,6 +165,7 @@ func (c *MultipleNodesClient) SubmitTransaction(ctx context.Context, tx common.T
 	for i, node := range c.nodes {
 		nodeCtx, cancel := shareRemainingBudget(ctx, len(c.nodes)-i)
 		hash, err := node.SubmitTransaction(nodeCtx, tx)
+		// Safe because the node method reads the whole response before returning.
 		cancel()
 		if err == nil {
 			return hash, nil

--- a/sdks/go/client/query_submitter.go
+++ b/sdks/go/client/query_submitter.go
@@ -22,7 +22,7 @@ func NewQuerySubmitter(baseUrl string) *QuerySubmitter {
 
 	return &QuerySubmitter{
 		baseUrl: url,
-		client:  http.DefaultClient,
+		client:  newHTTPClient(),
 	}
 }
 

--- a/sdks/go/client/query_submitter.go
+++ b/sdks/go/client/query_submitter.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
@@ -32,27 +31,10 @@ func (q *QuerySubmitter) SubmitTransaction(ctx context.Context, tx types.Transac
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrEphemeral, err)
 	}
-
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%w: %v", ErrEphemeral, response.Status)
-	}
-
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrEphemeral, err)
-	}
-
-	var hash types.TaggedBase64
-	if err := json.Unmarshal(body, &hash); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrEphemeral, err)
-	}
-
-	return &hash, nil
+	return decodeSubmitResponse(response)
 }
 
 // This function handles the http post requests for the query submitter.
-// This could likely be abstracted in a future PR to avoid code duplication between the individual submitter types.
 func (q *QuerySubmitter) tryPostRequest(ctx context.Context, baseUrl string, tx types.Transaction) (*http.Response, error) {
 
 	marshalled, err := json.Marshal(tx)

--- a/sdks/go/client/query_submitter.go
+++ b/sdks/go/client/query_submitter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/EspressoSystems/espresso-network/sdks/go/internal/httpclient"
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 )
 
@@ -21,7 +22,7 @@ func NewQuerySubmitter(baseUrl string) *QuerySubmitter {
 
 	return &QuerySubmitter{
 		baseUrl: url,
-		client:  newHTTPClient(),
+		client:  httpclient.New(),
 	}
 }
 

--- a/sdks/go/client/timeout_test.go
+++ b/sdks/go/client/timeout_test.go
@@ -1,0 +1,126 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// Every constructor must hand out a bounded http.Client: a consumer that never
+// sets a deadline on its context is exactly the caller that used to wedge.
+func TestConstructorsBoundTheirHTTPClients(t *testing.T) {
+	client := NewClient("http://localhost:1")
+	require.Equal(t, requestTimeout, client.client.Timeout)
+	require.Equal(t, requestTimeout, client.transactionSubmitter.(*QuerySubmitter).client.Timeout)
+
+	fromOptions, err := NewClientFromOptions(WithBaseUrl("http://localhost:1"), WithTransactionSubmitter(NewQuerySubmitter("http://localhost:1")))
+	require.NoError(t, err)
+	require.Equal(t, requestTimeout, fromOptions.client.Timeout)
+
+	builders, err := NewBuilderSubmitter([]string{"http://localhost:1", "http://localhost:2"})
+	require.NoError(t, err)
+	for _, builder := range builders.builderClients {
+		require.Equal(t, requestTimeout, builder.Timeout)
+	}
+
+	nodes, err := NewMultipleNodesClient([]string{"http://localhost:1", "http://localhost:2"})
+	require.NoError(t, err)
+	for _, node := range nodes.nodes {
+		require.Equal(t, requestTimeout, node.client.Timeout)
+	}
+}
+
+// A node that accepts the connection and never answers, which is what a
+// black-holed endpoint looks like to the SDK.
+func blackHoleNode(t *testing.T) string {
+	t.Helper()
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	// Close waits for the handlers, which only return once released.
+	t.Cleanup(func() {
+		close(release)
+		server.Close()
+	})
+	return server.URL
+}
+
+// The wedge this exists for: a black-holed node must not park a caller whose
+// context has no deadline. The timeout is shortened from the default so the
+// test runs in milliseconds; the mechanism under test is the same.
+func TestBlackHoledNodeDoesNotParkTheCaller(t *testing.T) {
+	url := blackHoleNode(t)
+	const timeout = 100 * time.Millisecond
+	tx := types.Transaction{Namespace: 1, Payload: []byte("tx")}
+
+	client := NewClient(url)
+	client.client.Timeout = timeout
+	submitter := NewQuerySubmitter(url)
+	submitter.client.Timeout = timeout
+	builders, err := NewBuilderSubmitter([]string{url})
+	require.NoError(t, err)
+	builders.builderClients[0].Timeout = timeout
+
+	calls := map[string]func(context.Context) error{
+		"fetch": func(ctx context.Context) error {
+			_, err := client.FetchLatestBlockHeight(ctx)
+			return err
+		},
+		"query submit": func(ctx context.Context) error {
+			_, err := submitter.SubmitTransaction(ctx, tx)
+			return err
+		},
+		"builder submit": func(ctx context.Context) error {
+			_, err := builders.SubmitTransaction(ctx, tx)
+			return err
+		},
+	}
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			done := make(chan error, 1)
+			go func() { done <- call(context.Background()) }()
+			select {
+			case err := <-done:
+				require.Error(t, err)
+			case <-time.After(10 * time.Second):
+				t.Fatal("the call was not bounded")
+			}
+		})
+	}
+}
+
+// The request timeout bounds the WebSocket handshake only. An open stream has
+// to outlive it, which is the coder/websocket behaviour the SDK relies on.
+func TestStreamOutlivesTheRequestTimeout(t *testing.T) {
+	const timeout = 100 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		time.Sleep(3 * timeout)
+		_ = conn.Write(r.Context(), websocket.MessageText, []byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	client.client.Timeout = timeout
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	stream, err := client.StreamTransactions(ctx, 0)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	msg, err := stream.NextRaw(ctx)
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(msg))
+}

--- a/sdks/go/client/timeout_test.go
+++ b/sdks/go/client/timeout_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -37,11 +38,14 @@ func TestConstructorsBoundTheirHTTPClients(t *testing.T) {
 }
 
 // A node that accepts the connection and never answers, which is what a
-// black-holed endpoint looks like to the SDK.
-func blackHoleNode(t *testing.T) string {
+// black-holed endpoint looks like to the SDK. requests reports how many
+// requests reached it.
+func blackHoleNode(t *testing.T) (url string, requests func() int64) {
 	t.Helper()
+	var received atomic.Int64
 	release := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
 		<-release
 	}))
 	// Close waits for the handlers, which only return once released.
@@ -49,14 +53,14 @@ func blackHoleNode(t *testing.T) string {
 		close(release)
 		server.Close()
 	})
-	return server.URL
+	return server.URL, received.Load
 }
 
 // The wedge this exists for: a black-holed node must not park a caller whose
 // context has no deadline. The timeout is shortened from the default so the
 // test runs in milliseconds; the mechanism under test is the same.
 func TestBlackHoledNodeDoesNotParkTheCaller(t *testing.T) {
-	url := blackHoleNode(t)
+	url, _ := blackHoleNode(t)
 	const timeout = 100 * time.Millisecond
 	tx := types.Transaction{Namespace: 1, Payload: []byte("tx")}
 
@@ -94,6 +98,77 @@ func TestBlackHoledNodeDoesNotParkTheCaller(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Two black-holed nodes under one caller deadline that is far shorter than
+// requestTimeout. The first node must not consume the whole deadline and hand
+// the second an already-expired context: both have to be reached.
+func TestSequentialWalkGivesEachEndpointItsOwnShare(t *testing.T) {
+	firstUrl, firstRequests := blackHoleNode(t)
+	secondUrl, secondRequests := blackHoleNode(t)
+	const callerBudget = 600 * time.Millisecond
+	tx := types.Transaction{Namespace: 1, Payload: []byte("tx")}
+
+	nodes, err := NewMultipleNodesClient([]string{firstUrl, secondUrl})
+	require.NoError(t, err)
+	builders, err := NewBuilderSubmitter([]string{firstUrl, secondUrl})
+	require.NoError(t, err)
+
+	calls := map[string]func(context.Context) error{
+		"multiple nodes fetch": func(ctx context.Context) error {
+			_, err := nodes.FetchLatestBlockHeight(ctx)
+			return err
+		},
+		"multiple nodes submit": func(ctx context.Context) error {
+			_, err := nodes.SubmitTransaction(ctx, tx)
+			return err
+		},
+		"builder submit": func(ctx context.Context) error {
+			_, err := builders.SubmitTransaction(ctx, tx)
+			return err
+		},
+	}
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			before := firstRequests() + secondRequests()
+			ctx, cancel := context.WithTimeout(context.Background(), callerBudget)
+			defer cancel()
+
+			require.Error(t, call(ctx))
+			require.Equal(t, int64(2), firstRequests()+secondRequests()-before, "both endpoints should have been reached")
+		})
+	}
+}
+
+func TestShareRemainingBudget(t *testing.T) {
+	t.Run("splits what is left evenly across the endpoints still to try", func(t *testing.T) {
+		caller, cancelCaller := context.WithTimeout(context.Background(), 4*time.Second)
+		defer cancelCaller()
+
+		share, cancel := shareRemainingBudget(caller, 4)
+		defer cancel()
+		deadline, ok := share.Deadline()
+		require.True(t, ok)
+		require.WithinDuration(t, time.Now().Add(time.Second), deadline, 100*time.Millisecond)
+	})
+
+	t.Run("gives the last endpoint everything that is left", func(t *testing.T) {
+		caller, cancelCaller := context.WithTimeout(context.Background(), 4*time.Second)
+		defer cancelCaller()
+
+		share, cancel := shareRemainingBudget(caller, 1)
+		defer cancel()
+		deadline, ok := share.Deadline()
+		require.True(t, ok)
+		require.WithinDuration(t, time.Now().Add(4*time.Second), deadline, 100*time.Millisecond)
+	})
+
+	t.Run("leaves a caller without a deadline alone", func(t *testing.T) {
+		share, cancel := shareRemainingBudget(context.Background(), 4)
+		defer cancel()
+		_, ok := share.Deadline()
+		require.False(t, ok)
+	})
 }
 
 // The request timeout bounds the WebSocket handshake only. An open stream has

--- a/sdks/go/client/timeout_test.go
+++ b/sdks/go/client/timeout_test.go
@@ -17,25 +17,29 @@ import (
 // Stands in for httpclient.Timeout so the tests run in milliseconds.
 const testTimeout = 100 * time.Millisecond
 
+func testTransport() *http.Transport {
+	return &http.Transport{ResponseHeaderTimeout: testTimeout}
+}
+
 var testTx = types.Transaction{Namespace: 1, Payload: []byte("tx")}
 
 func TestConstructorsBoundTheirHTTPClients(t *testing.T) {
 	client := NewClient("http://localhost:1")
-	require.Equal(t, httpclient.Timeout, client.client.Timeout)
-	require.Equal(t, httpclient.Timeout, client.transactionSubmitter.(*QuerySubmitter).client.Timeout)
+	require.Same(t, httpclient.Transport, client.client.Transport)
+	require.Same(t, httpclient.Transport, client.transactionSubmitter.(*QuerySubmitter).client.Transport)
 
 	fromOptions, err := NewClientFromOptions(WithBaseUrl("http://localhost:1"), WithTransactionSubmitter(NewQuerySubmitter("http://localhost:1")))
 	require.NoError(t, err)
-	require.Equal(t, httpclient.Timeout, fromOptions.client.Timeout)
+	require.Same(t, httpclient.Transport, fromOptions.client.Transport)
 
 	builders, err := NewBuilderSubmitter([]string{"http://localhost:1", "http://localhost:2"})
 	require.NoError(t, err)
-	require.Equal(t, httpclient.Timeout, builders.client.Timeout)
+	require.Same(t, httpclient.Transport, builders.client.Transport)
 
 	nodes, err := NewMultipleNodesClient([]string{"http://localhost:1", "http://localhost:2"})
 	require.NoError(t, err)
 	for _, node := range nodes.nodes {
-		require.Equal(t, httpclient.Timeout, node.client.Timeout)
+		require.Same(t, httpclient.Transport, node.client.Transport)
 	}
 }
 
@@ -60,12 +64,12 @@ func TestBlackHoledNodeDoesNotParkTheCaller(t *testing.T) {
 	url, _ := blackHoleNode(t)
 
 	client := NewClient(url)
-	client.client.Timeout = testTimeout
+	client.client.Transport = testTransport()
 	submitter := NewQuerySubmitter(url)
-	submitter.client.Timeout = testTimeout
+	submitter.client.Transport = testTransport()
 	builders, err := NewBuilderSubmitter([]string{url})
 	require.NoError(t, err)
-	builders.client.Timeout = testTimeout
+	builders.client.Transport = testTransport()
 
 	calls := []struct {
 		name string
@@ -81,6 +85,10 @@ func TestBlackHoledNodeDoesNotParkTheCaller(t *testing.T) {
 		}},
 		{"builder submit", func(ctx context.Context) error {
 			_, err := builders.SubmitTransaction(ctx, testTx)
+			return err
+		}},
+		{"stream", func(ctx context.Context) error {
+			_, err := client.StreamTransactions(ctx, 0)
 			return err
 		}},
 	}
@@ -180,7 +188,25 @@ func TestShareRemainingBudget(t *testing.T) {
 	})
 }
 
-func TestStreamOutlivesTheRequestTimeout(t *testing.T) {
+// Answers at once, then takes longer than the header timeout to send the body.
+func TestSlowBodyOutlivesTheResponseHeaderTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		time.Sleep(3 * testTimeout)
+		_, _ = w.Write([]byte(`7`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	client.client.Transport = testTransport()
+
+	height, err := client.FetchLatestBlockHeight(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), height)
+}
+
+func TestStreamOutlivesTheResponseHeaderTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := websocket.Accept(w, r, nil)
 		if err != nil {
@@ -193,7 +219,7 @@ func TestStreamOutlivesTheRequestTimeout(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	client := NewClient(server.URL)
-	client.client.Timeout = testTimeout
+	client.client.Transport = testTransport()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/sdks/go/client/timeout_test.go
+++ b/sdks/go/client/timeout_test.go
@@ -107,9 +107,9 @@ func TestBlackHoledNodeDoesNotParkTheCaller(t *testing.T) {
 }
 
 func TestSequentialWalkGivesEachEndpointItsOwnShare(t *testing.T) {
-	// Far below httpclient.Timeout, so it is the deadline split and not the client
-	// timeout that has to leave the second endpoint a share.
-	const callerBudget = 300 * time.Millisecond
+	// Far below httpclient.Timeout, so it is the deadline split and not the
+	// response-header timeout that has to leave the second endpoint a share.
+	const callerBudget = 1 * time.Second
 
 	calls := []struct {
 		name string
@@ -143,7 +143,9 @@ func TestSequentialWalkGivesEachEndpointItsOwnShare(t *testing.T) {
 
 			require.Error(t, tc.call(t, ctx, []string{firstUrl, secondUrl}))
 			require.Equal(t, int64(1), firstRequests())
-			require.Equal(t, int64(1), secondRequests(), "the first endpoint consumed the whole deadline")
+			// The server may enter the handler just after the client gives up.
+			require.Eventually(t, func() bool { return secondRequests() == 1 }, time.Second, 10*time.Millisecond,
+				"the first endpoint consumed the whole deadline")
 		})
 	}
 }

--- a/sdks/go/client/timeout_test.go
+++ b/sdks/go/client/timeout_test.go
@@ -13,8 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Every constructor must hand out a bounded http.Client: a consumer that never
-// sets a deadline on its context is exactly the caller that used to wedge.
+// Stands in for requestTimeout so the tests run in milliseconds.
+const testTimeout = 100 * time.Millisecond
+
+var testTx = types.Transaction{Namespace: 1, Payload: []byte("tx")}
+
 func TestConstructorsBoundTheirHTTPClients(t *testing.T) {
 	client := NewClient("http://localhost:1")
 	require.Equal(t, requestTimeout, client.client.Timeout)
@@ -26,9 +29,7 @@ func TestConstructorsBoundTheirHTTPClients(t *testing.T) {
 
 	builders, err := NewBuilderSubmitter([]string{"http://localhost:1", "http://localhost:2"})
 	require.NoError(t, err)
-	for _, builder := range builders.builderClients {
-		require.Equal(t, requestTimeout, builder.Timeout)
-	}
+	require.Equal(t, requestTimeout, builders.client.Timeout)
 
 	nodes, err := NewMultipleNodesClient([]string{"http://localhost:1", "http://localhost:2"})
 	require.NoError(t, err)
@@ -37,9 +38,7 @@ func TestConstructorsBoundTheirHTTPClients(t *testing.T) {
 	}
 }
 
-// A node that accepts the connection and never answers, which is what a
-// black-holed endpoint looks like to the SDK. requests reports how many
-// requests reached it.
+// Accepts the connection and never answers, like a black-holed endpoint.
 func blackHoleNode(t *testing.T) (url string, requests func() int64) {
 	t.Helper()
 	var received atomic.Int64
@@ -56,86 +55,86 @@ func blackHoleNode(t *testing.T) (url string, requests func() int64) {
 	return server.URL, received.Load
 }
 
-// The wedge this exists for: a black-holed node must not park a caller whose
-// context has no deadline. The timeout is shortened from the default so the
-// test runs in milliseconds; the mechanism under test is the same.
 func TestBlackHoledNodeDoesNotParkTheCaller(t *testing.T) {
 	url, _ := blackHoleNode(t)
-	const timeout = 100 * time.Millisecond
-	tx := types.Transaction{Namespace: 1, Payload: []byte("tx")}
 
 	client := NewClient(url)
-	client.client.Timeout = timeout
+	client.client.Timeout = testTimeout
 	submitter := NewQuerySubmitter(url)
-	submitter.client.Timeout = timeout
+	submitter.client.Timeout = testTimeout
 	builders, err := NewBuilderSubmitter([]string{url})
 	require.NoError(t, err)
-	builders.builderClients[0].Timeout = timeout
+	builders.client.Timeout = testTimeout
 
-	calls := map[string]func(context.Context) error{
-		"fetch": func(ctx context.Context) error {
+	calls := []struct {
+		name string
+		call func(context.Context) error
+	}{
+		{"fetch", func(ctx context.Context) error {
 			_, err := client.FetchLatestBlockHeight(ctx)
 			return err
-		},
-		"query submit": func(ctx context.Context) error {
-			_, err := submitter.SubmitTransaction(ctx, tx)
+		}},
+		{"query submit", func(ctx context.Context) error {
+			_, err := submitter.SubmitTransaction(ctx, testTx)
 			return err
-		},
-		"builder submit": func(ctx context.Context) error {
-			_, err := builders.SubmitTransaction(ctx, tx)
+		}},
+		{"builder submit", func(ctx context.Context) error {
+			_, err := builders.SubmitTransaction(ctx, testTx)
 			return err
-		},
+		}},
 	}
-	for name, call := range calls {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range calls {
+		t.Run(tc.name, func(t *testing.T) {
 			done := make(chan error, 1)
-			go func() { done <- call(context.Background()) }()
+			go func() { done <- tc.call(context.Background()) }()
 			select {
 			case err := <-done:
 				require.Error(t, err)
-			case <-time.After(10 * time.Second):
+			case <-time.After(2 * time.Second):
 				t.Fatal("the call was not bounded")
 			}
 		})
 	}
 }
 
-// Two black-holed nodes under one caller deadline that is far shorter than
-// requestTimeout. The first node must not consume the whole deadline and hand
-// the second an already-expired context: both have to be reached.
 func TestSequentialWalkGivesEachEndpointItsOwnShare(t *testing.T) {
-	firstUrl, firstRequests := blackHoleNode(t)
-	secondUrl, secondRequests := blackHoleNode(t)
-	const callerBudget = 600 * time.Millisecond
-	tx := types.Transaction{Namespace: 1, Payload: []byte("tx")}
+	// Far below requestTimeout, so it is the deadline split and not the client
+	// timeout that has to leave the second endpoint a share.
+	const callerBudget = 300 * time.Millisecond
 
-	nodes, err := NewMultipleNodesClient([]string{firstUrl, secondUrl})
-	require.NoError(t, err)
-	builders, err := NewBuilderSubmitter([]string{firstUrl, secondUrl})
-	require.NoError(t, err)
-
-	calls := map[string]func(context.Context) error{
-		"multiple nodes fetch": func(ctx context.Context) error {
-			_, err := nodes.FetchLatestBlockHeight(ctx)
+	calls := []struct {
+		name string
+		call func(t *testing.T, ctx context.Context, urls []string) error
+	}{
+		{"multiple nodes fetch", func(t *testing.T, ctx context.Context, urls []string) error {
+			nodes, err := NewMultipleNodesClient(urls)
+			require.NoError(t, err)
+			_, err = nodes.FetchLatestBlockHeight(ctx)
 			return err
-		},
-		"multiple nodes submit": func(ctx context.Context) error {
-			_, err := nodes.SubmitTransaction(ctx, tx)
+		}},
+		{"multiple nodes submit", func(t *testing.T, ctx context.Context, urls []string) error {
+			nodes, err := NewMultipleNodesClient(urls)
+			require.NoError(t, err)
+			_, err = nodes.SubmitTransaction(ctx, testTx)
 			return err
-		},
-		"builder submit": func(ctx context.Context) error {
-			_, err := builders.SubmitTransaction(ctx, tx)
+		}},
+		{"builder submit", func(t *testing.T, ctx context.Context, urls []string) error {
+			builders, err := NewBuilderSubmitter(urls)
+			require.NoError(t, err)
+			_, err = builders.SubmitTransaction(ctx, testTx)
 			return err
-		},
+		}},
 	}
-	for name, call := range calls {
-		t.Run(name, func(t *testing.T) {
-			before := firstRequests() + secondRequests()
+	for _, tc := range calls {
+		t.Run(tc.name, func(t *testing.T) {
+			firstUrl, firstRequests := blackHoleNode(t)
+			secondUrl, secondRequests := blackHoleNode(t)
 			ctx, cancel := context.WithTimeout(context.Background(), callerBudget)
 			defer cancel()
 
-			require.Error(t, call(ctx))
-			require.Equal(t, int64(2), firstRequests()+secondRequests()-before, "both endpoints should have been reached")
+			require.Error(t, tc.call(t, ctx, []string{firstUrl, secondUrl}))
+			require.Equal(t, int64(1), firstRequests())
+			require.Equal(t, int64(1), secondRequests(), "the first endpoint consumed the whole deadline")
 		})
 	}
 }
@@ -171,23 +170,20 @@ func TestShareRemainingBudget(t *testing.T) {
 	})
 }
 
-// The request timeout bounds the WebSocket handshake only. An open stream has
-// to outlive it, which is the coder/websocket behaviour the SDK relies on.
 func TestStreamOutlivesTheRequestTimeout(t *testing.T) {
-	const timeout = 100 * time.Millisecond
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := websocket.Accept(w, r, nil)
 		if err != nil {
 			return
 		}
 		defer conn.CloseNow()
-		time.Sleep(3 * timeout)
+		time.Sleep(3 * testTimeout)
 		_ = conn.Write(r.Context(), websocket.MessageText, []byte(`{}`))
 	}))
 	t.Cleanup(server.Close)
 
 	client := NewClient(server.URL)
-	client.client.Timeout = timeout
+	client.client.Timeout = testTimeout
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/sdks/go/client/timeout_test.go
+++ b/sdks/go/client/timeout_test.go
@@ -141,7 +141,7 @@ func TestSequentialWalkGivesEachEndpointItsOwnShare(t *testing.T) {
 }
 
 func TestShareRemainingBudget(t *testing.T) {
-	t.Run("splits what is left evenly across the endpoints still to try", func(t *testing.T) {
+	t.Run("gives an endpoint half of what is left", func(t *testing.T) {
 		caller, cancelCaller := context.WithTimeout(context.Background(), 4*time.Second)
 		defer cancelCaller()
 
@@ -149,7 +149,7 @@ func TestShareRemainingBudget(t *testing.T) {
 		defer cancel()
 		deadline, ok := share.Deadline()
 		require.True(t, ok)
-		require.WithinDuration(t, time.Now().Add(time.Second), deadline, 100*time.Millisecond)
+		require.WithinDuration(t, time.Now().Add(2*time.Second), deadline, 100*time.Millisecond)
 	})
 
 	t.Run("gives the last endpoint everything that is left", func(t *testing.T) {
@@ -168,6 +168,15 @@ func TestShareRemainingBudget(t *testing.T) {
 		defer cancel()
 		_, ok := share.Deadline()
 		require.False(t, ok)
+	})
+
+	t.Run("expires immediately once the caller's deadline has passed", func(t *testing.T) {
+		caller, cancelCaller := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancelCaller()
+
+		share, cancel := shareRemainingBudget(caller, 4)
+		defer cancel()
+		require.ErrorIs(t, share.Err(), context.DeadlineExceeded)
 	})
 }
 

--- a/sdks/go/client/timeout_test.go
+++ b/sdks/go/client/timeout_test.go
@@ -8,33 +8,34 @@ import (
 	"testing"
 	"time"
 
+	"github.com/EspressoSystems/espresso-network/sdks/go/internal/httpclient"
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 	"github.com/coder/websocket"
 	"github.com/stretchr/testify/require"
 )
 
-// Stands in for requestTimeout so the tests run in milliseconds.
+// Stands in for httpclient.Timeout so the tests run in milliseconds.
 const testTimeout = 100 * time.Millisecond
 
 var testTx = types.Transaction{Namespace: 1, Payload: []byte("tx")}
 
 func TestConstructorsBoundTheirHTTPClients(t *testing.T) {
 	client := NewClient("http://localhost:1")
-	require.Equal(t, requestTimeout, client.client.Timeout)
-	require.Equal(t, requestTimeout, client.transactionSubmitter.(*QuerySubmitter).client.Timeout)
+	require.Equal(t, httpclient.Timeout, client.client.Timeout)
+	require.Equal(t, httpclient.Timeout, client.transactionSubmitter.(*QuerySubmitter).client.Timeout)
 
 	fromOptions, err := NewClientFromOptions(WithBaseUrl("http://localhost:1"), WithTransactionSubmitter(NewQuerySubmitter("http://localhost:1")))
 	require.NoError(t, err)
-	require.Equal(t, requestTimeout, fromOptions.client.Timeout)
+	require.Equal(t, httpclient.Timeout, fromOptions.client.Timeout)
 
 	builders, err := NewBuilderSubmitter([]string{"http://localhost:1", "http://localhost:2"})
 	require.NoError(t, err)
-	require.Equal(t, requestTimeout, builders.client.Timeout)
+	require.Equal(t, httpclient.Timeout, builders.client.Timeout)
 
 	nodes, err := NewMultipleNodesClient([]string{"http://localhost:1", "http://localhost:2"})
 	require.NoError(t, err)
 	for _, node := range nodes.nodes {
-		require.Equal(t, requestTimeout, node.client.Timeout)
+		require.Equal(t, httpclient.Timeout, node.client.Timeout)
 	}
 }
 
@@ -98,7 +99,7 @@ func TestBlackHoledNodeDoesNotParkTheCaller(t *testing.T) {
 }
 
 func TestSequentialWalkGivesEachEndpointItsOwnShare(t *testing.T) {
-	// Far below requestTimeout, so it is the deadline split and not the client
+	// Far below httpclient.Timeout, so it is the deadline split and not the client
 	// timeout that has to leave the second endpoint a share.
 	const callerBudget = 300 * time.Millisecond
 

--- a/sdks/go/client/utilities.go
+++ b/sdks/go/client/utilities.go
@@ -1,11 +1,13 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 )
@@ -38,4 +40,15 @@ func decodeSubmitResponse(response *http.Response) (*types.TaggedBase64, error) 
 		return nil, fmt.Errorf("%w: %v", ErrEphemeral, err)
 	}
 	return &hash, nil
+}
+
+// Gives one attempt of a sequential walk half of what is left of the caller's
+// deadline, so an endpoint that never answers cannot spend the budget of the
+// endpoints after it, while a healthy first endpoint still gets most of it.
+func shareRemainingBudget(ctx context.Context, remaining int) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok || remaining <= 1 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, time.Until(deadline)/2)
 }

--- a/sdks/go/client/utilities.go
+++ b/sdks/go/client/utilities.go
@@ -1,6 +1,14 @@
 package client
 
-import "strings"
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
+)
 
 // Apply formatting rules to url before creating the client.
 // currently, this is just ensuring the url has the suffix `/`
@@ -10,4 +18,24 @@ func formatUrl(url string) string {
 		url += "/"
 	}
 	return url
+}
+
+// Consumes and closes response.Body.
+func decodeSubmitResponse(response *http.Response) (*types.TaggedBase64, error) {
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: %v", ErrEphemeral, response.Status)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrEphemeral, err)
+	}
+
+	var hash types.TaggedBase64
+	if err := json.Unmarshal(body, &hash); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrEphemeral, err)
+	}
+	return &hash, nil
 }

--- a/sdks/go/internal/httpclient/httpclient.go
+++ b/sdks/go/internal/httpclient/httpclient.go
@@ -1,0 +1,15 @@
+package httpclient
+
+import (
+	"net/http"
+	"time"
+)
+
+// Bounds a request whose caller supplied no deadline: a node that accepts the
+// connection and never answers would otherwise park it forever. coder/websocket
+// applies this to the handshake only, so open streams survive it.
+const Timeout = 30 * time.Second
+
+func New() *http.Client {
+	return &http.Client{Timeout: Timeout}
+}

--- a/sdks/go/internal/httpclient/httpclient.go
+++ b/sdks/go/internal/httpclient/httpclient.go
@@ -1,15 +1,34 @@
 package httpclient
 
 import (
+	"net"
 	"net/http"
 	"time"
 )
 
-// Bounds a request whose caller supplied no deadline: a node that accepts the
-// connection and never answers would otherwise park it forever. coder/websocket
-// applies this to the handshake only, so open streams survive it.
+// Bounds how long a request waits for the response headers: a node that
+// accepts the connection and never answers would otherwise park a caller who
+// set no deadline forever. Reading the body is not bounded, so a large but
+// healthy range fetch on a slow link still completes. A websocket handshake
+// ends with its response headers, so this bounds the dial and not the stream.
 const Timeout = 30 * time.Second
 
+// One transport for every client, so they keep sharing a connection pool the
+// way they did on http.DefaultTransport, whose settings the other fields copy.
+var Transport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+	ResponseHeaderTimeout: Timeout,
+}
+
 func New() *http.Client {
-	return &http.Client{Timeout: Timeout}
+	return &http.Client{Transport: Transport}
 }


### PR DESCRIPTION
Follows [celo-org/optimism#500](https://github.com/celo-org/optimism/pull/500): the timeout belongs in the SDK. A client timeout alone does not fix it.

## This PR

- Puts a 30s limit on every HTTP request. All five constructors used `http.DefaultClient`. Its `Timeout` is 0, so there was no limit at all. A node could take the connection and never reply. That blocked any caller who set no deadline, forever. See celo-org/optimism#493. The 30s value now lives in one new package, `internal/httpclient`.
- Shares the caller's deadline between endpoints that are tried one after another. This covers fetch and submit in `MultipleNodesClient`, and `BuilderSubmitter`. Before, a dead first node used up the whole deadline. The second node then got none of it. 
- Tidies up code. Behavior does not change. `submitToBuilder` is now its own method. `BuilderSubmitter` holds one HTTP client instead of one per URL. Both submitters now share `decodeSubmitResponse`.

## This PR does not

- Change the public API. Every new name is unexported, or sits under `internal/`.
- Add a setting for users. 30s is fixed. There is no `WithRequestTimeout`.
- Limit a whole walk when the caller sets no deadline. The split does nothing in that case. So N endpoints can still take N × 30s.
- Touch the stream methods: `StreamTransactions`, `StreamTransactionsInNamespace`, `StreamPayloads`. They do not share the deadline. They still fail on the first bad node.
- Cut short an open stream. coder/websocket uses `HTTPClient.Timeout` for the handshake only.

## How to test

```
cd sdks/go && go test ./client/ ./client-dev-node/
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218179911964595
