### PR TITLE
fix(new-protocol): keep missed and late-validated proposals on the validated path

### DIFF
--- a/crates/espresso/types/src/v0/impls/instance_state.rs
+++ b/crates/espresso/types/src/v0/impls/instance_state.rs
@@ -542,7 +542,6 @@ pub mod mock {
         backoff: BackoffParams,
         state: HashMap<ViewNumber, Arc<ValidatedState>>,
         delay: std::time::Duration,
-        /// Number of fetches served, shared with clones handed to a `NodeState`.
         fetches: Arc<AtomicUsize>,
     }
 
@@ -572,7 +571,7 @@ pub mod mock {
             self
         }
 
-        /// Number of fetches served so far, across all clones.
+        /// Fetches served so far, across clones.
         pub fn fetches(&self) -> usize {
             self.fetches.load(Ordering::SeqCst)
         }

--- a/crates/espresso/types/src/v0/impls/instance_state.rs
+++ b/crates/espresso/types/src/v0/impls/instance_state.rs
@@ -516,7 +516,10 @@ impl Upgrade {
 
 #[cfg(any(test, feature = "testing"))]
 pub mod mock {
-    use std::collections::HashMap;
+    use std::{
+        collections::HashMap,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
     use anyhow::Context;
     use async_trait::async_trait;
@@ -539,6 +542,8 @@ pub mod mock {
         backoff: BackoffParams,
         state: HashMap<ViewNumber, Arc<ValidatedState>>,
         delay: std::time::Duration,
+        /// Number of fetches served, shared with clones handed to a `NodeState`.
+        fetches: Arc<AtomicUsize>,
     }
 
     impl Default for MockStateCatchup {
@@ -547,6 +552,7 @@ pub mod mock {
                 backoff: Default::default(),
                 state: Default::default(),
                 delay: std::time::Duration::ZERO,
+                fetches: Default::default(),
             }
         }
     }
@@ -554,9 +560,8 @@ pub mod mock {
     impl FromIterator<(ViewNumber, Arc<ValidatedState>)> for MockStateCatchup {
         fn from_iter<I: IntoIterator<Item = (ViewNumber, Arc<ValidatedState>)>>(iter: I) -> Self {
             Self {
-                backoff: Default::default(),
                 state: iter.into_iter().collect(),
-                delay: std::time::Duration::ZERO,
+                ..Default::default()
             }
         }
     }
@@ -565,6 +570,15 @@ pub mod mock {
         pub fn with_delay(mut self, delay: std::time::Duration) -> Self {
             self.delay = delay;
             self
+        }
+
+        /// Number of fetches served so far, across all clones.
+        pub fn fetches(&self) -> usize {
+            self.fetches.load(Ordering::SeqCst)
+        }
+
+        fn record_fetch(&self) {
+            self.fetches.fetch_add(1, Ordering::SeqCst);
         }
     }
 
@@ -588,6 +602,7 @@ pub mod mock {
             fee_merkle_tree_root: FeeMerkleCommitment,
             accounts: &[FeeAccount],
         ) -> anyhow::Result<Vec<FeeAccountProof>> {
+            self.record_fetch();
             tokio::time::sleep(self.delay).await;
 
             let src = &self.state[&view].fee_merkle_tree;
@@ -619,6 +634,7 @@ pub mod mock {
             view: ViewNumber,
             mt: &mut BlockMerkleTree,
         ) -> anyhow::Result<()> {
+            self.record_fetch();
             tokio::time::sleep(self.delay).await;
 
             tracing::info!("catchup: fetching frontier for view {view}");
@@ -643,6 +659,7 @@ pub mod mock {
             _retry: usize,
             _commitment: Commitment<ChainConfig>,
         ) -> anyhow::Result<ChainConfig> {
+            self.record_fetch();
             tokio::time::sleep(self.delay).await;
 
             Ok(ChainConfig::default())

--- a/crates/espresso/types/src/v0/impls/state.rs
+++ b/crates/espresso/types/src/v0/impls/state.rs
@@ -560,7 +560,7 @@ pub(crate) struct ValidatedTransition<'a> {
     proposal: Proposal<'a>,
     total_rewards_distributed: Option<RewardAmount>,
     version: Version,
-    /// When the proposal was received; the anchor for timestamp drift.
+    /// Anchor for the timestamp drift check.
     received_at: OffsetDateTime,
     epoch_height: Option<u64>,
     leader_index: Option<usize>,
@@ -1326,10 +1326,6 @@ impl HotShotState<SeqTypes> for ValidatedState {
         }
         #[cfg(feature = "node")]
         {
-            // Timestamp drift is measured from when this node received the proposal, not from
-            // when validation runs: validation can start long after receipt (catchup, or queued
-            // behind the parent's validation), and that delay says nothing about the leader's
-            // clock.
             let received_at = OffsetDateTime::from(received_at);
 
             let (validated_state, delta, total_rewards_distributed) = self
@@ -2512,12 +2508,8 @@ mod test {
             .unwrap();
     }
 
-    /// A `from_header` state is what the state manager seeds for a leaf whose
-    /// real state never arrived (parent missed, proposal fetched later).
-    /// Validating a child against it succeeds, but every account and frontier
-    /// the header touches has to be fetched from peers first; against the real
-    /// parent state nothing is fetched. This is the cost that makes a single
-    /// missed proposal fan out into a catchup storm.
+    /// Validating against a `from_header` parent fetches every touched account
+    /// from peers; against the real parent it fetches nothing.
     #[tokio::test]
     async fn test_from_header_parent_validates_only_via_catchup() {
         let mut instance = NodeState::mock_v2();
@@ -2581,9 +2573,8 @@ mod test {
         );
     }
 
-    /// Timestamp drift is measured from when the proposal was received, so a
-    /// validation that starts late (queued behind a slow parent, or a fetched
-    /// proposal) is not failed for the delay.
+    /// Drift is measured from receipt, so a validation that starts late is not
+    /// failed for the delay.
     #[tokio::test]
     async fn test_timestamp_drift_anchored_at_receipt() {
         let instance = NodeState::mock_v2();
@@ -2595,7 +2586,6 @@ mod test {
         let mut expected_block_tree = genesis_state.block_merkle_tree.clone();
         expected_block_tree.push(parent_header.commit()).unwrap();
 
-        // Received 20 s ago with a timestamp from then, validated only now.
         let received_at = SystemTime::now() - Duration::from_secs(20);
         let proposed_header = match parent_header {
             Header::V2(header) => Header::V2(v0_2::Header {
@@ -2621,7 +2611,6 @@ mod test {
             .await
             .expect("late validation of a timely proposal succeeds");
 
-        // The same header received just now really is drifted.
         let err = genesis_state
             .validate_and_apply_header(
                 &instance,

--- a/crates/espresso/types/src/v0/impls/state.rs
+++ b/crates/espresso/types/src/v0/impls/state.rs
@@ -2507,4 +2507,71 @@ mod test {
             .await
             .unwrap();
     }
+
+    /// A `from_header` state is what the state manager seeds for a leaf whose
+    /// real state never arrived (parent missed, proposal fetched later).
+    /// Validating a child against it succeeds, but every account and frontier
+    /// the header touches has to be fetched from peers first; against the real
+    /// parent state nothing is fetched. This is the cost that makes a single
+    /// missed proposal fan out into a catchup storm.
+    #[tokio::test]
+    async fn test_from_header_parent_validates_only_via_catchup() {
+        let mut instance = NodeState::mock_v2();
+        let mut genesis_state = instance.genesis_state.clone();
+        genesis_state
+            .fee_merkle_tree
+            .update(FeeAccount::default(), FeeAmount::from(1u64))
+            .unwrap();
+        instance.genesis_state = genesis_state.clone();
+
+        let genesis = Leaf::genesis(&genesis_state, &instance, MOCK_UPGRADE.base).await;
+        let parent_leaf: Leaf2 = genesis.into();
+        let parent_header = parent_leaf.block_header().clone();
+
+        let mut expected_block_tree = genesis_state.block_merkle_tree.clone();
+        expected_block_tree.push(parent_header.commit()).unwrap();
+        let proposed_header = match parent_header.clone() {
+            Header::V2(header) => Header::V2(v0_2::Header {
+                height: header.height + 1,
+                timestamp: OffsetDateTime::now_utc().unix_timestamp() as u64,
+                block_merkle_tree_root: expected_block_tree.commitment(),
+                chain_config: header.chain_config.commit().into(),
+                ..header
+            }),
+            _ => panic!("Expected V2 header"),
+        };
+
+        let catchup =
+            MockStateCatchup::from_iter([(ViewNumber::new(0), Arc::new(genesis_state.clone()))]);
+        instance.state_catchup = Arc::new(catchup.clone());
+
+        genesis_state
+            .validate_and_apply_header(
+                &instance,
+                &parent_leaf,
+                &proposed_header,
+                0, /* payload_byte_len */
+                FEE_VERSION,
+                0, /* view_number */
+            )
+            .await
+            .unwrap();
+        assert_eq!(catchup.fetches(), 0, "a full parent state needs no catchup");
+
+        let stub = ValidatedState::from_header(&parent_header);
+        stub.validate_and_apply_header(
+            &instance,
+            &parent_leaf,
+            &proposed_header,
+            0, /* payload_byte_len */
+            FEE_VERSION,
+            0, /* view_number */
+        )
+        .await
+        .unwrap();
+        assert!(
+            catchup.fetches() > 0,
+            "a from_header parent can only be extended by fetching from peers"
+        );
+    }
 }

--- a/crates/espresso/types/src/v0/impls/state.rs
+++ b/crates/espresso/types/src/v0/impls/state.rs
@@ -1,4 +1,4 @@
-use std::ops::Add;
+use std::{ops::Add, time::SystemTime};
 
 use alloy::primitives::{Address, U256};
 use anyhow::{Context, bail};
@@ -560,7 +560,8 @@ pub(crate) struct ValidatedTransition<'a> {
     proposal: Proposal<'a>,
     total_rewards_distributed: Option<RewardAmount>,
     version: Version,
-    validation_start_time: OffsetDateTime,
+    /// When the proposal was received; the anchor for timestamp drift.
+    received_at: OffsetDateTime,
     epoch_height: Option<u64>,
     leader_index: Option<usize>,
 }
@@ -574,7 +575,7 @@ impl<'a> ValidatedTransition<'a> {
         proposal: Proposal<'a>,
         total_rewards_distributed: Option<RewardAmount>,
         version: Version,
-        validation_start_time: OffsetDateTime,
+        received_at: OffsetDateTime,
         epoch_height: Option<u64>,
         leader_index: Option<usize>,
     ) -> Self {
@@ -589,7 +590,7 @@ impl<'a> ValidatedTransition<'a> {
             proposal,
             total_rewards_distributed,
             version,
-            validation_start_time,
+            received_at,
             epoch_height,
             leader_index,
         }
@@ -760,8 +761,7 @@ impl<'a> ValidatedTransition<'a> {
         self.proposal
             .validate_timestamp_non_dec(self.parent.timestamp())?;
 
-        self.proposal
-            .validate_timestamp_drift(self.validation_start_time)?;
+        self.proposal.validate_timestamp_drift(self.received_at)?;
 
         Ok(())
     }
@@ -1317,6 +1317,7 @@ impl HotShotState<SeqTypes> for ValidatedState {
         payload_byte_len: u32,
         version: Version,
         view_number: u64,
+        received_at: SystemTime,
     ) -> Result<(Self, Self::Delta), Self::Error> {
         // The L1 deposit fetch and the wait for the proposal's L1 blocks require an L1 client.
         #[cfg(not(feature = "node"))]
@@ -1325,11 +1326,11 @@ impl HotShotState<SeqTypes> for ValidatedState {
         }
         #[cfg(feature = "node")]
         {
-            // Preferably we would do all validation that does not require catchup first, but this
-            // would require some refactoring of the header validation code that is out of scope for
-            // now. Record the time when validation started to later use it to validate the
-            // timestamp drift.
-            let validation_start_time = OffsetDateTime::now_utc();
+            // Timestamp drift is measured from when this node received the proposal, not from
+            // when validation runs: validation can start long after receipt (catchup, or queued
+            // behind the parent's validation), and that delay says nothing about the leader's
+            // clock.
+            let received_at = OffsetDateTime::from(received_at);
 
             let (validated_state, delta, total_rewards_distributed) = self
                 // TODO We can add this logic to `ValidatedTransition` or do something similar to that here.
@@ -1361,7 +1362,7 @@ impl HotShotState<SeqTypes> for ValidatedState {
                 Proposal::new(proposed_header, payload_byte_len),
                 total_rewards_distributed,
                 version,
-                validation_start_time,
+                received_at,
                 instance.epoch_height,
                 leader_index,
             )
@@ -1583,7 +1584,10 @@ impl MerklizedState<SeqTypes, { Self::ARITY }> for RewardMerkleTreeV1 {
 
 #[cfg(test)]
 mod test {
-    use std::{sync::Arc, time::Duration};
+    use std::{
+        sync::Arc,
+        time::{Duration, SystemTime},
+    };
 
     use espresso_utils::ser::FromStringOrInteger;
     use hotshot::traits::BlockPayload;
@@ -1744,7 +1748,6 @@ mod test {
     impl<'a> ValidatedTransition<'a> {
         fn mock(instance: NodeState, parent: &'a Header, proposal: Proposal<'a>) -> Self {
             let expected_chain_config = instance.chain_config;
-            let validation_start_time = OffsetDateTime::now_utc();
 
             Self {
                 state: instance.genesis_state,
@@ -1754,7 +1757,7 @@ mod test {
                 total_rewards_distributed: None,
                 epoch_height: instance.epoch_height,
                 version: version(0, 1),
-                validation_start_time,
+                received_at: OffsetDateTime::now_utc(),
                 leader_index: None,
             }
         }
@@ -2503,6 +2506,7 @@ mod test {
                 0, /* payload_byte_len */
                 FEE_VERSION,
                 0, /* view_number */
+                SystemTime::now(),
             )
             .await
             .unwrap();
@@ -2553,6 +2557,7 @@ mod test {
                 0, /* payload_byte_len */
                 FEE_VERSION,
                 0, /* view_number */
+                SystemTime::now(),
             )
             .await
             .unwrap();
@@ -2566,12 +2571,72 @@ mod test {
             0, /* payload_byte_len */
             FEE_VERSION,
             0, /* view_number */
+            SystemTime::now(),
         )
         .await
         .unwrap();
         assert!(
             catchup.fetches() > 0,
             "a from_header parent can only be extended by fetching from peers"
+        );
+    }
+
+    /// Timestamp drift is measured from when the proposal was received, so a
+    /// validation that starts late (queued behind a slow parent, or a fetched
+    /// proposal) is not failed for the delay.
+    #[tokio::test]
+    async fn test_timestamp_drift_anchored_at_receipt() {
+        let instance = NodeState::mock_v2();
+        let genesis_state = instance.genesis_state.clone();
+        let genesis = Leaf::genesis(&genesis_state, &instance, MOCK_UPGRADE.base).await;
+        let parent_leaf: Leaf2 = genesis.into();
+        let parent_header = parent_leaf.block_header().clone();
+
+        let mut expected_block_tree = genesis_state.block_merkle_tree.clone();
+        expected_block_tree.push(parent_header.commit()).unwrap();
+
+        // Received 20 s ago with a timestamp from then, validated only now.
+        let received_at = SystemTime::now() - Duration::from_secs(20);
+        let proposed_header = match parent_header {
+            Header::V2(header) => Header::V2(v0_2::Header {
+                height: header.height + 1,
+                timestamp: OffsetDateTime::from(received_at).unix_timestamp() as u64,
+                block_merkle_tree_root: expected_block_tree.commitment(),
+                chain_config: header.chain_config.commit().into(),
+                ..header
+            }),
+            _ => panic!("Expected V2 header"),
+        };
+
+        genesis_state
+            .validate_and_apply_header(
+                &instance,
+                &parent_leaf,
+                &proposed_header,
+                0, /* payload_byte_len */
+                FEE_VERSION,
+                0, /* view_number */
+                received_at,
+            )
+            .await
+            .expect("late validation of a timely proposal succeeds");
+
+        // The same header received just now really is drifted.
+        let err = genesis_state
+            .validate_and_apply_header(
+                &instance,
+                &parent_leaf,
+                &proposed_header,
+                0, /* payload_byte_len */
+                FEE_VERSION,
+                0, /* view_number */
+                SystemTime::now(),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("Timestamp drift too high"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/crates/hotshot/example-types/src/state_types.rs
+++ b/crates/hotshot/example-types/src/state_types.rs
@@ -32,7 +32,7 @@ use crate::{
 #[derive(Clone, Debug, Default)]
 pub struct TestInstanceState {
     pub delay_config: DelayConfig,
-    /// Block number whose header fails validation, to exercise failure paths.
+    /// Block number whose header fails validation.
     pub failing_block: Option<u64>,
 }
 

--- a/crates/hotshot/example-types/src/state_types.rs
+++ b/crates/hotshot/example-types/src/state_types.rs
@@ -32,13 +32,18 @@ use crate::{
 #[derive(Clone, Debug, Default)]
 pub struct TestInstanceState {
     pub delay_config: DelayConfig,
+    /// Block number whose header fails validation, to exercise failure paths.
+    pub failing_block: Option<u64>,
 }
 
 impl InstanceState for TestInstanceState {}
 
 impl TestInstanceState {
     pub fn new(delay_config: DelayConfig) -> Self {
-        TestInstanceState { delay_config }
+        TestInstanceState {
+            delay_config,
+            failing_block: None,
+        }
     }
 }
 
@@ -101,12 +106,17 @@ impl<TYPES: NodeType> ValidatedState<TYPES> for TestValidatedState {
         &self,
         instance: &Self::Instance,
         _parent_leaf: &Leaf2<TYPES>,
-        _proposed_header: &TYPES::BlockHeader,
+        proposed_header: &TYPES::BlockHeader,
         _payload_byte_len: u32,
         _version: Version,
         _view_number: u64,
     ) -> Result<(Self, Self::Delta), Self::Error> {
         Self::run_delay_settings_from_config(&instance.delay_config).await;
+        if instance.failing_block == Some(proposed_header.block_number()) {
+            return Err(BlockError::InvalidBlockHeader(
+                "configured to fail validation".into(),
+            ));
+        }
         Ok((
             TestValidatedState {
                 block_height: self.block_height + 1,

--- a/crates/hotshot/example-types/src/state_types.rs
+++ b/crates/hotshot/example-types/src/state_types.rs
@@ -5,7 +5,7 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 //! Implementations for examples and tests only
-use std::fmt::Debug;
+use std::{fmt::Debug, time::SystemTime};
 
 use async_trait::async_trait;
 use committable::{Commitment, Committable};
@@ -110,6 +110,7 @@ impl<TYPES: NodeType> ValidatedState<TYPES> for TestValidatedState {
         _payload_byte_len: u32,
         _version: Version,
         _view_number: u64,
+        _received_at: SystemTime,
     ) -> Result<(Self, Self::Delta), Self::Error> {
         Self::run_delay_settings_from_config(&instance.delay_config).await;
         if instance.failing_block == Some(proposed_header.block_number()) {

--- a/crates/hotshot/new-protocol/Cargo.toml
+++ b/crates/hotshot/new-protocol/Cargo.toml
@@ -48,7 +48,7 @@ versions = { workspace = true }
 [dev-dependencies]
 bitvec = { workspace = true }
 quickcheck = { workspace = true }
-# `test-util` for paused time in state-manager deadline tests.
+# Paused time in state-manager tests.
 tokio = { workspace = true, features = ["test-util"] }
 vbs = { workspace = true }
 # Enables `vid/testing` for tests only: constructs non-codeword dispersals to

--- a/crates/hotshot/new-protocol/Cargo.toml
+++ b/crates/hotshot/new-protocol/Cargo.toml
@@ -48,6 +48,8 @@ versions = { workspace = true }
 [dev-dependencies]
 bitvec = { workspace = true }
 quickcheck = { workspace = true }
+# `test-util` for paused time in state-manager deadline tests.
+tokio = { workspace = true, features = ["test-util"] }
 vbs = { workspace = true }
 # Enables `vid/testing` for tests only: constructs non-codeword dispersals to
 # exercise the unrecoverable VID reconstruction path.

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -209,10 +209,6 @@ pub(crate) const GC_MARGIN_VIEWS: NonZeroU64 = NonZeroU64::new(2).expect("2 > 0"
 // The decide buffer retains the proposals the VID reconstructor reads.
 const _: () = assert!(DECIDE_BUFFER >= VID_RECONSTRUCT_GC_MARGIN);
 
-/// Failed state validations of one proposal before it is dropped, see
-/// [`Consensus::handle_state_validation_failed`].
-pub(crate) const MAX_STATE_VALIDATION_FAILURES: u32 = 3;
-
 pub struct Consensus<T: NodeType> {
     proposals: BTreeMap<ViewNumber, Proposal<T>>,
     signed_proposals: BTreeMap<ViewNumber, SignedProposal<T, Proposal<T>>>,
@@ -221,8 +217,6 @@ pub struct Consensus<T: NodeType> {
     unpaired_proposals: UnpairedProposals<T>,
     unpaired_vid_shares: UnpairedVidShares<T>,
     states_verified: BTreeMap<ViewNumber, Commitment<Leaf2<T>>>,
-    /// Failed state validations per view, bounding the retries.
-    state_validation_failures: BTreeMap<ViewNumber, u32>,
     blocks_reconstructed: BTreeSet<(ViewNumber, VidCommitment2)>,
     blocks: BTreeMap<(ViewNumber, VidCommitment2), T::BlockPayload>,
     certs: BTreeMap<ViewNumber, Certificate1<T>>,
@@ -345,7 +339,6 @@ impl<T: NodeType> Consensus<T> {
             proposed_views: BTreeSet::new(),
             blocks: BTreeMap::new(),
             states_verified: BTreeMap::new(),
-            state_validation_failures: BTreeMap::new(),
             blocks_reconstructed: BTreeSet::new(),
             certs: BTreeMap::new(),
             certs2: BTreeMap::new(),
@@ -794,7 +787,28 @@ impl<T: NodeType> Consensus<T> {
                 Protocol::Continue
             },
             ConsensusInput::StateValidationFailed(state_response) => {
-                self.handle_state_validation_failed(state_response, outbox);
+                let view = state_response.view;
+                let stored_proposal = self.proposals.get(&view);
+                if let Some(proposal) = stored_proposal {
+                    let matches = proposal_commitment(proposal) == state_response.commitment;
+                    warn!(
+                        %view,
+                        block = %proposal.block_header.block_number(),
+                        epoch = %proposal.epoch,
+                        qc_view = %proposal.justify_qc.view_number(),
+                        qc_epoch = ?proposal.justify_qc.epoch(),
+                        commitment_matches = matches,
+                        "apply: state validation failed"
+                    );
+                    if !matches {
+                        return;
+                    }
+                } else {
+                    warn!(%view, "apply: state validation failed (no stored proposal)");
+                }
+                self.proposals.remove(&view);
+                self.leaves.remove(&view);
+                self.vid_shares.remove(&view);
                 return;
             },
             ConsensusInput::Timeout(view, epoch) => {
@@ -981,8 +995,6 @@ impl<T: NodeType> Consensus<T> {
                 self.certs2 = self.certs2.split_off(&keep_from);
                 self.decided_views = self.decided_views.split_off(&keep_from);
                 self.proposals = self.proposals.split_off(&keep_from);
-                self.state_validation_failures =
-                    self.state_validation_failures.split_off(&keep_from);
                 self.vote1_parent = self.vote1_parent.split_off(&keep_from);
                 self.leaves = self.leaves.split_off(&view);
                 self.signed_proposals = self.signed_proposals.split_off(&view);
@@ -2043,48 +2055,6 @@ impl<T: NodeType> Consensus<T> {
             auth_root,
             signed_state_digest,
         })
-    }
-
-    /// A failed validation does not mean the proposal is invalid: state
-    /// catchup timing out fails it too. Dropping the proposal would then make
-    /// every descendant validate against a `from_header` stub and, once a
-    /// child's QC names it, fetch it right back. Retry a bounded number of
-    /// times before dropping it.
-    fn handle_state_validation_failed(
-        &mut self,
-        response: StateResponse<T>,
-        outbox: &mut Outbox<ConsensusOutput<T>>,
-    ) {
-        let view = response.view;
-        let Some(proposal) = self.proposals.get(&view) else {
-            warn!(%view, "apply: state validation failed (no stored proposal)");
-            return;
-        };
-        let block = proposal.block_header.block_number();
-        let epoch = proposal.epoch;
-        if proposal_commitment(proposal) != response.commitment {
-            warn!(
-                %view, %block, %epoch,
-                "apply: state validation failed for a superseded proposal"
-            );
-            return;
-        }
-        let failures = self.state_validation_failures.entry(view).or_default();
-        *failures += 1;
-        let failures = *failures;
-        if failures < MAX_STATE_VALIDATION_FAILURES {
-            warn!(%view, %block, %epoch, failures, "apply: state validation failed; retrying");
-            let payload_size = self.payload_size_for(proposal);
-            self.request_state(proposal, payload_size, outbox);
-            return;
-        }
-        warn!(
-            %view, %block, %epoch, failures,
-            "apply: state validation failed repeatedly; dropping proposal"
-        );
-        self.proposals.remove(&view);
-        self.leaves.remove(&view);
-        self.vid_shares.remove(&view);
     }
 
     fn handle_stored(&mut self, stored: StorageOutput<T>, outbox: &mut Outbox<ConsensusOutput<T>>) {

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -1205,36 +1205,14 @@ impl<T: NodeType> Consensus<T> {
             }
         }
 
-        outbox.push_back(ConsensusOutput::RequestState(StateRequest {
-            view: proposal.view_number(),
-            parent_view: proposal.justify_qc.view_number(),
-            epoch,
-            block: proposal.block_header.block_number().into(),
-            proposal: proposal.clone(),
-            parent_commitment: proposal.justify_qc.data().leaf_commit,
-            payload_size,
-        }));
-
-        let epoch = if is_last_block(block_number, *self.epoch_height) {
-            epoch + 1
-        } else {
-            epoch
-        };
+        self.request_state(&proposal, payload_size, outbox);
 
         outbox.push_back(ConsensusOutput::ProposalValidated {
             proposal: signed_proposal,
             sender,
         });
 
-        if self.is_leader(view + 1, epoch) {
-            outbox.push_back(ConsensusOutput::RequestBlockAndHeader(
-                BlockAndHeaderRequest {
-                    view: view + 1,
-                    epoch,
-                    parent_proposal: proposal,
-                },
-            ));
-        }
+        self.request_block_and_header_if_next_leader(&proposal, outbox);
 
         Protocol::Continue
     }
@@ -1259,8 +1237,66 @@ impl<T: NodeType> Consensus<T> {
         self.leaves.insert(view, proposal.clone().into());
         self.signed_proposals.insert(view, signed_proposal);
         self.request_parent_proposal_if_missing(&proposal, outbox);
-        self.proposals.insert(view, proposal);
+        self.proposals.insert(view, proposal.clone());
         self.adopt_certified_drb(view);
+
+        let payload_size = self.payload_size_for(&proposal);
+        self.request_state(&proposal, payload_size, outbox);
+        self.request_block_and_header_if_next_leader(&proposal, outbox);
+    }
+
+    fn request_state(
+        &self,
+        proposal: &Proposal<T>,
+        payload_size: u32,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) {
+        outbox.push_back(ConsensusOutput::RequestState(StateRequest {
+            view: proposal.view_number(),
+            parent_view: proposal.justify_qc.view_number(),
+            epoch: proposal.epoch,
+            block: proposal.block_header.block_number().into(),
+            proposal: proposal.clone(),
+            parent_commitment: proposal.justify_qc.data().leaf_commit,
+            payload_size,
+        }));
+    }
+
+    /// A fetched proposal may have no share. A quorum already certified it,
+    /// size checks included, so zero only skips this node's block-size checks.
+    fn payload_size_for(&self, proposal: &Proposal<T>) -> u32 {
+        let view = proposal.view_number();
+        if let Some(share) = self.vid_shares.get(&view) {
+            return share.payload_byte_len();
+        }
+        let VidCommitment::V2(commitment) = proposal.block_header.payload_commitment() else {
+            return 0;
+        };
+        self.unpaired_vid_shares
+            .get(&(view, commitment))
+            .map_or(0, |share| share.payload_byte_len())
+    }
+
+    fn request_block_and_header_if_next_leader(
+        &self,
+        proposal: &Proposal<T>,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) {
+        let view = proposal.view_number();
+        let epoch = if is_last_block(proposal.block_header.block_number(), *self.epoch_height) {
+            proposal.epoch + 1
+        } else {
+            proposal.epoch
+        };
+        if self.is_leader(view + 1, epoch) {
+            outbox.push_back(ConsensusOutput::RequestBlockAndHeader(
+                BlockAndHeaderRequest {
+                    view: view + 1,
+                    epoch,
+                    parent_proposal: proposal.clone(),
+                },
+            ));
+        }
     }
 
     /// Ask for the payload of the view every proposal we could vote for is

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -787,28 +787,25 @@ impl<T: NodeType> Consensus<T> {
                 Protocol::Continue
             },
             ConsensusInput::StateValidationFailed(state_response) => {
+                // The proposal is kept, like a fetched or epoch-change
+                // proposal without a state: votes are gated on
+                // `states_verified`, and the state manager seeded a
+                // `from_header` stub for the leaf so its descendants can still
+                // be validated via catchup.
                 let view = state_response.view;
-                let stored_proposal = self.proposals.get(&view);
-                if let Some(proposal) = stored_proposal {
-                    let matches = proposal_commitment(proposal) == state_response.commitment;
-                    warn!(
+                match self.proposals.get(&view) {
+                    Some(proposal) => warn!(
                         %view,
                         block = %proposal.block_header.block_number(),
                         epoch = %proposal.epoch,
                         qc_view = %proposal.justify_qc.view_number(),
                         qc_epoch = ?proposal.justify_qc.epoch(),
-                        commitment_matches = matches,
+                        commitment_matches =
+                            proposal_commitment(proposal) == state_response.commitment,
                         "apply: state validation failed"
-                    );
-                    if !matches {
-                        return;
-                    }
-                } else {
-                    warn!(%view, "apply: state validation failed (no stored proposal)");
+                    ),
+                    None => warn!(%view, "apply: state validation failed (no stored proposal)"),
                 }
-                self.proposals.remove(&view);
-                self.leaves.remove(&view);
-                self.vid_shares.remove(&view);
                 return;
             },
             ConsensusInput::Timeout(view, epoch) => {

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -209,6 +209,10 @@ pub(crate) const GC_MARGIN_VIEWS: NonZeroU64 = NonZeroU64::new(2).expect("2 > 0"
 // The decide buffer retains the proposals the VID reconstructor reads.
 const _: () = assert!(DECIDE_BUFFER >= VID_RECONSTRUCT_GC_MARGIN);
 
+/// Failed state validations of one proposal before it is dropped, see
+/// [`Consensus::handle_state_validation_failed`].
+pub(crate) const MAX_STATE_VALIDATION_FAILURES: u32 = 3;
+
 pub struct Consensus<T: NodeType> {
     proposals: BTreeMap<ViewNumber, Proposal<T>>,
     signed_proposals: BTreeMap<ViewNumber, SignedProposal<T, Proposal<T>>>,
@@ -217,6 +221,8 @@ pub struct Consensus<T: NodeType> {
     unpaired_proposals: UnpairedProposals<T>,
     unpaired_vid_shares: UnpairedVidShares<T>,
     states_verified: BTreeMap<ViewNumber, Commitment<Leaf2<T>>>,
+    /// Failed state validations per view, bounding the retries.
+    state_validation_failures: BTreeMap<ViewNumber, u32>,
     blocks_reconstructed: BTreeSet<(ViewNumber, VidCommitment2)>,
     blocks: BTreeMap<(ViewNumber, VidCommitment2), T::BlockPayload>,
     certs: BTreeMap<ViewNumber, Certificate1<T>>,
@@ -339,6 +345,7 @@ impl<T: NodeType> Consensus<T> {
             proposed_views: BTreeSet::new(),
             blocks: BTreeMap::new(),
             states_verified: BTreeMap::new(),
+            state_validation_failures: BTreeMap::new(),
             blocks_reconstructed: BTreeSet::new(),
             certs: BTreeMap::new(),
             certs2: BTreeMap::new(),
@@ -787,28 +794,7 @@ impl<T: NodeType> Consensus<T> {
                 Protocol::Continue
             },
             ConsensusInput::StateValidationFailed(state_response) => {
-                let view = state_response.view;
-                let stored_proposal = self.proposals.get(&view);
-                if let Some(proposal) = stored_proposal {
-                    let matches = proposal_commitment(proposal) == state_response.commitment;
-                    warn!(
-                        %view,
-                        block = %proposal.block_header.block_number(),
-                        epoch = %proposal.epoch,
-                        qc_view = %proposal.justify_qc.view_number(),
-                        qc_epoch = ?proposal.justify_qc.epoch(),
-                        commitment_matches = matches,
-                        "apply: state validation failed"
-                    );
-                    if !matches {
-                        return;
-                    }
-                } else {
-                    warn!(%view, "apply: state validation failed (no stored proposal)");
-                }
-                self.proposals.remove(&view);
-                self.leaves.remove(&view);
-                self.vid_shares.remove(&view);
+                self.handle_state_validation_failed(state_response, outbox);
                 return;
             },
             ConsensusInput::Timeout(view, epoch) => {
@@ -995,6 +981,8 @@ impl<T: NodeType> Consensus<T> {
                 self.certs2 = self.certs2.split_off(&keep_from);
                 self.decided_views = self.decided_views.split_off(&keep_from);
                 self.proposals = self.proposals.split_off(&keep_from);
+                self.state_validation_failures =
+                    self.state_validation_failures.split_off(&keep_from);
                 self.vote1_parent = self.vote1_parent.split_off(&keep_from);
                 self.leaves = self.leaves.split_off(&view);
                 self.signed_proposals = self.signed_proposals.split_off(&view);
@@ -2055,6 +2043,48 @@ impl<T: NodeType> Consensus<T> {
             auth_root,
             signed_state_digest,
         })
+    }
+
+    /// A failed validation does not mean the proposal is invalid: state
+    /// catchup timing out fails it too. Dropping the proposal would then make
+    /// every descendant validate against a `from_header` stub and, once a
+    /// child's QC names it, fetch it right back. Retry a bounded number of
+    /// times before dropping it.
+    fn handle_state_validation_failed(
+        &mut self,
+        response: StateResponse<T>,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) {
+        let view = response.view;
+        let Some(proposal) = self.proposals.get(&view) else {
+            warn!(%view, "apply: state validation failed (no stored proposal)");
+            return;
+        };
+        let block = proposal.block_header.block_number();
+        let epoch = proposal.epoch;
+        if proposal_commitment(proposal) != response.commitment {
+            warn!(
+                %view, %block, %epoch,
+                "apply: state validation failed for a superseded proposal"
+            );
+            return;
+        }
+        let failures = self.state_validation_failures.entry(view).or_default();
+        *failures += 1;
+        let failures = *failures;
+        if failures < MAX_STATE_VALIDATION_FAILURES {
+            warn!(%view, %block, %epoch, failures, "apply: state validation failed; retrying");
+            let payload_size = self.payload_size_for(proposal);
+            self.request_state(proposal, payload_size, outbox);
+            return;
+        }
+        warn!(
+            %view, %block, %epoch, failures,
+            "apply: state validation failed repeatedly; dropping proposal"
+        );
+        self.proposals.remove(&view);
+        self.leaves.remove(&view);
+        self.vid_shares.remove(&view);
     }
 
     fn handle_stored(&mut self, stored: StorageOutput<T>, outbox: &mut Outbox<ConsensusOutput<T>>) {

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -788,11 +788,8 @@ impl<T: NodeType> Consensus<T> {
                 Protocol::Continue
             },
             ConsensusInput::StateValidationFailed(state_response) => {
-                // The proposal is kept, like a fetched or epoch-change
-                // proposal without a state: votes are gated on
-                // `states_verified`, and the state manager seeded a
-                // `from_header` stub for the leaf so its descendants can still
-                // be validated via catchup.
+                // Kept like any stateless proposal: votes are gated on
+                // `states_verified`, and the state manager stubbed the leaf.
                 let view = state_response.view;
                 match self.proposals.get(&view) {
                     Some(proposal) => warn!(

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -4,6 +4,7 @@ use std::{
     marker::PhantomData,
     num::NonZeroU64,
     sync::Arc,
+    time::SystemTime,
 };
 
 use committable::{Commitment, CommitmentBoundsArkless, Committable};
@@ -1256,6 +1257,7 @@ impl<T: NodeType> Consensus<T> {
             proposal: proposal.clone(),
             parent_commitment: proposal.justify_qc.data().leaf_commit,
             payload_size,
+            received_at: SystemTime::now(),
         }));
     }
 

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -229,7 +229,8 @@ where
             coordinator_metrics
                 .as_ref()
                 .map(|m| m.consensus.update_leaf_duration.clone().into()),
-        );
+        )
+        .with_parent_deadline(timeout_duration / 2);
         // Seed `from_header` stubs for restored undecided proposals so a child
         // proposal can be validated; anchor seeded last so its state wins.
         for p in initializer.saved_proposals().values() {

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -236,11 +236,7 @@ where
         for p in initializer.saved_proposals().values() {
             state_manager.seed_from_header(message::Proposal::from(p.data.clone()));
         }
-        state_manager.seed_state(
-            anchor_view,
-            initializer.anchor_state().clone(),
-            anchor_leaf.clone(),
-        );
+        state_manager.seed_state(initializer.anchor_state().clone(), anchor_leaf.clone());
         // The anchor leaf and persisted proposals are blocks this node had
         // reconstructed before it went down, so treat them as reconstructed on
         // restart
@@ -1957,12 +1953,12 @@ where
         let anchor_view = seed.decided_anchor.view_number();
         if let Some(state) = seed.validated_states.get(&anchor_view).cloned() {
             self.state_manager
-                .seed_state(anchor_view, state, seed.decided_anchor.clone());
+                .seed_state(state, seed.decided_anchor.clone());
         }
         for leaf in &seed.undecided {
             let view = leaf.view_number();
             if let Some(state) = seed.validated_states.get(&view).cloned() {
-                self.state_manager.seed_state(view, state, leaf.clone());
+                self.state_manager.seed_state(state, leaf.clone());
             }
         }
 

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -424,7 +424,9 @@ impl<T: NodeType> StateManager<T> {
                                 validated: true,
                             });
                         } else {
-                            self.pending_requests.remove(&response.commitment);
+                            // Requests queued on this leaf stay queued:
+                            // consensus may retry the validation, and a
+                            // success then releases them. `gc` bounds them.
                             return Some(StateManagerOutput::State {
                                 response,
                                 validated: false,

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -96,6 +96,8 @@ pub struct StateEntry<T: NodeType> {
     pub state: Arc<T::ValidatedState>,
     pub delta: Option<Delta<T>>,
     pub leaf: Leaf2<T>,
+    /// Built by `from_header`: extending it means catchup.
+    pub stub: bool,
 }
 
 pub struct StateManager<T: NodeType> {
@@ -115,17 +117,21 @@ pub struct StateManager<T: NodeType> {
 /// validation it aborts.
 struct InFlight<T: NodeType> {
     validation: AbortHandle,
-    deadline: AbortHandle,
+    /// Releases the descendants if the validation outlives the parent
+    /// deadline. `None` if they were released up front.
+    deadline: Option<AbortHandle>,
     view: ViewNumber,
     proposal: Proposal<T>,
-    /// Outlived the parent deadline; requests no longer wait for it.
-    overdue: bool,
+    /// Descendants wait for this validation before starting.
+    gates_descendants: bool,
 }
 
 impl<T: NodeType> InFlight<T> {
     fn abort(&self) {
         self.validation.abort();
-        self.deadline.abort();
+        if let Some(deadline) = &self.deadline {
+            deadline.abort();
+        }
     }
 }
 
@@ -172,10 +178,11 @@ impl<T: NodeType> StateManager<T> {
         }
     }
 
-    /// How long requests wait for a parent's in-flight validation before
+    /// How long descendants wait for a parent's in-flight validation before
     /// proceeding against its `from_header` stub. A validation this slow is
     /// catchup-bound, and queueing more catchups behind it costs more than
-    /// running them in parallel.
+    /// running them in parallel. A validation known to be catchup-bound when
+    /// it starts (its own parent is a stub) is not waited for at all.
     pub fn with_parent_deadline(mut self, deadline: Duration) -> Self {
         self.parent_deadline = deadline;
         self
@@ -212,6 +219,7 @@ impl<T: NodeType> StateManager<T> {
             state,
             delta: None,
             leaf,
+            stub: false,
         });
     }
 
@@ -234,7 +242,7 @@ impl<T: NodeType> StateManager<T> {
             return;
         }
 
-        if self.parent_in_flight(&request.parent_commitment) {
+        if self.parent_gates(&request.parent_commitment) {
             self.pending_requests
                 .entry(request.parent_commitment)
                 .or_default()
@@ -282,6 +290,9 @@ impl<T: NodeType> StateManager<T> {
             return;
         };
 
+        // Extending a stub means catchup, and so does extending whatever that
+        // yields; descendants gain nothing by waiting for it.
+        let catchup_bound = parent_entry.stub;
         let duration_metric = self.validate_duration_metric.clone();
         let validation = self.tasks.spawn(async move {
             let measurement = duration_metric.map(Measurement::start);
@@ -328,29 +339,34 @@ impl<T: NodeType> StateManager<T> {
                 },
             }
         });
-        let parent_deadline = self.parent_deadline;
-        let deadline_proposal = proposal.clone();
-        let deadline = self.tasks.spawn(async move {
-            sleep(parent_deadline).await;
-            Completed::Deadline(deadline_proposal)
-        });
-
+        let deadline = (!catchup_bound).then(|| self.spawn_deadline(proposal.clone()));
         self.state_requests.insert(
             commitment,
             InFlight {
                 validation,
                 deadline,
                 view,
-                proposal,
-                overdue: false,
+                proposal: proposal.clone(),
+                gates_descendants: !catchup_bound,
             },
         );
+        if catchup_bound {
+            self.seed_from_header(proposal);
+        }
     }
 
-    fn parent_in_flight(&self, commitment: &Commitment<Leaf2<T>>) -> bool {
+    fn spawn_deadline(&mut self, proposal: Proposal<T>) -> AbortHandle {
+        let parent_deadline = self.parent_deadline;
+        self.tasks.spawn(async move {
+            sleep(parent_deadline).await;
+            Completed::Deadline(proposal)
+        })
+    }
+
+    fn parent_gates(&self, commitment: &Commitment<Leaf2<T>>) -> bool {
         self.state_requests
             .get(commitment)
-            .is_some_and(|in_flight| !in_flight.overdue)
+            .is_some_and(|in_flight| in_flight.gates_descendants)
     }
 
     pub fn request_header(&mut self, request: HeaderRequest<T>) {
@@ -362,7 +378,7 @@ impl<T: NodeType> StateManager<T> {
             return;
         }
 
-        if self.parent_in_flight(&parent_commitment) {
+        if self.parent_gates(&parent_commitment) {
             self.pending_requests
                 .entry(parent_commitment)
                 .or_default()
@@ -437,7 +453,12 @@ impl<T: NodeType> StateManager<T> {
             leaf, state, delta, ..
         } = update;
         let commitment = leaf.commit();
-        self.insert_state(StateEntry { state, delta, leaf });
+        self.insert_state(StateEntry {
+            state,
+            delta,
+            leaf,
+            stub: false,
+        });
         if let Some(in_flight) = self.state_requests.remove(&commitment) {
             in_flight.abort();
         }
@@ -458,7 +479,9 @@ impl<T: NodeType> StateManager<T> {
                         else {
                             continue;
                         };
-                        in_flight.deadline.abort();
+                        if let Some(deadline) = in_flight.deadline {
+                            deadline.abort();
+                        }
                         // A failed validation still leaves a stub so queued
                         // requests proceed via catchup.
                         let measurement = if validated {
@@ -472,6 +495,7 @@ impl<T: NodeType> StateManager<T> {
                             state: response.state.clone(),
                             delta: response.delta.clone(),
                             leaf,
+                            stub: !validated,
                         });
                         finish_measurement(measurement);
                         self.start_pending(response.commitment);
@@ -495,7 +519,7 @@ impl<T: NodeType> StateManager<T> {
                         let Some(in_flight) = self.state_requests.get_mut(&commitment) else {
                             continue;
                         };
-                        in_flight.overdue = true;
+                        in_flight.gates_descendants = false;
                         warn!(
                             view = %proposal.view_number(),
                             deadline = ?self.parent_deadline,
@@ -586,6 +610,7 @@ impl<T: NodeType> StateManager<T> {
             state: Arc::new(state),
             delta: None,
             leaf: proposal.into(),
+            stub: true,
         });
     }
 

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -424,9 +424,7 @@ impl<T: NodeType> StateManager<T> {
                                 validated: true,
                             });
                         } else {
-                            // Requests queued on this leaf stay queued:
-                            // consensus may retry the validation, and a
-                            // success then releases them. `gc` bounds them.
+                            self.pending_requests.remove(&response.commitment);
                             return Some(StateManagerOutput::State {
                                 response,
                                 validated: false,

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -207,8 +207,12 @@ impl<T: NodeType> StateManager<T> {
             .map(|(_, entry)| entry.leaf.clone())
     }
 
-    pub fn seed_state(&mut self, view: ViewNumber, state: Arc<T::ValidatedState>, leaf: Leaf2<T>) {
-        self.insert_state(view, state, None, leaf);
+    pub fn seed_state(&mut self, state: Arc<T::ValidatedState>, leaf: Leaf2<T>) {
+        self.insert_state(StateEntry {
+            state,
+            delta: None,
+            leaf,
+        });
     }
 
     /// Seed a commitment-only (`from_header`) state so a child proposal can be
@@ -430,13 +434,10 @@ impl<T: NodeType> StateManager<T> {
     /// Provide an externally-obtained validated state.
     pub fn update_state(&mut self, update: UpdateLeaf<T>) {
         let UpdateLeaf {
-            view,
-            leaf,
-            state,
-            delta,
+            leaf, state, delta, ..
         } = update;
         let commitment = leaf.commit();
-        self.insert_state(view, state, delta, leaf);
+        self.insert_state(StateEntry { state, delta, leaf });
         if let Some(in_flight) = self.state_requests.remove(&commitment) {
             in_flight.abort();
         }
@@ -467,12 +468,11 @@ impl<T: NodeType> StateManager<T> {
                         } else {
                             None
                         };
-                        self.insert_state(
-                            response.view,
-                            response.state.clone(),
-                            response.delta.clone(),
+                        self.insert_state(StateEntry {
+                            state: response.state.clone(),
+                            delta: response.delta.clone(),
                             leaf,
-                        );
+                        });
                         finish_measurement(measurement);
                         self.start_pending(response.commitment);
                         return Some(StateManagerOutput::State {
@@ -565,35 +565,28 @@ impl<T: NodeType> StateManager<T> {
     /// have no delta. States produced by `validate_and_apply_header` carry a delta representing
     /// the state transition. This method prevents a `from_header` state from overwriting a
     /// fully validated state that already has a delta.
-    fn insert_state(
-        &mut self,
-        view: ViewNumber,
-        state: Arc<T::ValidatedState>,
-        delta: Option<Delta<T>>,
-        leaf: Leaf2<T>,
-    ) {
-        if let Some(existing) = self.validated_states.get(&leaf.commit())
+    fn insert_state(&mut self, entry: StateEntry<T>) {
+        let commitment = entry.leaf.commit();
+        if let Some(existing) = self.validated_states.get(&commitment)
             && existing.delta.is_some()
-            && delta.is_none()
+            && entry.delta.is_none()
         {
             warn!(
-                ?view,
+                view = ?entry.leaf.view_number(),
                 "Skipping state update to not override a state with a delta"
             );
             return;
         }
-        self.validated_states
-            .insert(leaf.commit(), StateEntry { state, delta, leaf });
+        self.validated_states.insert(commitment, entry);
     }
 
     fn insert_empty_state(&mut self, proposal: Proposal<T>) {
         let state = T::ValidatedState::from_header(&proposal.block_header);
-        self.insert_state(
-            proposal.view_number(),
-            Arc::new(state),
-            None,
-            proposal.into(),
-        );
+        self.insert_state(StateEntry {
+            state: Arc::new(state),
+            delta: None,
+            leaf: proposal.into(),
+        });
     }
 
     #[cfg(test)]

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 
 use committable::{Commitment, Committable};
@@ -17,7 +17,10 @@ use hotshot_types::{
     utils::BuilderCommitment,
     vote::HasViewNumber,
 };
-use tokio::task::{AbortHandle, JoinSet};
+use tokio::{
+    task::{AbortHandle, JoinSet},
+    time::sleep,
+};
 use tracing::{error, warn};
 
 use crate::{
@@ -25,6 +28,9 @@ use crate::{
     helpers::proposal_commitment,
     message::Proposal,
 };
+
+/// Default for [`StateManager::with_parent_deadline`].
+const DEFAULT_PARENT_DEADLINE: Duration = Duration::from_secs(5);
 
 pub struct UpdateLeaf<T: NodeType> {
     pub view: ViewNumber,
@@ -104,13 +110,27 @@ pub struct StateManager<T: NodeType> {
     tasks: JoinSet<Completed<T>>,
     validate_duration_metric: Option<Arc<dyn Histogram>>,
     update_leaf_duration_metric: Option<Arc<dyn Histogram>>,
+    /// See [`Self::with_parent_deadline`].
+    parent_deadline: Duration,
 }
 
-/// The proposal lets `gc` seed a stub for a validation it aborts.
+/// A state validation in progress. The proposal lets `gc` seed a stub for a
+/// validation it aborts.
 struct InFlight<T: NodeType> {
-    handle: AbortHandle,
+    validation: AbortHandle,
+    deadline: AbortHandle,
     view: ViewNumber,
     proposal: Proposal<T>,
+    /// Set once the validation outlives the parent deadline; requests on this
+    /// leaf then proceed against its `from_header` stub instead of waiting.
+    overdue: bool,
+}
+
+impl<T: NodeType> InFlight<T> {
+    fn abort(&self) {
+        self.validation.abort();
+        self.deadline.abort();
+    }
 }
 
 enum Pending<T: NodeType> {
@@ -137,6 +157,8 @@ enum Completed<T: NodeType> {
         response: HeaderResponse<T>,
         header: Option<T::BlockHeader>,
     },
+    /// The parent deadline elapsed for the validation of this proposal.
+    Deadline(Proposal<T>),
 }
 
 impl<T: NodeType> StateManager<T> {
@@ -151,7 +173,20 @@ impl<T: NodeType> StateManager<T> {
             tasks: JoinSet::new(),
             validate_duration_metric: None,
             update_leaf_duration_metric: None,
+            parent_deadline: DEFAULT_PARENT_DEADLINE,
         }
+    }
+
+    /// How long a request waits for its parent's in-flight validation before
+    /// proceeding against a `from_header` stub of the parent instead.
+    ///
+    /// Validation is fast on a dense state; one that takes this long is bound
+    /// by catchup, and queueing more catchups behind it costs more than running
+    /// them in parallel. The real state still replaces the stub when the
+    /// validation finishes.
+    pub fn with_parent_deadline(mut self, deadline: Duration) -> Self {
+        self.parent_deadline = deadline;
+        self
     }
 
     pub fn with_metrics(
@@ -203,7 +238,7 @@ impl<T: NodeType> StateManager<T> {
             return;
         }
 
-        if self.state_requests.contains_key(&request.parent_commitment) {
+        if self.parent_in_flight(&request.parent_commitment) {
             self.pending_requests
                 .entry(request.parent_commitment)
                 .or_default()
@@ -252,7 +287,7 @@ impl<T: NodeType> StateManager<T> {
         };
 
         let duration_metric = self.validate_duration_metric.clone();
-        let handle = self.tasks.spawn(async move {
+        let validation = self.tasks.spawn(async move {
             let measurement = duration_metric.map(Measurement::start);
             let result = parent_entry
                 .state
@@ -297,15 +332,31 @@ impl<T: NodeType> StateManager<T> {
                 },
             }
         });
+        let parent_deadline = self.parent_deadline;
+        let deadline_proposal = proposal.clone();
+        let deadline = self.tasks.spawn(async move {
+            sleep(parent_deadline).await;
+            Completed::Deadline(deadline_proposal)
+        });
 
         self.state_requests.insert(
             commitment,
             InFlight {
-                handle,
+                validation,
+                deadline,
                 view,
                 proposal,
+                overdue: false,
             },
         );
+    }
+
+    /// Whether requests on `commitment` should wait: its validation is running
+    /// and has not outlived the parent deadline.
+    fn parent_in_flight(&self, commitment: &Commitment<Leaf2<T>>) -> bool {
+        self.state_requests
+            .get(commitment)
+            .is_some_and(|in_flight| !in_flight.overdue)
     }
 
     pub fn request_header(&mut self, request: HeaderRequest<T>) {
@@ -317,7 +368,7 @@ impl<T: NodeType> StateManager<T> {
             return;
         }
 
-        if self.state_requests.contains_key(&parent_commitment) {
+        if self.parent_in_flight(&parent_commitment) {
             self.pending_requests
                 .entry(parent_commitment)
                 .or_default()
@@ -397,7 +448,7 @@ impl<T: NodeType> StateManager<T> {
         let commitment = leaf.commit();
         self.insert_state(view, state, delta, leaf);
         if let Some(in_flight) = self.state_requests.remove(&commitment) {
-            in_flight.handle.abort();
+            in_flight.abort();
         }
         self.start_pending(commitment);
     }
@@ -412,9 +463,11 @@ impl<T: NodeType> StateManager<T> {
                         leaf,
                         validated,
                     } => {
-                        if self.state_requests.remove(&response.commitment).is_none() {
+                        let Some(in_flight) = self.state_requests.remove(&response.commitment)
+                        else {
                             continue;
-                        }
+                        };
+                        in_flight.deadline.abort();
                         // A failed validation leaves a `from_header` stub
                         // (never displacing a real state) so the requests
                         // queued on this leaf proceed via catchup instead of
@@ -448,6 +501,20 @@ impl<T: NodeType> StateManager<T> {
                             continue;
                         }
                         return Some(StateManagerOutput::Header { response, header });
+                    },
+                    Completed::Deadline(proposal) => {
+                        let commitment = proposal_commitment(&proposal);
+                        let Some(in_flight) = self.state_requests.get_mut(&commitment) else {
+                            continue;
+                        };
+                        in_flight.overdue = true;
+                        warn!(
+                            view = %proposal.view_number(),
+                            deadline = ?self.parent_deadline,
+                            "state validation still running past the parent deadline; \
+                             descendants proceed against a from_header stub"
+                        );
+                        self.seed_from_header(proposal);
                     },
                 },
                 Some(Err(err)) => {
@@ -485,7 +552,7 @@ impl<T: NodeType> StateManager<T> {
             .extract_if(|_, in_flight| in_flight.view < view_number)
             .collect();
         for (commitment, in_flight) in stale {
-            in_flight.handle.abort();
+            in_flight.abort();
             if self.pending_requests.contains_key(&commitment) {
                 self.seed_from_header(in_flight.proposal);
             }

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
+    time::SystemTime,
 };
 
 use committable::{Commitment, Committable};
@@ -41,6 +42,8 @@ pub struct StateRequest<T: NodeType> {
     pub proposal: Proposal<T>,
     pub parent_commitment: Commitment<Leaf2<T>>,
     pub payload_size: u32,
+    /// When this node obtained the proposal; validation may start much later.
+    pub received_at: SystemTime,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -260,6 +263,7 @@ impl<T: NodeType> StateManager<T> {
                     payload_size,
                     upgrade_lock,
                     *view,
+                    request.received_at,
                 )
                 .await;
             let leaf = request.proposal.into();

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -94,13 +94,20 @@ pub struct StateEntry<T: NodeType> {
 pub struct StateManager<T: NodeType> {
     instance: Arc<T::InstanceState>,
     validated_states: BTreeMap<Commitment<Leaf2<T>>, StateEntry<T>>,
-    state_requests: HashMap<Commitment<Leaf2<T>>, (AbortHandle, ViewNumber)>,
+    state_requests: HashMap<Commitment<Leaf2<T>>, InFlight<T>>,
     header_requests: HashMap<(ViewNumber, Commitment<Leaf2<T>>), AbortHandle>,
     pending_requests: HashMap<Commitment<Leaf2<T>>, Vec<Pending<T>>>,
     upgrade_lock: UpgradeLock<T>,
     tasks: JoinSet<Completed<T>>,
     validate_duration_metric: Option<Arc<dyn Histogram>>,
     update_leaf_duration_metric: Option<Arc<dyn Histogram>>,
+}
+
+/// The proposal lets `gc` seed a stub for a validation it aborts.
+struct InFlight<T: NodeType> {
+    handle: AbortHandle,
+    view: ViewNumber,
+    proposal: Proposal<T>,
 }
 
 enum Pending<T: NodeType> {
@@ -231,6 +238,7 @@ impl<T: NodeType> StateManager<T> {
 
         let instance = self.instance.clone();
         let header = request.proposal.block_header.clone();
+        let proposal = request.proposal.clone();
         let view = request.view;
         let payload_size = request.payload_size;
 
@@ -282,7 +290,14 @@ impl<T: NodeType> StateManager<T> {
             }
         });
 
-        self.state_requests.insert(commitment, (handle, view));
+        self.state_requests.insert(
+            commitment,
+            InFlight {
+                handle,
+                view,
+                proposal,
+            },
+        );
     }
 
     pub fn request_header(&mut self, request: HeaderRequest<T>) {
@@ -373,8 +388,8 @@ impl<T: NodeType> StateManager<T> {
         } = update;
         let commitment = leaf.commit();
         self.insert_state(view, state, delta, leaf);
-        if let Some((task, _)) = self.state_requests.remove(&commitment) {
-            task.abort();
+        if let Some(in_flight) = self.state_requests.remove(&commitment) {
+            in_flight.handle.abort();
         }
         self.start_pending(commitment);
     }
@@ -437,18 +452,12 @@ impl<T: NodeType> StateManager<T> {
         }
     }
 
+    /// The decided view's own validation, or a header this node needs to
+    /// propose, may be queued behind a validation aborted here. A stub for the
+    /// aborted proposal lets them proceed via catchup instead of hanging.
     pub fn gc(&mut self, view_number: ViewNumber) {
         self.validated_states
             .retain(|_, entry| entry.leaf.view_number() >= view_number);
-
-        for (task, view) in self.state_requests.values() {
-            if *view < view_number {
-                task.abort();
-            }
-        }
-
-        self.state_requests
-            .retain(|_, (_, view)| *view >= view_number);
 
         self.header_requests.retain(|(view, _), handle| {
             let keep = *view >= view_number;
@@ -462,6 +471,17 @@ impl<T: NodeType> StateManager<T> {
             pending.retain(|p| p.view() >= view_number);
             !pending.is_empty()
         });
+
+        let stale: Vec<_> = self
+            .state_requests
+            .extract_if(|_, in_flight| in_flight.view < view_number)
+            .collect();
+        for (commitment, in_flight) in stale {
+            in_flight.handle.abort();
+            if self.pending_requests.contains_key(&commitment) {
+                self.seed_from_header(in_flight.proposal);
+            }
+        }
     }
 
     fn start_pending(&mut self, finished_commitment: Commitment<Leaf2<T>>) {

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -29,7 +29,6 @@ use crate::{
     message::Proposal,
 };
 
-/// Default for [`StateManager::with_parent_deadline`].
 const DEFAULT_PARENT_DEADLINE: Duration = Duration::from_secs(5);
 
 pub struct UpdateLeaf<T: NodeType> {
@@ -48,7 +47,6 @@ pub struct StateRequest<T: NodeType> {
     pub proposal: Proposal<T>,
     pub parent_commitment: Commitment<Leaf2<T>>,
     pub payload_size: u32,
-    /// When this node obtained the proposal; validation may start much later.
     pub received_at: SystemTime,
 }
 
@@ -110,7 +108,6 @@ pub struct StateManager<T: NodeType> {
     tasks: JoinSet<Completed<T>>,
     validate_duration_metric: Option<Arc<dyn Histogram>>,
     update_leaf_duration_metric: Option<Arc<dyn Histogram>>,
-    /// See [`Self::with_parent_deadline`].
     parent_deadline: Duration,
 }
 
@@ -121,8 +118,7 @@ struct InFlight<T: NodeType> {
     deadline: AbortHandle,
     view: ViewNumber,
     proposal: Proposal<T>,
-    /// Set once the validation outlives the parent deadline; requests on this
-    /// leaf then proceed against its `from_header` stub instead of waiting.
+    /// Outlived the parent deadline; requests no longer wait for it.
     overdue: bool,
 }
 
@@ -157,7 +153,6 @@ enum Completed<T: NodeType> {
         response: HeaderResponse<T>,
         header: Option<T::BlockHeader>,
     },
-    /// The parent deadline elapsed for the validation of this proposal.
     Deadline(Proposal<T>),
 }
 
@@ -177,13 +172,10 @@ impl<T: NodeType> StateManager<T> {
         }
     }
 
-    /// How long a request waits for its parent's in-flight validation before
-    /// proceeding against a `from_header` stub of the parent instead.
-    ///
-    /// Validation is fast on a dense state; one that takes this long is bound
-    /// by catchup, and queueing more catchups behind it costs more than running
-    /// them in parallel. The real state still replaces the stub when the
-    /// validation finishes.
+    /// How long requests wait for a parent's in-flight validation before
+    /// proceeding against its `from_header` stub. A validation this slow is
+    /// catchup-bound, and queueing more catchups behind it costs more than
+    /// running them in parallel.
     pub fn with_parent_deadline(mut self, deadline: Duration) -> Self {
         self.parent_deadline = deadline;
         self
@@ -351,8 +343,6 @@ impl<T: NodeType> StateManager<T> {
         );
     }
 
-    /// Whether requests on `commitment` should wait: its validation is running
-    /// and has not outlived the parent deadline.
     fn parent_in_flight(&self, commitment: &Commitment<Leaf2<T>>) -> bool {
         self.state_requests
             .get(commitment)
@@ -468,10 +458,8 @@ impl<T: NodeType> StateManager<T> {
                             continue;
                         };
                         in_flight.deadline.abort();
-                        // A failed validation leaves a `from_header` stub
-                        // (never displacing a real state) so the requests
-                        // queued on this leaf proceed via catchup instead of
-                        // being dropped.
+                        // A failed validation still leaves a stub so queued
+                        // requests proceed via catchup.
                         let measurement = if validated {
                             self.update_leaf_duration_metric
                                 .clone()

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -127,7 +127,8 @@ impl<T: NodeType> Pending<T> {
 enum Completed<T: NodeType> {
     State {
         response: StateResponse<T>,
-        leaf: Option<Leaf2<T>>,
+        leaf: Leaf2<T>,
+        validated: bool,
     },
     Header {
         response: HeaderResponse<T>,
@@ -261,6 +262,7 @@ impl<T: NodeType> StateManager<T> {
                     *view,
                 )
                 .await;
+            let leaf = request.proposal.into();
             match result {
                 Ok((state, delta)) => {
                     finish_measurement(measurement);
@@ -271,7 +273,8 @@ impl<T: NodeType> StateManager<T> {
                             state: Arc::new(state),
                             delta: Some(Arc::new(delta)),
                         },
-                        leaf: Some(request.proposal.into()),
+                        leaf,
+                        validated: true,
                     }
                 },
                 Err(err) => {
@@ -284,7 +287,8 @@ impl<T: NodeType> StateManager<T> {
                             state: Arc::new(T::ValidatedState::from_header(&header)),
                             delta: None,
                         },
-                        leaf: None,
+                        leaf,
+                        validated: false,
                     }
                 },
             }
@@ -401,35 +405,35 @@ impl<T: NodeType> StateManager<T> {
                 Some(Ok(result)) => match result {
                     Completed::State {
                         response,
-                        leaf: leaf2,
+                        leaf,
+                        validated,
                     } => {
                         if self.state_requests.remove(&response.commitment).is_none() {
                             continue;
                         }
-                        if let Some(leaf) = leaf2 {
-                            let measurement = self
-                                .update_leaf_duration_metric
+                        // A failed validation leaves a `from_header` stub
+                        // (never displacing a real state) so the requests
+                        // queued on this leaf proceed via catchup instead of
+                        // being dropped.
+                        let measurement = if validated {
+                            self.update_leaf_duration_metric
                                 .clone()
-                                .map(Measurement::start);
-                            self.insert_state(
-                                response.view,
-                                response.state.clone(),
-                                response.delta.clone(),
-                                leaf,
-                            );
-                            finish_measurement(measurement);
-                            self.start_pending(response.commitment);
-                            return Some(StateManagerOutput::State {
-                                response,
-                                validated: true,
-                            });
+                                .map(Measurement::start)
                         } else {
-                            self.pending_requests.remove(&response.commitment);
-                            return Some(StateManagerOutput::State {
-                                response,
-                                validated: false,
-                            });
-                        }
+                            None
+                        };
+                        self.insert_state(
+                            response.view,
+                            response.state.clone(),
+                            response.delta.clone(),
+                            leaf,
+                        );
+                        finish_measurement(measurement);
+                        self.start_pending(response.commitment);
+                        return Some(StateManagerOutput::State {
+                            response,
+                            validated,
+                        });
                     },
                     Completed::Header { response, header } => {
                         let key = (

--- a/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
@@ -103,21 +103,17 @@ pub async fn build_test_coordinator(
 
     let mut state_manager = StateManager::new(instance.clone(), upgrade_lock.clone());
     let genesis_state = Arc::new(genesis_state);
-    state_manager.seed_state(
-        ViewNumber::genesis(),
-        genesis_state.clone(),
-        genesis_leaf.clone(),
-    );
+    state_manager.seed_state(genesis_state.clone(), genesis_leaf.clone());
 
     if let Some(seed) = pre_cutover_seed.as_ref() {
         let anchor_view = seed.decided_anchor.view_number();
         if let Some(state) = seed.validated_states.get(&anchor_view).cloned() {
-            state_manager.seed_state(anchor_view, state, seed.decided_anchor.clone());
+            state_manager.seed_state(state, seed.decided_anchor.clone());
         }
         for leaf in &seed.undecided {
             let view = leaf.view_number();
             if let Some(state) = seed.validated_states.get(&view).cloned() {
-                state_manager.seed_state(view, state, leaf.clone());
+                state_manager.seed_state(state, leaf.clone());
             }
         }
     }
@@ -156,7 +152,7 @@ pub async fn build_test_coordinator(
         let anchor_state = <TestValidatedState as hotshot_types::traits::states::ValidatedState<
             TestTypes,
         >>::from_header(anchor_leaf.block_header());
-        state_manager.seed_state(anchor_view, Arc::new(anchor_state), anchor_leaf.clone());
+        state_manager.seed_state(Arc::new(anchor_state), anchor_leaf.clone());
         let reconstructed = reconstructed_blocks(
             std::iter::once((anchor_view, anchor_leaf.block_header().clone())).chain(
                 storage
@@ -183,11 +179,7 @@ pub async fn build_test_coordinator(
         // `genesis_leaf` (which has a null justify_qc). `request_header` for view 1
         // looks up the parent state by the proposal's leaf commitment, so seed the
         // genesis state under that commitment too.
-        state_manager.seed_state(
-            ViewNumber::genesis(),
-            genesis_state,
-            Leaf2::from(genesis_proposal.clone()),
-        );
+        state_manager.seed_state(genesis_state, Leaf2::from(genesis_proposal.clone()));
         consensus.seed_parent(
             genesis_cert1.clone(),
             genesis_proposal.clone(),

--- a/crates/hotshot/new-protocol/src/tests/common/harness.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/harness.rs
@@ -102,7 +102,7 @@ impl TestHarness {
         );
 
         let mut state_manager = StateManager::new(instance.clone(), upgrade_lock.clone());
-        state_manager.seed_state(ViewNumber::genesis(), Arc::new(genesis_state), genesis_leaf);
+        state_manager.seed_state(Arc::new(genesis_state), genesis_leaf);
 
         let proposal_validator =
             ProposalValidator::new(membership.clone(), epoch_height, upgrade_lock.clone());

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -483,35 +483,27 @@ async fn test_no_duplicate_vote2() {
     );
 }
 
-/// StateValidationFailed with matching commitment removes proposal and vid_share.
+/// A proposal whose state validation failed is kept: votes are gated on
+/// `states_verified`, and the state manager seeds a stub for the leaf, so its
+/// child can still be validated and voted on.
 #[tokio::test]
-async fn test_state_validation_failed_removes_proposal() {
+async fn test_child_of_failed_validation_can_vote() {
     let mut harness = ConsensusHarness::new(0).await;
     let test_data = TestData::new(3).await;
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
+    // Hold view 1's validation result and inject a failure instead.
+    harness.defer_state(ViewNumber::new(1));
     harness
         .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
         .await;
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
-
-    // Send proposal for view 2 — but bypass the harness auto-response
-    // by directly applying the proposal input, then manually sending
-    // StateValidationFailed instead of letting the harness auto-respond.
-    // We need to call consensus.apply directly to avoid auto StateVerified.
-    let (proposal_input, vid_share_input) = test_data.views[1].proposal_input_consensus(&node_key);
-    let mut outbox = Outbox::new();
-    harness.consensus.apply(proposal_input, &mut outbox);
-    harness.consensus.apply(vid_share_input, &mut outbox);
-    harness.collected.extend(outbox.take());
-
-    // Send StateVerificationFailed — removes proposal
-    let proposal: Proposal<TestTypes> = test_data.views[1].proposal.data.clone();
+    let proposal: Proposal<TestTypes> = test_data.views[0].proposal.data.clone();
     harness
         .apply(ConsensusInput::StateValidationFailed(StateResponse {
-            view: test_data.views[1].view_number,
+            view: test_data.views[0].view_number,
             commitment: proposal_commitment(&proposal),
             state: Arc::new(
                 <TestValidatedState as ValidatedState<TestTypes>>::from_header(
@@ -521,16 +513,17 @@ async fn test_state_validation_failed_removes_proposal() {
             delta: None,
         }))
         .await;
-
-    // Now send cert1 + block_reconstructed — vote2 should NOT fire
-    harness
-        .apply(test_data.views[1].block_reconstructed_input())
-        .await;
-    harness.apply(test_data.views[1].cert1_input()).await;
-
     assert!(
-        !any(harness.outputs(), is_vote2),
-        "Vote2 should not fire after proposal removed by StateVerificationFailed"
+        !any(harness.outputs(), is_vote1),
+        "no vote1 for a view whose validation failed"
+    );
+
+    harness
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
+        .await;
+    assert!(
+        any(harness.outputs(), is_vote1),
+        "the child of a failed view must still be votable"
     );
 }
 

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -719,6 +719,52 @@ async fn test_leader_sends_proposal() {
     );
 }
 
+/// A fetched proposal gets its state validated like a gossiped one.
+#[tokio::test]
+async fn test_fetched_proposal_requests_state() {
+    let test_data = TestData::new(2).await;
+    let mut harness = ConsensusHarness::new(0).await;
+
+    harness
+        .apply(ConsensusInput::FetchedProposal(
+            test_data.views[0].proposal_message(),
+        ))
+        .await;
+
+    assert!(
+        any(harness.outputs(), |o| matches!(
+            o,
+            ConsensusOutput::RequestState(r) if r.view == ViewNumber::new(1)
+        )),
+        "state validation must be requested for a fetched proposal"
+    );
+}
+
+/// Regression: a leader whose parent arrived via fetch could not propose.
+#[tokio::test]
+async fn test_leader_proposes_off_fetched_parent() {
+    let test_data = TestData::new(3).await;
+    let leader_for_view_2 = test_data.views[1].leader_public_key;
+    let leader_index = node_index_for_key(&leader_for_view_2);
+    let mut harness = ConsensusHarness::new(leader_index).await;
+
+    harness
+        .apply(ConsensusInput::FetchedProposal(
+            test_data.views[0].proposal_message(),
+        ))
+        .await;
+    harness.apply(test_data.views[0].cert1_input()).await;
+
+    assert!(
+        any(harness.outputs(), is_request_block_and_header),
+        "leader must request block and header off a fetched parent"
+    );
+    assert!(
+        any(harness.outputs(), |o| is_proposal_for_view(o, 2)),
+        "leader must propose once the fetched parent's cert1 forms"
+    );
+}
+
 /// Regression: `maybe_propose` must refuse to propose when
 /// `self.proposals[parent_view]` has drifted from
 /// `parent_cert.data.leaf_commit`.
@@ -859,13 +905,14 @@ async fn test_timeout_proposal_chains_from_lock_not_timed_out_cert1() {
         .await;
     harness.apply(test_data.views[0].cert1_input()).await;
 
-    // View 2 arrives via fetch (no optimistic header request); its cert1
-    // forms but the block is never reconstructed, so the lock stays at 1.
-    harness
-        .apply(ConsensusInput::FetchedProposal(
-            test_data.views[1].proposal_message(),
-        ))
-        .await;
+    // View 2 arrives via fetch and its block is never reconstructed, so the
+    // lock stays at 1. Bypass the harness so the header request off view 2
+    // stays unanswered and the leader cannot propose view 3 from cert1(2).
+    let mut fetched = Outbox::new();
+    harness.consensus.apply(
+        ConsensusInput::FetchedProposal(test_data.views[1].proposal_message()),
+        &mut fetched,
+    );
     harness.apply(test_data.views[1].cert1_input()).await;
     assert!(
         harness
@@ -917,15 +964,15 @@ async fn test_bridged_legacy_qc_adopts_lock_and_reproposes() {
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
     harness.apply(test_data.views[0].cert1_input()).await;
-    harness
-        .apply(ConsensusInput::FetchedProposal(
-            test_data.views[1].proposal_message(),
-        ))
-        .await;
 
-    // Manual outbox from here: the TC's header request stays unfulfilled, so
+    // Manual outbox from here so both header requests stay unfulfilled and
     // the leader has not proposed view 3 when the legacy QC arrives.
     let mut outbox = Outbox::new();
+    harness.consensus.apply(
+        ConsensusInput::FetchedProposal(test_data.views[1].proposal_message()),
+        &mut outbox,
+    );
+    outbox.clear();
     harness
         .consensus
         .apply(test_data.views[1].timeout_cert_input(), &mut outbox);

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -15,7 +15,7 @@ use hotshot_types::{
 
 use super::common::utils::{TestData, TestView};
 use crate::{
-    consensus::{ConsensusInput, ConsensusOutput, MAX_STATE_VALIDATION_FAILURES},
+    consensus::{ConsensusInput, ConsensusOutput},
     coordinator::GcScope,
     helpers::proposal_commitment,
     message::Proposal,
@@ -483,27 +483,9 @@ async fn test_no_duplicate_vote2() {
     );
 }
 
-fn state_validation_failed_input(view: &TestView) -> ConsensusInput<TestTypes> {
-    let proposal: Proposal<TestTypes> = view.proposal.data.clone();
-    ConsensusInput::StateValidationFailed(StateResponse {
-        view: view.view_number,
-        commitment: proposal_commitment(&proposal),
-        state: Arc::new(
-            <TestValidatedState as ValidatedState<TestTypes>>::from_header(&proposal.block_header),
-        ),
-        delta: None,
-    })
-}
-
-fn requests_state_for(output: &ConsensusOutput<TestTypes>, view: u64) -> bool {
-    matches!(output, ConsensusOutput::RequestState(r) if *r.view == view)
-}
-
-/// A failed state validation is retried: catchup timing out fails validation
-/// too, and dropping the proposal would leave every descendant validating
-/// against a `from_header` stub. Once the retry succeeds the node votes.
+/// StateValidationFailed with matching commitment removes proposal and vid_share.
 #[tokio::test]
-async fn test_state_validation_failed_retries() {
+async fn test_state_validation_failed_removes_proposal() {
     let mut harness = ConsensusHarness::new(0).await;
     let test_data = TestData::new(3).await;
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
@@ -514,80 +496,41 @@ async fn test_state_validation_failed_retries() {
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
-    let votes_before = count_matching(harness.outputs(), is_vote1);
 
-    // Hold view 2's validation result so a failure can be injected instead.
-    harness.defer_state(ViewNumber::new(2));
+    // Send proposal for view 2 — but bypass the harness auto-response
+    // by directly applying the proposal input, then manually sending
+    // StateValidationFailed instead of letting the harness auto-respond.
+    // We need to call consensus.apply directly to avoid auto StateVerified.
+    let (proposal_input, vid_share_input) = test_data.views[1].proposal_input_consensus(&node_key);
+    let mut outbox = Outbox::new();
+    harness.consensus.apply(proposal_input, &mut outbox);
+    harness.consensus.apply(vid_share_input, &mut outbox);
+    harness.collected.extend(outbox.take());
+
+    // Send StateVerificationFailed — removes proposal
+    let proposal: Proposal<TestTypes> = test_data.views[1].proposal.data.clone();
     harness
-        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
+        .apply(ConsensusInput::StateValidationFailed(StateResponse {
+            view: test_data.views[1].view_number,
+            commitment: proposal_commitment(&proposal),
+            state: Arc::new(
+                <TestValidatedState as ValidatedState<TestTypes>>::from_header(
+                    &proposal.block_header,
+                ),
+            ),
+            delta: None,
+        }))
         .await;
-    assert_eq!(
-        count_matching(harness.outputs(), |o| requests_state_for(o, 2)),
-        1
-    );
 
-    harness
-        .apply(state_validation_failed_input(&test_data.views[1]))
-        .await;
-    assert_eq!(
-        count_matching(harness.outputs(), |o| requests_state_for(o, 2)),
-        2,
-        "a failed validation must be re-requested"
-    );
-
-    // The retry succeeds: the proposal was kept, so the node can vote on it.
-    harness.release_state(ViewNumber::new(2)).await;
-    assert_eq!(
-        count_matching(harness.outputs(), is_vote1),
-        votes_before + 1,
-        "vote1 must follow the retried validation"
-    );
-}
-
-/// After the last permitted failure the proposal is dropped, as before
-/// retries existed: even a late success must not make the node vote on it.
-#[tokio::test]
-async fn test_state_validation_failed_repeatedly_drops_proposal() {
-    let mut harness = ConsensusHarness::new(0).await;
-    let test_data = TestData::new(3).await;
-    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
-
-    harness
-        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
-        .await;
-    harness
-        .apply(test_data.views[0].block_reconstructed_input())
-        .await;
-    let votes_before = count_matching(harness.outputs(), is_vote1);
-
-    harness.defer_state(ViewNumber::new(2));
-    harness
-        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
-        .await;
-    for _ in 0..MAX_STATE_VALIDATION_FAILURES {
-        harness
-            .apply(state_validation_failed_input(&test_data.views[1]))
-            .await;
-    }
-    assert_eq!(
-        count_matching(harness.outputs(), |o| requests_state_for(o, 2)),
-        MAX_STATE_VALIDATION_FAILURES as usize,
-        "no retry after the last permitted failure"
-    );
-
-    harness.release_state(ViewNumber::new(2)).await;
+    // Now send cert1 + block_reconstructed — vote2 should NOT fire
     harness
         .apply(test_data.views[1].block_reconstructed_input())
         .await;
     harness.apply(test_data.views[1].cert1_input()).await;
-    assert_eq!(
-        count_matching(harness.outputs(), is_vote1),
-        votes_before,
-        "no vote1 for a dropped proposal"
-    );
+
     assert!(
         !any(harness.outputs(), is_vote2),
-        "no vote2 for a dropped proposal"
+        "Vote2 should not fire after proposal removed by StateVerificationFailed"
     );
 }
 

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -483,16 +483,13 @@ async fn test_no_duplicate_vote2() {
     );
 }
 
-/// A proposal whose state validation failed is kept: votes are gated on
-/// `states_verified`, and the state manager seeds a stub for the leaf, so its
-/// child can still be validated and voted on.
+/// A proposal whose validation failed is kept, so its child can still be voted on.
 #[tokio::test]
 async fn test_child_of_failed_validation_can_vote() {
     let mut harness = ConsensusHarness::new(0).await;
     let test_data = TestData::new(3).await;
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
 
-    // Hold view 1's validation result and inject a failure instead.
     harness.defer_state(ViewNumber::new(1));
     harness
         .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -15,7 +15,7 @@ use hotshot_types::{
 
 use super::common::utils::{TestData, TestView};
 use crate::{
-    consensus::{ConsensusInput, ConsensusOutput},
+    consensus::{ConsensusInput, ConsensusOutput, MAX_STATE_VALIDATION_FAILURES},
     coordinator::GcScope,
     helpers::proposal_commitment,
     message::Proposal,
@@ -483,9 +483,27 @@ async fn test_no_duplicate_vote2() {
     );
 }
 
-/// StateValidationFailed with matching commitment removes proposal and vid_share.
+fn state_validation_failed_input(view: &TestView) -> ConsensusInput<TestTypes> {
+    let proposal: Proposal<TestTypes> = view.proposal.data.clone();
+    ConsensusInput::StateValidationFailed(StateResponse {
+        view: view.view_number,
+        commitment: proposal_commitment(&proposal),
+        state: Arc::new(
+            <TestValidatedState as ValidatedState<TestTypes>>::from_header(&proposal.block_header),
+        ),
+        delta: None,
+    })
+}
+
+fn requests_state_for(output: &ConsensusOutput<TestTypes>, view: u64) -> bool {
+    matches!(output, ConsensusOutput::RequestState(r) if *r.view == view)
+}
+
+/// A failed state validation is retried: catchup timing out fails validation
+/// too, and dropping the proposal would leave every descendant validating
+/// against a `from_header` stub. Once the retry succeeds the node votes.
 #[tokio::test]
-async fn test_state_validation_failed_removes_proposal() {
+async fn test_state_validation_failed_retries() {
     let mut harness = ConsensusHarness::new(0).await;
     let test_data = TestData::new(3).await;
     let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
@@ -496,41 +514,80 @@ async fn test_state_validation_failed_removes_proposal() {
     harness
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
+    let votes_before = count_matching(harness.outputs(), is_vote1);
 
-    // Send proposal for view 2 — but bypass the harness auto-response
-    // by directly applying the proposal input, then manually sending
-    // StateValidationFailed instead of letting the harness auto-respond.
-    // We need to call consensus.apply directly to avoid auto StateVerified.
-    let (proposal_input, vid_share_input) = test_data.views[1].proposal_input_consensus(&node_key);
-    let mut outbox = Outbox::new();
-    harness.consensus.apply(proposal_input, &mut outbox);
-    harness.consensus.apply(vid_share_input, &mut outbox);
-    harness.collected.extend(outbox.take());
-
-    // Send StateVerificationFailed — removes proposal
-    let proposal: Proposal<TestTypes> = test_data.views[1].proposal.data.clone();
+    // Hold view 2's validation result so a failure can be injected instead.
+    harness.defer_state(ViewNumber::new(2));
     harness
-        .apply(ConsensusInput::StateValidationFailed(StateResponse {
-            view: test_data.views[1].view_number,
-            commitment: proposal_commitment(&proposal),
-            state: Arc::new(
-                <TestValidatedState as ValidatedState<TestTypes>>::from_header(
-                    &proposal.block_header,
-                ),
-            ),
-            delta: None,
-        }))
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
+    assert_eq!(
+        count_matching(harness.outputs(), |o| requests_state_for(o, 2)),
+        1
+    );
 
-    // Now send cert1 + block_reconstructed — vote2 should NOT fire
+    harness
+        .apply(state_validation_failed_input(&test_data.views[1]))
+        .await;
+    assert_eq!(
+        count_matching(harness.outputs(), |o| requests_state_for(o, 2)),
+        2,
+        "a failed validation must be re-requested"
+    );
+
+    // The retry succeeds: the proposal was kept, so the node can vote on it.
+    harness.release_state(ViewNumber::new(2)).await;
+    assert_eq!(
+        count_matching(harness.outputs(), is_vote1),
+        votes_before + 1,
+        "vote1 must follow the retried validation"
+    );
+}
+
+/// After the last permitted failure the proposal is dropped, as before
+/// retries existed: even a late success must not make the node vote on it.
+#[tokio::test]
+async fn test_state_validation_failed_repeatedly_drops_proposal() {
+    let mut harness = ConsensusHarness::new(0).await;
+    let test_data = TestData::new(3).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+
+    harness
+        .apply_pair(test_data.views[0].proposal_input_consensus(&node_key))
+        .await;
+    harness
+        .apply(test_data.views[0].block_reconstructed_input())
+        .await;
+    let votes_before = count_matching(harness.outputs(), is_vote1);
+
+    harness.defer_state(ViewNumber::new(2));
+    harness
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
+        .await;
+    for _ in 0..MAX_STATE_VALIDATION_FAILURES {
+        harness
+            .apply(state_validation_failed_input(&test_data.views[1]))
+            .await;
+    }
+    assert_eq!(
+        count_matching(harness.outputs(), |o| requests_state_for(o, 2)),
+        MAX_STATE_VALIDATION_FAILURES as usize,
+        "no retry after the last permitted failure"
+    );
+
+    harness.release_state(ViewNumber::new(2)).await;
     harness
         .apply(test_data.views[1].block_reconstructed_input())
         .await;
     harness.apply(test_data.views[1].cert1_input()).await;
-
+    assert_eq!(
+        count_matching(harness.outputs(), is_vote1),
+        votes_before,
+        "no vote1 for a dropped proposal"
+    );
     assert!(
         !any(harness.outputs(), is_vote2),
-        "Vote2 should not fire after proposal removed by StateVerificationFailed"
+        "no vote2 for a dropped proposal"
     );
 }
 

--- a/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
@@ -274,18 +274,14 @@ async fn build_cutover_coordinator(
     let genesis_cert1 = build_genesis_cert1(&genesis_leaf);
     let genesis_proposal = build_genesis_proposal(&genesis_leaf, &genesis_cert1);
     let genesis_state = Arc::new(genesis_state);
-    state_manager.seed_state(ViewNumber::genesis(), genesis_state.clone(), genesis_leaf);
+    state_manager.seed_state(genesis_state.clone(), genesis_leaf);
     // The synthetic genesis proposal carries the genesis cert1 as its
     // justify_qc, so the leaf derived from it has a different commitment than
     // the natural `Leaf2::genesis`. `request_header` for view 1 looks up the
     // parent state by the proposal's leaf commitment, so seed under that
     // commitment too — otherwise the view-1 leader's header request never
     // completes and the new protocol cannot make progress before cutover.
-    state_manager.seed_state(
-        ViewNumber::genesis(),
-        genesis_state,
-        Leaf2::from(genesis_proposal.clone()),
-    );
+    state_manager.seed_state(genesis_state, Leaf2::from(genesis_proposal.clone()));
     consensus.seed_parent(genesis_cert1, genesis_proposal, std::iter::empty());
 
     let block_builder = BlockBuilder::new(

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::SystemTime};
 
 use hotshot::traits::BlockPayload;
 use hotshot_example_types::{
@@ -34,6 +34,7 @@ fn make_state_request(view: &TestView) -> StateRequest<TestTypes> {
         proposal: proposal.clone(),
         parent_commitment: proposal.justify_qc.data().leaf_commit,
         payload_size: 0,
+        received_at: SystemTime::now(),
     }
 }
 

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -426,3 +426,56 @@ async fn test_interleaved_state_and_header_requests() {
         "Header request should complete"
     );
 }
+
+/// A decide that garbage-collects a still-running validation must not orphan
+/// the requests queued behind it: view 2's own validation queued on view 1,
+/// and the header for view 3 (led by this node) queued on view 2.
+#[tokio::test]
+async fn test_gc_releases_requests_queued_on_aborted_validation() {
+    let mut manager = new_manager().await;
+    let test_data = TestData::new(4).await;
+
+    // Spawned but not yet polled, so view 1 is still in flight at the gc.
+    manager.request_state(make_state_request(&test_data.views[0]));
+    manager.request_state(make_state_request(&test_data.views[1]));
+    manager.request_header(make_header_request(
+        &test_data.views[1],
+        test_data.views[2].view_number,
+    ));
+
+    manager.gc(test_data.views[1].view_number);
+
+    let mut outputs = Vec::new();
+    while let Some(output) = manager.next().await {
+        outputs.push(output);
+    }
+    assert_eq!(
+        count_state_verified(&outputs),
+        1,
+        "view 2 should validate against a stub of the aborted view 1"
+    );
+    assert_eq!(
+        count_header_created(&outputs),
+        1,
+        "the header for view 3 should be built once view 2's state lands"
+    );
+}
+
+/// No stub is seeded for an aborted validation nothing is queued on.
+#[tokio::test]
+async fn test_gc_aborts_stale_validation_without_dependents() {
+    let mut manager = new_manager().await;
+    let test_data = TestData::new(3).await;
+
+    manager.request_state(make_state_request(&test_data.views[0]));
+    manager.gc(test_data.views[1].view_number);
+
+    assert!(
+        manager.next().await.is_none(),
+        "the aborted validation should produce no output"
+    );
+    assert!(
+        !manager.validated_contains_view(test_data.views[0].view_number),
+        "no stub should be seeded for a view nothing is queued on"
+    );
+}

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -247,16 +247,7 @@ async fn test_failed_validation_seeds_stub_for_children() {
 async fn test_child_proceeds_on_stub_after_parent_deadline() {
     let test_data = TestData::new(3).await;
     let validation_delay = Duration::from_millis(500);
-    let mut delay_config = DelayConfig::default();
-    delay_config.add_setting(
-        SupportedTraitTypesForAsyncDelay::ValidatedState,
-        &DelaySettings {
-            delay_option: DelayOptions::Fixed,
-            fixed_time_in_milliseconds: validation_delay.as_millis() as u64,
-            ..Default::default()
-        },
-    );
-    let mut manager = new_manager_with_instance(TestInstanceState::new(delay_config))
+    let mut manager = new_manager_with_instance(slow_validation(validation_delay))
         .await
         .with_parent_deadline(Duration::from_millis(50));
 
@@ -296,16 +287,7 @@ async fn test_child_proceeds_on_stub_after_parent_deadline() {
 async fn test_child_waits_for_parent_within_deadline() {
     let test_data = TestData::new(3).await;
     let validation_delay = Duration::from_millis(500);
-    let mut delay_config = DelayConfig::default();
-    delay_config.add_setting(
-        SupportedTraitTypesForAsyncDelay::ValidatedState,
-        &DelaySettings {
-            delay_option: DelayOptions::Fixed,
-            fixed_time_in_milliseconds: validation_delay.as_millis() as u64,
-            ..Default::default()
-        },
-    );
-    let mut manager = new_manager_with_instance(TestInstanceState::new(delay_config))
+    let mut manager = new_manager_with_instance(slow_validation(validation_delay))
         .await
         .with_parent_deadline(Duration::from_secs(5));
 
@@ -318,6 +300,111 @@ async fn test_child_waits_for_parent_within_deadline() {
         started.elapsed() >= validation_delay * 2,
         "view 2 must validate against the real parent state, after it"
     );
+}
+
+fn slow_validation(delay: Duration) -> TestInstanceState {
+    let mut delay_config = DelayConfig::default();
+    delay_config.add_setting(
+        SupportedTraitTypesForAsyncDelay::ValidatedState,
+        &DelaySettings {
+            delay_option: DelayOptions::Fixed,
+            fixed_time_in_milliseconds: delay.as_millis() as u64,
+            ..Default::default()
+        },
+    );
+    TestInstanceState::new(delay_config)
+}
+
+/// A validation against a stub parent is catchup-bound, so its descendants
+/// are released up front: the next leader's header and a child proposal
+/// proceed against this proposal's stub at once, not after the deadline.
+#[tokio::test(start_paused = true)]
+async fn test_descendants_of_catchup_bound_validation_released_at_once() {
+    let test_data = TestData::new(4).await;
+    let validation_delay = Duration::from_millis(500);
+    let mut manager = new_manager_with_instance(slow_validation(validation_delay))
+        .await
+        .with_parent_deadline(Duration::from_secs(5));
+
+    // View 1 is known by its header only, as after a restart or a failed validation.
+    manager.seed_from_header(test_data.views[0].proposal.data.clone());
+
+    let started = tokio::time::Instant::now();
+    manager.request_state(make_state_request(&test_data.views[1]));
+    manager.request_header(make_header_request(
+        &test_data.views[1],
+        test_data.views[2].view_number,
+    ));
+    manager.request_state(make_state_request(&test_data.views[2]));
+
+    let view_2_commit = proposal_commitment(&test_data.views[1].proposal.data);
+    assert!(
+        !manager.pending_contains_commitment(&view_2_commit),
+        "nothing waits on view 2's catchup-bound validation"
+    );
+
+    let header = manager.next().await.expect("header completes");
+    assert!(
+        matches!(
+            header,
+            StateManagerOutput::Header {
+                header: Some(_),
+                ..
+            }
+        ),
+        "the header is created before any validation finishes"
+    );
+    assert!(started.elapsed() < validation_delay);
+
+    let mut validated = Vec::new();
+    for _ in 0..2 {
+        match manager.next().await.expect("both views complete") {
+            StateManagerOutput::State {
+                response,
+                validated: true,
+            } => validated.push(response.view),
+            other => panic!("unexpected output: {other:?}"),
+        }
+    }
+    validated.sort();
+    assert_eq!(validated, vec![ViewNumber::new(2), ViewNumber::new(3)]);
+    assert!(
+        started.elapsed() < validation_delay * 2,
+        "view 3 must validate in parallel with view 2"
+    );
+    assert!(
+        manager
+            .get_state(ViewNumber::new(2))
+            .is_some_and(|entry| entry.delta.is_some()),
+        "the real state for view 2 replaces its stub"
+    );
+}
+
+/// The state a catchup-bound validation yields is not itself a stub, so its
+/// children wait for their parent as usual.
+#[tokio::test(start_paused = true)]
+async fn test_child_of_state_validated_against_stub_waits() {
+    let test_data = TestData::new(4).await;
+    let validation_delay = Duration::from_millis(500);
+    let mut manager = new_manager_with_instance(slow_validation(validation_delay))
+        .await
+        .with_parent_deadline(Duration::from_secs(5));
+
+    manager.seed_from_header(test_data.views[0].proposal.data.clone());
+    manager.request_state(make_state_request(&test_data.views[1]));
+    manager.next().await.expect("view 2 completes");
+
+    let started = tokio::time::Instant::now();
+    manager.request_state(make_state_request(&test_data.views[2]));
+    manager.request_state(make_state_request(&test_data.views[3]));
+    let view_3_commit = proposal_commitment(&test_data.views[2].proposal.data);
+    assert!(
+        manager.pending_contains_commitment(&view_3_commit),
+        "view 4 waits on view 3, whose parent state is real"
+    );
+    manager.next().await.expect("view 3 completes");
+    manager.next().await.expect("view 4 completes");
+    assert!(started.elapsed() >= validation_delay * 2);
 }
 
 /// State request with seeded genesis parent spawns validation and produces output.

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -1,10 +1,14 @@
-use std::{sync::Arc, time::SystemTime};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use hotshot::traits::BlockPayload;
 use hotshot_example_types::{
     block_types::{TestBlockPayload, TestMetadata},
     node_types::{TEST_VERSIONS, TestTypes},
     state_types::{TestInstanceState, TestValidatedState},
+    testable_delay::{DelayConfig, DelayOptions, DelaySettings, SupportedTraitTypesForAsyncDelay},
 };
 use hotshot_types::{
     data::{Leaf2, ViewNumber, vid_commitment},
@@ -236,6 +240,86 @@ async fn test_failed_validation_seeds_stub_for_children() {
             } if response.view == ViewNumber::new(2)
         ),
         "view 2 must validate against the stub"
+    );
+}
+
+/// A child waits for its parent's in-flight validation only up to the parent
+/// deadline. Past it the parent is stubbed and the child validates against the
+/// stub, in parallel with the parent; the real parent state still lands.
+#[tokio::test(start_paused = true)]
+async fn test_child_proceeds_on_stub_after_parent_deadline() {
+    let test_data = TestData::new(3).await;
+    let validation_delay = Duration::from_millis(500);
+    let mut delay_config = DelayConfig::default();
+    delay_config.add_setting(
+        SupportedTraitTypesForAsyncDelay::ValidatedState,
+        &DelaySettings {
+            delay_option: DelayOptions::Fixed,
+            fixed_time_in_milliseconds: validation_delay.as_millis() as u64,
+            ..Default::default()
+        },
+    );
+    let mut manager = new_manager_with_instance(TestInstanceState::new(delay_config))
+        .await
+        .with_parent_deadline(Duration::from_millis(50));
+
+    let started = tokio::time::Instant::now();
+    manager.request_state(make_state_request(&test_data.views[0]));
+    manager.request_state(make_state_request(&test_data.views[1]));
+
+    let mut validated = Vec::new();
+    for _ in 0..2 {
+        match manager.next().await.expect("both views complete") {
+            StateManagerOutput::State {
+                response,
+                validated: true,
+            } => validated.push(response.view),
+            other => panic!("unexpected output: {other:?}"),
+        }
+    }
+    assert_eq!(
+        validated,
+        vec![ViewNumber::new(1), ViewNumber::new(2)],
+        "both views validate, the parent first"
+    );
+    assert!(
+        started.elapsed() < validation_delay * 2,
+        "view 2 must not wait for view 1's full validation"
+    );
+    assert!(
+        manager
+            .get_state(ViewNumber::new(1))
+            .is_some_and(|entry| entry.delta.is_some()),
+        "the real parent state replaces the stub"
+    );
+}
+
+/// Without the deadline elapsing, a child still waits for its parent.
+#[tokio::test(start_paused = true)]
+async fn test_child_waits_for_parent_within_deadline() {
+    let test_data = TestData::new(3).await;
+    let validation_delay = Duration::from_millis(500);
+    let mut delay_config = DelayConfig::default();
+    delay_config.add_setting(
+        SupportedTraitTypesForAsyncDelay::ValidatedState,
+        &DelaySettings {
+            delay_option: DelayOptions::Fixed,
+            fixed_time_in_milliseconds: validation_delay.as_millis() as u64,
+            ..Default::default()
+        },
+    );
+    let mut manager = new_manager_with_instance(TestInstanceState::new(delay_config))
+        .await
+        .with_parent_deadline(Duration::from_secs(5));
+
+    let started = tokio::time::Instant::now();
+    manager.request_state(make_state_request(&test_data.views[0]));
+    manager.request_state(make_state_request(&test_data.views[1]));
+    manager.next().await.expect("view 1 completes");
+    manager.next().await.expect("view 2 completes");
+    assert!(
+        started.elapsed() >= validation_delay * 2,
+        "view 2 must validate against the real parent state, after it"
     );
 }
 

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -79,19 +79,18 @@ fn make_header_request(
 }
 
 async fn new_manager() -> StateManager<TestTypes> {
-    let mut manager =
-        StateManager::new(Arc::new(TestInstanceState::default()), test_upgrade_lock());
+    new_manager_with_instance(TestInstanceState::default()).await
+}
+
+async fn new_manager_with_instance(instance: TestInstanceState) -> StateManager<TestTypes> {
+    let mut manager = StateManager::new(Arc::new(instance.clone()), test_upgrade_lock());
     let genesis_state = TestValidatedState::default();
     // Must match the version used by `TestViewGenerator` (which produces the
     // proposals fed to the manager), otherwise the genesis leaf commitment
     // won't match the `parent_commitment` carried by the first proposal's
     // justify_qc.
-    let genesis_leaf = Leaf2::<TestTypes>::genesis(
-        &genesis_state,
-        &TestInstanceState::default(),
-        TEST_VERSIONS.vid2.base,
-    )
-    .await;
+    let genesis_leaf =
+        Leaf2::<TestTypes>::genesis(&genesis_state, &instance, TEST_VERSIONS.vid2.base).await;
     manager.seed_state(ViewNumber::genesis(), Arc::new(genesis_state), genesis_leaf);
     manager
 }
@@ -190,6 +189,52 @@ async fn test_state_request_missing_parent_retried_after_seed() {
             }
         ),
         "View 2 should validate against the seeded parent state"
+    );
+}
+
+/// A failed validation seeds a `from_header` stub for the leaf, so a child
+/// queued behind it is validated (via catchup) instead of being dropped.
+#[tokio::test]
+async fn test_failed_validation_seeds_stub_for_children() {
+    let test_data = TestData::new(3).await;
+    let failing_block =
+        BlockHeader::<TestTypes>::block_number(&test_data.views[0].proposal.data.block_header);
+    let mut manager = new_manager_with_instance(TestInstanceState {
+        failing_block: Some(failing_block),
+        ..Default::default()
+    })
+    .await;
+
+    manager.request_state(make_state_request(&test_data.views[0]));
+    // View 2 queues behind its in-flight parent.
+    manager.request_state(make_state_request(&test_data.views[1]));
+
+    let first = manager.next().await.expect("view 1 should complete");
+    assert!(
+        matches!(
+            &first,
+            StateManagerOutput::State {
+                response,
+                validated: false,
+            } if response.view == ViewNumber::new(1)
+        ),
+        "view 1 must fail validation"
+    );
+    assert!(
+        manager.validated_contains_view(ViewNumber::new(1)),
+        "a from_header stub must be seeded for the failed leaf"
+    );
+
+    let second = manager.next().await.expect("view 2 should complete");
+    assert!(
+        matches!(
+            &second,
+            StateManagerOutput::State {
+                response,
+                validated: true,
+            } if response.view == ViewNumber::new(2)
+        ),
+        "view 2 must validate against the stub"
     );
 }
 

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -96,7 +96,7 @@ async fn new_manager_with_instance(instance: TestInstanceState) -> StateManager<
     // justify_qc.
     let genesis_leaf =
         Leaf2::<TestTypes>::genesis(&genesis_state, &instance, TEST_VERSIONS.vid2.base).await;
-    manager.seed_state(ViewNumber::genesis(), Arc::new(genesis_state), genesis_leaf);
+    manager.seed_state(Arc::new(genesis_state), genesis_leaf);
     manager
 }
 

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -197,8 +197,7 @@ async fn test_state_request_missing_parent_retried_after_seed() {
     );
 }
 
-/// A failed validation seeds a `from_header` stub for the leaf, so a child
-/// queued behind it is validated (via catchup) instead of being dropped.
+/// A failed validation seeds a stub, so a queued child is validated instead of dropped.
 #[tokio::test]
 async fn test_failed_validation_seeds_stub_for_children() {
     let test_data = TestData::new(3).await;
@@ -211,7 +210,6 @@ async fn test_failed_validation_seeds_stub_for_children() {
     .await;
 
     manager.request_state(make_state_request(&test_data.views[0]));
-    // View 2 queues behind its in-flight parent.
     manager.request_state(make_state_request(&test_data.views[1]));
 
     let first = manager.next().await.expect("view 1 should complete");
@@ -243,9 +241,8 @@ async fn test_failed_validation_seeds_stub_for_children() {
     );
 }
 
-/// A child waits for its parent's in-flight validation only up to the parent
-/// deadline. Past it the parent is stubbed and the child validates against the
-/// stub, in parallel with the parent; the real parent state still lands.
+/// Past the parent deadline a queued child validates against the parent's stub,
+/// in parallel with it; the real parent state still lands.
 #[tokio::test(start_paused = true)]
 async fn test_child_proceeds_on_stub_after_parent_deadline() {
     let test_data = TestData::new(3).await;

--- a/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
@@ -4,7 +4,10 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::Arc,
+    time::{Instant, SystemTime},
+};
 
 use async_broadcast::{InactiveReceiver, Sender};
 use chrono::Utc;
@@ -362,6 +365,7 @@ pub(crate) async fn update_shared_state<TYPES: NodeType>(
             vid_share.data.payload_byte_len(),
             version,
             *view_number,
+            SystemTime::now(),
         )
         .await
         .wrap()

--- a/crates/hotshot/types/src/traits/states.rs
+++ b/crates/hotshot/types/src/traits/states.rs
@@ -56,10 +56,8 @@ pub trait ValidatedState<TYPES: NodeType>:
     ///
     /// # Arguments
     /// * `instance` - Immutable instance-level state.
-    /// * `received_at` - When this node obtained the proposal. Validation can
-    ///   run well after that (queued behind the parent's validation, or for a
-    ///   fetched proposal), so checks against the local clock must use this
-    ///   rather than the time validation runs.
+    /// * `received_at` - When this node obtained the proposal. Validation may
+    ///   run much later, so checks against the local clock must use this.
     ///
     /// # Errors
     ///

--- a/crates/hotshot/types/src/traits/states.rs
+++ b/crates/hotshot/types/src/traits/states.rs
@@ -10,7 +10,7 @@
 //! compatibilities over the current network state, which is modified by the transactions contained
 //! within blocks.
 
-use std::{error::Error, fmt::Debug, future::Future};
+use std::{error::Error, fmt::Debug, future::Future, time::SystemTime};
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use vbs::version::Version;
@@ -56,10 +56,15 @@ pub trait ValidatedState<TYPES: NodeType>:
     ///
     /// # Arguments
     /// * `instance` - Immutable instance-level state.
+    /// * `received_at` - When this node obtained the proposal. Validation can
+    ///   run well after that (queued behind the parent's validation, or for a
+    ///   fetched proposal), so checks against the local clock must use this
+    ///   rather than the time validation runs.
     ///
     /// # Errors
     ///
     /// If the block header is invalid or appending it would lead to an invalid state.
+    #[allow(clippy::too_many_arguments)]
     fn validate_and_apply_header(
         &self,
         instance: &Self::Instance,
@@ -68,6 +73,7 @@ pub trait ValidatedState<TYPES: NodeType>:
         payload_byte_len: u32,
         version: Version,
         view_number: u64,
+        received_at: SystemTime,
     ) -> impl Future<Output = Result<(Self, Self::Delta), Self::Error>> + Send;
 
     /// Construct the state with the given block header.


### PR DESCRIPTION
> **Stacked on #4865** (`fix/state-gc-orphaned-requests`), which now carries the `handle_fetched_proposal` state/header fix that used to open this stack; the remaining commits here build on its `InFlight` bookkeeping (`gc` seeds a stub for an aborted validation so queued requests are released).

## Summary

A single missed proposal on a far-away validator turned into a lasting remote-catchup storm and left the next leader unable to propose. Four gaps, all in the state-validation path of the new protocol:

1. **Fetched proposals never got a state or a header.** `handle_fetched_proposal` stored the proposal but, unlike the gossip path, emitted neither `RequestState` nor (for the next view's leader) `RequestBlockAndHeader`. Every descendant was validated against a `from_header` stub — one remote catchup per touched account — and a leader whose parent arrived via fetch could not propose its view at all.
2. **A failed validation dropped the proposal and its queued children.** Validation also fails for reasons unrelated to the header (the node's catchup stack makes a single attempt; a stake table not yet known). After the drop the child was never validated, the grandchild became the stub, and the node resumed voting three views later; a leader whose parent failed validation lost its queued header request and timed out.
3. **Timestamp drift was measured from when validation *started*.** A child waits for its parent's validation, and a fetched proposal is validated when the fetch completes, so a slow parent validation failed the child with `InvalidTimestampDrift` even though its leader's clock was fine.
4. **A child waited for its parent's validation indefinitely.** A validation that runs long is catchup-bound, and serializing the child's catchup behind it compounds the delay for every following view.

## Changes

- `test(types)`: `MockStateCatchup` counts fetches; a test pins that validating against `from_header(parent)` fetches while validating against the real parent does not.
- `fix(new-protocol)`: `handle_fetched_proposal` emits `RequestState` and `RequestBlockAndHeader` through helpers factored out of the gossip path. A fetched proposal has no VID share, so `payload_size_for` falls back to a parked share, then 0 (a quorum already certified the proposal, size checks included).
- `fix(new-protocol)`: on validation failure the state manager seeds the `from_header` stub for the failed leaf (as `seed_from_header` already does for epoch-change and restored proposals) and releases the requests queued on it; consensus keeps the proposal like any other stateless one — votes stay gated on `states_verified`. `TestInstanceState` gains `failing_block` to exercise the path.
- `fix(types)`: `ValidatedState::validate_and_apply_header` takes `received_at: SystemTime`; espresso measures drift from it. The legacy vote path validates on receipt and passes now; the new protocol records it on the `StateRequest`.
- `feat(new-protocol)`: each in-flight validation gets a deadline of `timeout_duration / 2` (5 s today). Past it the leaf is stubbed and queued requests proceed via catchup in parallel; the real state still replaces the stub when the validation finishes. Tests use tokio paused time (`test-util` dev-dependency).

History note: a first version of (2) retried validation up to 3× before dropping. Review concluded that buys nothing over stubbing (same catchup cost, useless against permanent failures such as drift), so it is reverted in-branch and replaced; squash on merge.

## Where to focus

- `payload_size_for` returning 0 for a share-less fetched proposal skips the block-size/fee checks on this node only.
- Keeping a proposal whose validation failed: nothing can be voted on without `states_verified`, and `maybe_propose` off it needs a header, which needs a parent state, so a stub only enables proposing after catchup succeeds.
- The deadline trades dense state for bounded latency: a child validated against a stub carries a sparse state forward (a trickle of fetches for newly touched accounts, one bulk reward-account fetch at the next epoch boundary). Half the view timeout is the point where the child's own vote is at risk anyway.
- Drift for a *fetched* proposal is still measured from fetch time, so a proposal fetched more than 12 s after its timestamp still fails validation. Skipping the check for QC-certified leaves is a follow-up.
- The trait signature change touches `hotshot-types`, `hotshot-example-types`, `hotshot-task-impls`, `hotshot-new-protocol`, `espresso-types`; all implementors and callers are in this PR.

## Tests

- `cargo test -p espresso-types -- timestamp_drift from_header_parent slow_catchup` — 5 passed
- `cargo test -p hotshot-new-protocol` — 213 passed
- `cargo clippy -p hotshot-types -p hotshot-example-types -p hotshot-task-impls -p hotshot-new-protocol -p espresso-types --all-targets -- -D warnings` — clean

New tests: `test_from_header_parent_validates_only_via_catchup`, `test_timestamp_drift_anchored_at_receipt`, `test_fetched_proposal_requests_state`, `test_leader_proposes_off_fetched_parent`, `test_failed_validation_seeds_stub_for_children`, `test_child_of_failed_validation_can_vote`, `test_child_proceeds_on_stub_after_parent_deadline`, `test_child_waits_for_parent_within_deadline`.

Note: `tests::restarts::restart_all_nodes_at_epoch_boundary` times out when run *in isolation* on this machine, on `main` as well as on this branch; it passes in the full suite. Pre-existing, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)