### PR TITLE
fix(new-protocol): stop orphaning state requests (gc abort, fetched proposals)

### DIFF
--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -1205,36 +1205,14 @@ impl<T: NodeType> Consensus<T> {
             }
         }
 
-        outbox.push_back(ConsensusOutput::RequestState(StateRequest {
-            view: proposal.view_number(),
-            parent_view: proposal.justify_qc.view_number(),
-            epoch,
-            block: proposal.block_header.block_number().into(),
-            proposal: proposal.clone(),
-            parent_commitment: proposal.justify_qc.data().leaf_commit,
-            payload_size,
-        }));
-
-        let epoch = if is_last_block(block_number, *self.epoch_height) {
-            epoch + 1
-        } else {
-            epoch
-        };
+        self.request_state(&proposal, payload_size, outbox);
 
         outbox.push_back(ConsensusOutput::ProposalValidated {
             proposal: signed_proposal,
             sender,
         });
 
-        if self.is_leader(view + 1, epoch) {
-            outbox.push_back(ConsensusOutput::RequestBlockAndHeader(
-                BlockAndHeaderRequest {
-                    view: view + 1,
-                    epoch,
-                    parent_proposal: proposal,
-                },
-            ));
-        }
+        self.request_block_and_header_if_next_leader(&proposal, outbox);
 
         Protocol::Continue
     }
@@ -1259,8 +1237,66 @@ impl<T: NodeType> Consensus<T> {
         self.leaves.insert(view, proposal.clone().into());
         self.signed_proposals.insert(view, signed_proposal);
         self.request_parent_proposal_if_missing(&proposal, outbox);
-        self.proposals.insert(view, proposal);
+        self.proposals.insert(view, proposal.clone());
         self.adopt_certified_drb(view);
+
+        let payload_size = self.payload_size_for(&proposal);
+        self.request_state(&proposal, payload_size, outbox);
+        self.request_block_and_header_if_next_leader(&proposal, outbox);
+    }
+
+    fn request_state(
+        &self,
+        proposal: &Proposal<T>,
+        payload_size: u32,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) {
+        outbox.push_back(ConsensusOutput::RequestState(StateRequest {
+            view: proposal.view_number(),
+            parent_view: proposal.justify_qc.view_number(),
+            epoch: proposal.epoch,
+            block: proposal.block_header.block_number().into(),
+            proposal: proposal.clone(),
+            parent_commitment: proposal.justify_qc.data().leaf_commit,
+            payload_size,
+        }));
+    }
+
+    /// A fetched proposal may have no share. A quorum already certified it,
+    /// size checks included, so zero only skips this node's block-size checks.
+    fn payload_size_for(&self, proposal: &Proposal<T>) -> u32 {
+        let view = proposal.view_number();
+        if let Some(share) = self.vid_shares.get(&view) {
+            return share.payload_byte_len();
+        }
+        let VidCommitment::V2(commitment) = proposal.block_header.payload_commitment() else {
+            return 0;
+        };
+        self.unpaired_vid_shares
+            .get(&(view, commitment))
+            .map_or(0, |share| share.payload_byte_len())
+    }
+
+    fn request_block_and_header_if_next_leader(
+        &self,
+        proposal: &Proposal<T>,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) {
+        let view = proposal.view_number();
+        let epoch = if is_last_block(proposal.block_header.block_number(), *self.epoch_height) {
+            proposal.epoch + 1
+        } else {
+            proposal.epoch
+        };
+        if self.is_leader(view + 1, epoch) {
+            outbox.push_back(ConsensusOutput::RequestBlockAndHeader(
+                BlockAndHeaderRequest {
+                    view: view + 1,
+                    epoch,
+                    parent_proposal: proposal.clone(),
+                },
+            ));
+        }
     }
 
     /// Ask for the payload of the view every proposal we could vote for is

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -94,13 +94,20 @@ pub struct StateEntry<T: NodeType> {
 pub struct StateManager<T: NodeType> {
     instance: Arc<T::InstanceState>,
     validated_states: BTreeMap<Commitment<Leaf2<T>>, StateEntry<T>>,
-    state_requests: HashMap<Commitment<Leaf2<T>>, (AbortHandle, ViewNumber)>,
+    state_requests: HashMap<Commitment<Leaf2<T>>, InFlight<T>>,
     header_requests: HashMap<(ViewNumber, Commitment<Leaf2<T>>), AbortHandle>,
     pending_requests: HashMap<Commitment<Leaf2<T>>, Vec<Pending<T>>>,
     upgrade_lock: UpgradeLock<T>,
     tasks: JoinSet<Completed<T>>,
     validate_duration_metric: Option<Arc<dyn Histogram>>,
     update_leaf_duration_metric: Option<Arc<dyn Histogram>>,
+}
+
+/// The proposal lets `gc` seed a stub for a validation it aborts.
+struct InFlight<T: NodeType> {
+    handle: AbortHandle,
+    view: ViewNumber,
+    proposal: Proposal<T>,
 }
 
 enum Pending<T: NodeType> {
@@ -231,6 +238,7 @@ impl<T: NodeType> StateManager<T> {
 
         let instance = self.instance.clone();
         let header = request.proposal.block_header.clone();
+        let proposal = request.proposal.clone();
         let view = request.view;
         let payload_size = request.payload_size;
 
@@ -282,7 +290,14 @@ impl<T: NodeType> StateManager<T> {
             }
         });
 
-        self.state_requests.insert(commitment, (handle, view));
+        self.state_requests.insert(
+            commitment,
+            InFlight {
+                handle,
+                view,
+                proposal,
+            },
+        );
     }
 
     pub fn request_header(&mut self, request: HeaderRequest<T>) {
@@ -373,8 +388,8 @@ impl<T: NodeType> StateManager<T> {
         } = update;
         let commitment = leaf.commit();
         self.insert_state(view, state, delta, leaf);
-        if let Some((task, _)) = self.state_requests.remove(&commitment) {
-            task.abort();
+        if let Some(in_flight) = self.state_requests.remove(&commitment) {
+            in_flight.handle.abort();
         }
         self.start_pending(commitment);
     }
@@ -437,18 +452,12 @@ impl<T: NodeType> StateManager<T> {
         }
     }
 
+    /// The decided view's own validation, or a header this node needs to
+    /// propose, may be queued behind a validation aborted here. A stub for the
+    /// aborted proposal lets them proceed via catchup instead of hanging.
     pub fn gc(&mut self, view_number: ViewNumber) {
         self.validated_states
             .retain(|_, entry| entry.leaf.view_number() >= view_number);
-
-        for (task, view) in self.state_requests.values() {
-            if *view < view_number {
-                task.abort();
-            }
-        }
-
-        self.state_requests
-            .retain(|_, (_, view)| *view >= view_number);
 
         self.header_requests.retain(|(view, _), handle| {
             let keep = *view >= view_number;
@@ -462,6 +471,17 @@ impl<T: NodeType> StateManager<T> {
             pending.retain(|p| p.view() >= view_number);
             !pending.is_empty()
         });
+
+        let stale: Vec<_> = self
+            .state_requests
+            .extract_if(|_, in_flight| in_flight.view < view_number)
+            .collect();
+        for (commitment, in_flight) in stale {
+            in_flight.handle.abort();
+            if self.pending_requests.contains_key(&commitment) {
+                self.seed_from_header(in_flight.proposal);
+            }
+        }
     }
 
     fn start_pending(&mut self, finished_commitment: Commitment<Leaf2<T>>) {

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -719,6 +719,52 @@ async fn test_leader_sends_proposal() {
     );
 }
 
+/// A fetched proposal gets its state validated like a gossiped one.
+#[tokio::test]
+async fn test_fetched_proposal_requests_state() {
+    let test_data = TestData::new(2).await;
+    let mut harness = ConsensusHarness::new(0).await;
+
+    harness
+        .apply(ConsensusInput::FetchedProposal(
+            test_data.views[0].proposal_message(),
+        ))
+        .await;
+
+    assert!(
+        any(harness.outputs(), |o| matches!(
+            o,
+            ConsensusOutput::RequestState(r) if r.view == ViewNumber::new(1)
+        )),
+        "state validation must be requested for a fetched proposal"
+    );
+}
+
+/// Regression: a leader whose parent arrived via fetch could not propose.
+#[tokio::test]
+async fn test_leader_proposes_off_fetched_parent() {
+    let test_data = TestData::new(3).await;
+    let leader_for_view_2 = test_data.views[1].leader_public_key;
+    let leader_index = node_index_for_key(&leader_for_view_2);
+    let mut harness = ConsensusHarness::new(leader_index).await;
+
+    harness
+        .apply(ConsensusInput::FetchedProposal(
+            test_data.views[0].proposal_message(),
+        ))
+        .await;
+    harness.apply(test_data.views[0].cert1_input()).await;
+
+    assert!(
+        any(harness.outputs(), is_request_block_and_header),
+        "leader must request block and header off a fetched parent"
+    );
+    assert!(
+        any(harness.outputs(), |o| is_proposal_for_view(o, 2)),
+        "leader must propose once the fetched parent's cert1 forms"
+    );
+}
+
 /// Regression: `maybe_propose` must refuse to propose when
 /// `self.proposals[parent_view]` has drifted from
 /// `parent_cert.data.leaf_commit`.
@@ -859,13 +905,14 @@ async fn test_timeout_proposal_chains_from_lock_not_timed_out_cert1() {
         .await;
     harness.apply(test_data.views[0].cert1_input()).await;
 
-    // View 2 arrives via fetch (no optimistic header request); its cert1
-    // forms but the block is never reconstructed, so the lock stays at 1.
-    harness
-        .apply(ConsensusInput::FetchedProposal(
-            test_data.views[1].proposal_message(),
-        ))
-        .await;
+    // View 2 arrives via fetch and its block is never reconstructed, so the
+    // lock stays at 1. Bypass the harness so the header request off view 2
+    // stays unanswered and the leader cannot propose view 3 from cert1(2).
+    let mut fetched = Outbox::new();
+    harness.consensus.apply(
+        ConsensusInput::FetchedProposal(test_data.views[1].proposal_message()),
+        &mut fetched,
+    );
     harness.apply(test_data.views[1].cert1_input()).await;
     assert!(
         harness
@@ -917,15 +964,15 @@ async fn test_bridged_legacy_qc_adopts_lock_and_reproposes() {
         .apply(test_data.views[0].block_reconstructed_input())
         .await;
     harness.apply(test_data.views[0].cert1_input()).await;
-    harness
-        .apply(ConsensusInput::FetchedProposal(
-            test_data.views[1].proposal_message(),
-        ))
-        .await;
 
-    // Manual outbox from here: the TC's header request stays unfulfilled, so
+    // Manual outbox from here so both header requests stay unfulfilled and
     // the leader has not proposed view 3 when the legacy QC arrives.
     let mut outbox = Outbox::new();
+    harness.consensus.apply(
+        ConsensusInput::FetchedProposal(test_data.views[1].proposal_message()),
+        &mut outbox,
+    );
+    outbox.clear();
     harness
         .consensus
         .apply(test_data.views[1].timeout_cert_input(), &mut outbox);

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -426,3 +426,56 @@ async fn test_interleaved_state_and_header_requests() {
         "Header request should complete"
     );
 }
+
+/// A decide that garbage-collects a still-running validation must not orphan
+/// the requests queued behind it: view 2's own validation queued on view 1,
+/// and the header for view 3 (led by this node) queued on view 2.
+#[tokio::test]
+async fn test_gc_releases_requests_queued_on_aborted_validation() {
+    let mut manager = new_manager().await;
+    let test_data = TestData::new(4).await;
+
+    // Spawned but not yet polled, so view 1 is still in flight at the gc.
+    manager.request_state(make_state_request(&test_data.views[0]));
+    manager.request_state(make_state_request(&test_data.views[1]));
+    manager.request_header(make_header_request(
+        &test_data.views[1],
+        test_data.views[2].view_number,
+    ));
+
+    manager.gc(test_data.views[1].view_number);
+
+    let mut outputs = Vec::new();
+    while let Some(output) = manager.next().await {
+        outputs.push(output);
+    }
+    assert_eq!(
+        count_state_verified(&outputs),
+        1,
+        "view 2 should validate against a stub of the aborted view 1"
+    );
+    assert_eq!(
+        count_header_created(&outputs),
+        1,
+        "the header for view 3 should be built once view 2's state lands"
+    );
+}
+
+/// No stub is seeded for an aborted validation nothing is queued on.
+#[tokio::test]
+async fn test_gc_aborts_stale_validation_without_dependents() {
+    let mut manager = new_manager().await;
+    let test_data = TestData::new(3).await;
+
+    manager.request_state(make_state_request(&test_data.views[0]));
+    manager.gc(test_data.views[1].view_number);
+
+    assert!(
+        manager.next().await.is_none(),
+        "the aborted validation should produce no output"
+    );
+    assert!(
+        !manager.validated_contains_view(test_data.views[0].view_number),
+        "no stub should be seeded for a view nothing is queued on"
+    );
+}


### PR DESCRIPTION
Two commits, both closing paths where a node's state manager is left waiting on a validation nothing will ever run. Together they account for all 19 leader timeouts in a one-hour Pier Two (decaf, Sydney) log — 16 via the first, 3 via the second — and the stub→catchup cascade behind its ~17% missed votes.

## 1. `fix(new-protocol): release requests queued on a gc-aborted validation`

`StateManager::gc` aborts any validation still running for a view below the newest decided view, but left the requests queued behind it in `pending_requests`, keyed on a commitment nothing would ever complete.

On a node where a validation takes longer than the decide cadence (a remote catchup round trip, or an L1 head wait), the decided view's own validation is routinely queued behind such a validation — and so is the header this node needs when it leads the next view. Both then hung until the view timed out, and the following proposal found the parent state missing and fell back to a `from_header` stub, which forces another catchup, which loses the next race, and so on. Example, view 15660472:

```
42.942  validate 15660470 begins → catchup: fetch frontier from cache.decaf
43.107  15660470 decided → gc(15660470) keeps it (in-flight view ≥ decided)
43.206  still validating 15660470 → second round trip: fetch accounts
43.260  view → 15660472  (this node leads; header queued on 15660471's state,
        which is itself queued on 15660470)
43.468  15660471 decided → gc(15660471) aborts the in-flight validation of 15660470
53.261  timeout: we were the leader but did not propose  missing=block_header,block_payload
53.744  next proposal: parent state unavailable  parent_view=15660471
```

**Fix:** when `gc` aborts a validation that has requests queued on it, seed a `from_header` stub for the aborted proposal and restart the queue — the same recovery `request_state` already uses for a proposal whose parent never arrived. The in-flight bookkeeping keeps the proposal (`InFlight { handle, view, proposal }`) so the stub can be seeded; nothing is seeded when no request depends on the aborted validation.

## 2. `fix(new-protocol): request state and header for fetched proposals`

`handle_fetched_proposal` stored the proposal but, unlike the gossip path, never asked the state manager to validate it or, when this node leads the next view, for a block and header to extend it. Descendants of a fetched proposal were therefore validated against a `from_header` stub (every touched account a remote catchup), and a leader whose parent arrived via fetch could not propose its view at all — fix 1 has nothing queued to release in that case.

**Fix:** factor the two requests out of the gossip path and issue them from the fetched path too. A fetched proposal has no VID share, so the payload size falls back to a parked share or zero; a quorum already validated the size when it certified the proposal.

## Review focus

- Ordering in `gc`: `pending_requests` is pruned *before* seeding, so only requests at or above the decided view restart, and the stub for the already-decided parent is dropped by the next gc after its dependents have cloned it.
- `payload_size_for` returning 0 for a share-less fetched proposal — this skips only this node's block-size checks on a proposal a quorum already certified.
- Regression tests: `test_gc_releases_requests_queued_on_aborted_validation` (fails on `main` — nothing ever completes), `test_fetched_proposal_requests_state`, `test_leader_proposes_off_fetched_parent`.

## Not in this PR

A validation that *fails* still drops its dependents in `StateManager::next()` — same orphaning class, separate change.

## Testing

- `cargo nextest run -p hotshot-new-protocol`: 232/232 pass. `restarts::restart_all_nodes_at_epoch_boundary` needed a retry under the full parallel run; run in isolation it fails with `TestError::Timeout` at the 300 s runner deadline on **`main` as well as on each commit here** (bisected), so it is pre-existing (also noted in #4723) and unrelated to this change.
- `cargo clippy -p hotshot-new-protocol --features testing --all-targets -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

