### PR TITLE
Display IPv6 addresses as socket addresses, and validate addresses

### DIFF
--- a/crates/cliquenet-types/src/addr.rs
+++ b/crates/cliquenet-types/src/addr.rs
@@ -87,13 +87,12 @@ impl NetAddr {
     /// Checks that this address is well-formed.
     ///
     /// A hostname is dot-separated labels, each 1 to 63 characters of ASCII letters,
-    /// digits, `-` and `_`, not beginning or ending with `-`, at most 253 characters in
-    /// all, and not digits and dots alone. RFC 952 and RFC 1123 do not allow `_`, but
-    /// names using it are in use. An IP address must be the address it prints as, so an
-    /// IPv4 address in IPv6 form is not well-formed; [`IpAddr::to_canonical`] converts
-    /// it.
+    /// digits, `-` and `_`, not beginning or ending with `-`, and not digits and dots
+    /// alone. RFC 952 and RFC 1123 do not allow `_`, but names using it are in use. An
+    /// IP address must be the address it prints as, so an IPv4 address in IPv6 form is
+    /// not well-formed; [`IpAddr::to_canonical`] converts it.
     ///
-    /// The port is not checked.
+    /// Neither the port nor the length of the whole name is checked.
     pub fn validate(&self) -> Result<(), InvalidNetAddr> {
         match self {
             Self::Inet(ip, _) => {
@@ -103,14 +102,10 @@ impl NetAddr {
                 Ok(())
             },
             Self::Name(host, _) => {
-                const MAX_NAME_LEN: usize = 253;
                 const MAX_LABEL_LEN: usize = 63;
 
                 if host.is_empty() {
                     return Err(InvalidNetAddr("empty hostname"));
-                }
-                if host.len() > MAX_NAME_LEN {
-                    return Err(InvalidNetAddr("hostname is longer than 253 characters"));
                 }
                 if host.bytes().all(|b| b.is_ascii_digit() || b == b'.') {
                     return Err(InvalidNetAddr("host is not an IP address nor a hostname"));

--- a/crates/cliquenet-types/src/addr.rs
+++ b/crates/cliquenet-types/src/addr.rs
@@ -83,11 +83,76 @@ impl NetAddr {
             Self::Name(host, _) => !host.eq_ignore_ascii_case("localhost"),
         }
     }
+
+    /// Checks that this address is well-formed.
+    ///
+    /// A hostname is dot-separated labels, each 1 to 63 characters of ASCII letters,
+    /// digits, `-` and `_`, not beginning or ending with `-`, at most 253 characters in
+    /// all, and not digits and dots alone. RFC 952 and RFC 1123 do not allow `_`, but
+    /// names using it are in use. An IP address must be the address it prints as, so an
+    /// IPv4 address in IPv6 form is not well-formed; [`IpAddr::to_canonical`] converts
+    /// it.
+    ///
+    /// The port is not checked.
+    pub fn validate(&self) -> Result<(), InvalidNetAddr> {
+        match self {
+            Self::Inet(ip, _) => {
+                if ip.to_canonical() != *ip {
+                    return Err(InvalidNetAddr("IPv4 address in IPv6 form"));
+                }
+                Ok(())
+            },
+            Self::Name(host, _) => {
+                const MAX_NAME_LEN: usize = 253;
+                const MAX_LABEL_LEN: usize = 63;
+
+                if host.is_empty() {
+                    return Err(InvalidNetAddr("empty hostname"));
+                }
+                if host.len() > MAX_NAME_LEN {
+                    return Err(InvalidNetAddr("hostname is longer than 253 characters"));
+                }
+                if host.bytes().all(|b| b.is_ascii_digit() || b == b'.') {
+                    return Err(InvalidNetAddr("host is not an IP address nor a hostname"));
+                }
+                for label in host.split('.') {
+                    if label.is_empty() {
+                        return Err(InvalidNetAddr("hostname contains invalid dots"));
+                    }
+                    if label.len() > MAX_LABEL_LEN {
+                        return Err(InvalidNetAddr("hostname part is longer than 63 chars"));
+                    }
+                    if label.starts_with('-') || label.ends_with('-') {
+                        return Err(InvalidNetAddr("hostname part starts or ends with `-`"));
+                    }
+                    if !label
+                        .bytes()
+                        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+                    {
+                        return Err(InvalidNetAddr("hostname contains invalid characters"));
+                    }
+                }
+                Ok(())
+            },
+        }
+    }
+
+    /// The address without brackets around an IPv6 literal.
+    ///
+    /// This is how [`fmt::Display`] printed every address before IPv6 literals were
+    /// bracketed. The format is retained here for backwards compatibility.
+    pub fn unbracketed_string(&self) -> String {
+        match self {
+            Self::Inet(a, p) => format!("{a}:{p}"),
+            Self::Name(h, p) => format!("{h}:{p}"),
+        }
+    }
 }
 
 impl fmt::Display for NetAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Inet(a @ IpAddr::V6(_), p) => write!(f, "[{a}]:{p}"),
             Self::Inet(a, p) => write!(f, "{a}:{p}"),
             Self::Name(h, p) => write!(f, "{h}:{p}"),
         }
@@ -130,17 +195,35 @@ impl From<SocketAddr> for NetAddr {
     }
 }
 
+/// Grammar:
+///
+/// addr = host               -- port is 0
+///      | host ":" port
+///      | "[" host "]"       -- port is 0
+///      | "[" host "]:" port
+///
+/// host = IP | name
+/// IP   = <std::net::IpAddr>
+/// name = <any sequence of characters, possibly empty>
+/// port = <u16>
+///
+/// - Input starting with "[" has the port after the last "]:". With no "]:" anywhere there
+/// is no port, so "[a:80" is the name "[a:80" on port 0.
+/// - Input not starting with "[" has the port after the last ":" or defaults to 0 if there
+/// is no ":".
+/// - `host` is an IP if `IpAddr` parses it, a name otherwise.
+/// - Parsing the port permits a leading "+" and leading zeros.
 impl std::str::FromStr for NetAddr {
     type Err = InvalidNetAddr;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
-            return Err(InvalidNetAddr(()));
+            return Err(InvalidNetAddr("the address is empty"));
         }
 
         let parse = |a: &str, p: Option<&str>| {
             let p: u16 = if let Some(p) = p {
-                p.parse().map_err(|_| InvalidNetAddr(()))?
+                p.parse().map_err(|_| InvalidNetAddr("invalid port"))?
             } else {
                 0
             };
@@ -179,15 +262,15 @@ impl TryFrom<&str> for NetAddr {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("invalid network address")]
-pub struct InvalidNetAddr(());
+#[error("invalid network address: {0}")]
+pub struct InvalidNetAddr(&'static str);
 
 // TODO: distinguish human-readable:
 
 #[cfg(feature = "serde")]
 impl Serialize for NetAddr {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        self.to_string().serialize(s)
+        self.unbracketed_string().serialize(s)
     }
 }
 
@@ -202,7 +285,10 @@ impl<'de> Deserialize<'de> for NetAddr {
 
 #[cfg(test)]
 mod tests {
-    use std::{iter::repeat_with, net::IpAddr};
+    use std::{
+        iter::repeat_with,
+        net::{IpAddr, SocketAddr},
+    };
 
     use quickcheck::{Arbitrary, Gen, quickcheck};
 
@@ -237,6 +323,86 @@ mod tests {
     }
 
     #[test]
+    fn validate_accepts() {
+        let cases: &[&str] = &[
+            // an IP address, however it was written
+            "1.2.3.4:8080",
+            "1.2.3.4:0",
+            "1.2.3.4:65535",
+            "[::1]:9977",
+            "::1:9977",
+            "[2001:db8::1]:9000",
+            "2001:db8::1:9000",
+            "[::]:80",
+            ":::80",
+            "[::ffff:0:102:304]:80",
+            "[1.2.3.4]:80",
+            // hostnames, in any case, and with or without a port
+            "localhost:1234",
+            "example.com",
+            "a-b.c:80",
+            "a_b.example.com:80",
+            "_svc.example.com:80",
+            "Node.Example.COM:8080",
+            "[node.example.com]:8080",
+            "crpk232f2b1uqepj3qmg.bdnodes.net:9977",
+        ];
+        for s in cases {
+            let a: NetAddr = s.parse().unwrap_or_else(|_| panic!("parse {s}"));
+            assert_eq!(a.validate().map_err(|e| e.to_string()), Ok(()), "for {s}");
+        }
+    }
+
+    #[test]
+    fn validate_rejects() {
+        let cases: &[&str] = &[
+            // an IPv6 address without a port is a hostname with an empty part
+            "2001:db8::1",
+            "::1",
+            "[foo:bar]:80",
+            "[::1]:80]:90",
+            "[]:7",
+            // digits and dots that are not an IP address
+            "01.2.3.4:80",
+            "1.2.3.4.5:80",
+            "127.1:1",
+            "12345:80",
+            // hostname parts
+            "example.com.:80",
+            ".example.com:80",
+            "a..b:80",
+            "-a.b:80",
+            "a-.b:80",
+            "a b:80",
+            "ä:80",
+            "%:1",
+            "a/b:80",
+        ];
+        for s in cases {
+            let a: NetAddr = s.parse().unwrap_or_else(|_| panic!("parse {s}"));
+            assert!(a.validate().is_err(), "should be rejected: {s:?}");
+        }
+
+        // An IPv4 address in IPv6 form is one address written two ways.
+        let mapped: NetAddr = "[::ffff:1.2.3.4]:80".parse().expect("parse");
+        assert!(mapped.validate().is_err());
+        assert!(
+            mapped
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("IPv4 address in IPv6 form")
+        );
+        let NetAddr::Inet(ip, port) = mapped else {
+            panic!("an IP address")
+        };
+        assert_eq!(
+            NetAddr::Inet(ip.to_canonical(), port),
+            "1.2.3.4:80".parse().expect("parse")
+        );
+    }
+
+    #[test]
     fn test_is_probably_global() {
         let cases: &[(&str, bool)] = &[
             ("127.0.0.1:1234", false),
@@ -262,5 +428,13 @@ mod tests {
             let a: NetAddr = s.parse().unwrap_or_else(|_| panic!("parse {s}"));
             assert_eq!(a.is_probably_global(), *expected, "for input {s}");
         }
+    }
+
+    #[test]
+    fn ipv6_prints_as_a_socket_addr() {
+        let a: NetAddr = "::1:9977".parse().expect("parse");
+        assert_eq!(a.to_string(), "[::1]:9977");
+        assert!(a.to_string().parse::<SocketAddr>().is_ok());
+        assert!("::1:9977".parse::<SocketAddr>().is_err());
     }
 }

--- a/crates/cliquenet-types/src/addr.rs
+++ b/crates/cliquenet-types/src/addr.rs
@@ -192,6 +192,7 @@ impl From<SocketAddr> for NetAddr {
 
 /// Grammar:
 ///
+/// ```text
 /// addr = host               -- port is 0
 ///      | host ":" port
 ///      | "[" host "]"       -- port is 0
@@ -201,13 +202,14 @@ impl From<SocketAddr> for NetAddr {
 /// IP   = <std::net::IpAddr>
 /// name = <any sequence of characters, possibly empty>
 /// port = <u16>
+/// ```
 ///
-/// - Input starting with "[" has the port after the last "]:". With no "]:" anywhere there
-/// is no port, so "[a:80" is the name "[a:80" on port 0.
-/// - Input not starting with "[" has the port after the last ":" or defaults to 0 if there
-/// is no ":".
+/// - Input starting with `[` has the port after the last `]:`. With no `]:` anywhere there
+///   is no port, so `[a:80` is the name `[a:80` on port 0.
+/// - Input not starting with `[` has the port after the last `:` or defaults to 0 if there
+///   is no `:`.
 /// - `host` is an IP if `IpAddr` parses it, a name otherwise.
-/// - Parsing the port permits a leading "+" and leading zeros.
+/// - Parsing the port permits a leading `+` and leading zeros.
 impl std::str::FromStr for NetAddr {
     type Err = InvalidNetAddr;
 

--- a/crates/cliquenet/src/net.rs
+++ b/crates/cliquenet/src/net.rs
@@ -106,9 +106,13 @@ pub enum SendAction {
 
 impl Network {
     pub async fn create(conf: Config) -> Result<Self, NetworkError> {
-        let listener = TcpListener::bind(conf.bind.to_string())
-            .await
-            .map_err(|e| NetworkError::Bind(conf.bind.clone(), e))?;
+        let listener = {
+            let result = match &conf.bind {
+                NetAddr::Inet(ip, port) => TcpListener::bind((*ip, *port)).await,
+                NetAddr::Name(hs, port) => TcpListener::bind((&**hs, *port)).await,
+            };
+            result.map_err(|e| NetworkError::Bind(conf.bind.clone(), e))?
+        };
 
         let addr = listener.local_addr()?;
         let node = conf.keypair.public_key();

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -772,7 +772,7 @@ impl Party {
         let NetAddr::Inet(ip, _) = &self.addr else {
             return false;
         };
-        *ip != addr
+        ip.to_canonical() != addr.to_canonical()
     }
 }
 

--- a/crates/espresso/node/src/options.rs
+++ b/crates/espresso/node/src/options.rs
@@ -76,7 +76,8 @@ pub struct Options {
     #[clap(
         long,
         env = "ESPRESSO_NODE_CLIQUENET_BIND_ADDRESS",
-        default_value = "0.0.0.0:9977"
+        default_value = "0.0.0.0:9977",
+        value_parser = parse_bind_addr
     )]
     pub cliquenet_bind_address: NetAddr,
 
@@ -84,7 +85,11 @@ pub struct Options {
     ///
     /// Only used for orchestrator-based setup (test networks). On real networks the address
     /// must be registered in the stake table contract instead.
-    #[clap(long, env = "ESPRESSO_NODE_CLIQUENET_ADVERTISE_ADDRESS")]
+    #[clap(
+        long,
+        env = "ESPRESSO_NODE_CLIQUENET_ADVERTISE_ADDRESS",
+        value_parser = parse_advertise_addr
+    )]
     pub cliquenet_advertise_address: Option<NetAddr>,
 
     /// The address to bind to for Libp2p (in `host:port` form)
@@ -370,6 +375,25 @@ impl Options {
     pub fn modules(&self) -> Modules {
         ModuleArgs(self.modules.clone()).parse()
     }
+}
+
+/// Parse an address to bind to, and check that it is well-formed, so that a mistyped
+/// host fails at startup rather than when the first peer cannot reach us.
+fn parse_bind_addr(s: &str) -> Result<NetAddr, String> {
+    let addr = s.parse::<NetAddr>().map_err(|e| e.to_string())?;
+    addr.validate().map_err(|e| e.to_string())?;
+    Ok(addr)
+}
+
+/// As [`parse_bind_addr`], and the port has to be one a peer can connect to. A listener
+/// may ask for an ephemeral port, an advertised address cannot: an address written
+/// without a port is port 0.
+fn parse_advertise_addr(s: &str) -> Result<NetAddr, String> {
+    let addr = parse_bind_addr(s)?;
+    if addr.port() == 0 {
+        return Err("port 0 is not a port a peer can connect to".to_string());
+    }
+    Ok(addr)
 }
 
 /// Identity represents identifying information concerning the sequencer node.

--- a/crates/espresso/types/src/v0/v0_3/stake_table.rs
+++ b/crates/espresso/types/src/v0/v0_3/stake_table.rs
@@ -365,7 +365,7 @@ impl<KEY: SignatureKey> Committable for RegisteredValidator<KEY> {
             builder = builder.var_size_field("x25519_key", key.as_slice());
         }
         if let Some(addr) = &self.p2p_addr {
-            builder = builder.var_size_field("p2p_addr", addr.to_string().as_bytes());
+            builder = builder.var_size_field("p2p_addr", addr.unbracketed_string().as_bytes());
         }
 
         builder = builder.constant_str("delegators");
@@ -586,6 +586,28 @@ mod tests {
         assert_ne!(commit_base, commit_x25519);
         assert_ne!(commit_base, commit_p2p);
         assert_ne!(commit_x25519, commit_p2p);
+    }
+
+    #[test]
+    fn test_commitment_of_ipv6_addr_is_frozen() {
+        let p2p_addr: NetAddr = "[2001:db8::1]:9977".parse().unwrap();
+        assert_eq!(p2p_addr.unbracketed_string(), "2001:db8::1:9977");
+
+        let validator = RegisteredValidator::<BLSPubKey> {
+            account: Address::repeat_byte(7),
+            stake_table_key: Some(BLSPubKey::generated_from_seed_indexed([1u8; 32], 0).0),
+            state_ver_key: Some(StateVerKey::default()),
+            stake: U256::from(1000),
+            commission: 500,
+            delegators: HashMap::new(),
+            authenticated: true,
+            x25519_key: None,
+            p2p_addr: Some(p2p_addr),
+        };
+        assert_eq!(
+            validator.commit().to_string(),
+            "VALIDATOR~7K4UdfSAqHRUGHW6HvabPzbi7dnJxEbHfO66O3eO3Sbw"
+        );
     }
 
     /// Unauthenticated validators must produce a different commitment than authenticated ones.

--- a/staking-cli/README.md
+++ b/staking-cli/README.md
@@ -697,6 +697,10 @@ staking-cli update-p2p-addr --p2p-addr validator.example.com:9000
 All three commands accept the env vars `X25519_KEY` and `P2P_ADDR`, and support `--export-calldata` for multisig
 wallets.
 
+They reject a p2p address that other validators cannot reach: one that is not publicly routable, or a name that does
+not resolve to a publicly routable address. Pass `--skip-reachability-check` to register such an address anyway, for
+example when the name only resolves once the node is deployed.
+
 ### Exporting Node Signatures
 
 To avoid mixing Espresso and Ethereum keys on a single host we can pre-sign the validator address for registration and

--- a/staking-cli/src/cli.rs
+++ b/staking-cli/src/cli.rs
@@ -41,6 +41,7 @@ use crate::{
     output::{
         CalldataInfo, format_esp, output_calldata, output_error, output_success, output_warn,
     },
+    p2p_addr::warn_if_unreachable,
     signature::{NodeSignatureDestination, NodeSignatureInput, NodeSignatures},
     transaction::Transaction,
 };
@@ -698,6 +699,10 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
                     .context("use --skip-metadata-validation to skip")?;
             }
 
+            if let Some(addr) = p2p_addr {
+                warn_if_unreachable(addr).await;
+            }
+
             Transaction::RegisterValidator {
                 stake_table: stake_table_addr,
                 commission: *commission,
@@ -773,6 +778,8 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
             if !config.export_calldata {
                 wallet.as_ref().ok_or_else(&require_wallet)?;
             }
+            warn_if_unreachable(p2p_addr).await;
+
             Transaction::UpdateNetworkConfig {
                 stake_table: stake_table_addr,
                 x25519_key: *x25519_key,
@@ -792,6 +799,8 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
             if !config.export_calldata {
                 wallet.as_ref().ok_or_else(&require_wallet)?;
             }
+            warn_if_unreachable(p2p_addr).await;
+
             Transaction::UpdateP2pAddr {
                 stake_table: stake_table_addr,
                 p2p_addr: p2p_addr.clone(),

--- a/staking-cli/src/cli.rs
+++ b/staking-cli/src/cli.rs
@@ -41,7 +41,7 @@ use crate::{
     output::{
         CalldataInfo, format_esp, output_calldata, output_error, output_success, output_warn,
     },
-    p2p_addr::warn_if_unreachable,
+    p2p_addr::check_if_reachable,
     signature::{NodeSignatureDestination, NodeSignatureInput, NodeSignatures},
     transaction::Transaction,
 };
@@ -664,6 +664,7 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
             metadata_uri_args,
             x25519_key,
             p2p_addr,
+            skip_reachability_check,
         } => {
             let version = fetch_stake_table_version(&readonly_provider, stake_table_addr).await?;
             if config.export_calldata && matches!(version, StakeTableContractVersion::V1) {
@@ -699,8 +700,10 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
                     .context("use --skip-metadata-validation to skip")?;
             }
 
-            if let Some(addr) = p2p_addr {
-                warn_if_unreachable(addr).await;
+            if let Some(addr) = p2p_addr
+                && !skip_reachability_check
+            {
+                check_if_reachable(addr).await;
             }
 
             Transaction::RegisterValidator {
@@ -774,12 +777,14 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
         Commands::UpdateNetworkConfig {
             x25519_key,
             p2p_addr,
+            skip_reachability_check,
         } => {
             if !config.export_calldata {
                 wallet.as_ref().ok_or_else(&require_wallet)?;
             }
-            warn_if_unreachable(p2p_addr).await;
-
+            if !skip_reachability_check {
+                check_if_reachable(p2p_addr).await;
+            }
             Transaction::UpdateNetworkConfig {
                 stake_table: stake_table_addr,
                 x25519_key: *x25519_key,
@@ -795,12 +800,16 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
                 x25519_key: *x25519_key,
             }
         },
-        Commands::UpdateP2pAddr { p2p_addr } => {
+        Commands::UpdateP2pAddr {
+            p2p_addr,
+            skip_reachability_check,
+        } => {
             if !config.export_calldata {
                 wallet.as_ref().ok_or_else(&require_wallet)?;
             }
-            warn_if_unreachable(p2p_addr).await;
-
+            if !skip_reachability_check {
+                check_if_reachable(p2p_addr).await;
+            }
             Transaction::UpdateP2pAddr {
                 stake_table: stake_table_addr,
                 p2p_addr: p2p_addr.clone(),

--- a/staking-cli/src/lib.rs
+++ b/staking-cli/src/lib.rs
@@ -365,6 +365,10 @@ pub(crate) enum Commands {
         /// p2p address in host:port format. Required for V3 stake tables.
         #[clap(long, value_parser = p2p_addr::parse_p2p_addr, env = "P2P_ADDR")]
         p2p_addr: Option<NetAddr>,
+
+        /// Do not check if the address is reachable.
+        #[clap(long)]
+        skip_reachability_check: bool,
     },
     /// Update a validators Espresso consensus signing keys.
     UpdateConsensusKeys {
@@ -402,6 +406,10 @@ pub(crate) enum Commands {
         /// The p2p address in host:port format
         #[clap(long, value_parser = p2p_addr::parse_p2p_addr, env = "P2P_ADDR")]
         p2p_addr: NetAddr,
+
+        /// Do not check if the address is reachable.
+        #[clap(long)]
+        skip_reachability_check: bool,
     },
     /// Set x25519 encryption key for a validator.
     UpdateX25519Key {
@@ -414,6 +422,10 @@ pub(crate) enum Commands {
         /// The p2p address in host:port format
         #[clap(long, value_parser = p2p_addr::parse_p2p_addr, env = "P2P_ADDR")]
         p2p_addr: NetAddr,
+
+        /// Do not check if the address is reachable.
+        #[clap(long)]
+        skip_reachability_check: bool,
     },
     /// Approve stake table contract to move tokens
     Approve {

--- a/staking-cli/src/lib.rs
+++ b/staking-cli/src/lib.rs
@@ -36,6 +36,7 @@ pub(crate) mod metadata_types;
 // TODO: Replace with imports from staking-ui-service once version compatibility is resolved
 pub(crate) mod openmetrics;
 pub(crate) mod output;
+pub(crate) mod p2p_addr;
 pub(crate) mod parse;
 pub(crate) mod receipt;
 pub(crate) mod registration;
@@ -362,7 +363,7 @@ pub(crate) enum Commands {
         x25519_key: Option<x25519::PublicKey>,
 
         /// p2p address in host:port format. Required for V3 stake tables.
-        #[clap(long, value_parser = parse::parse_net_addr, env = "P2P_ADDR")]
+        #[clap(long, value_parser = p2p_addr::parse_p2p_addr, env = "P2P_ADDR")]
         p2p_addr: Option<NetAddr>,
     },
     /// Update a validators Espresso consensus signing keys.
@@ -399,7 +400,7 @@ pub(crate) enum Commands {
         x25519_key: x25519::PublicKey,
 
         /// The p2p address in host:port format
-        #[clap(long, value_parser = parse::parse_net_addr, env = "P2P_ADDR")]
+        #[clap(long, value_parser = p2p_addr::parse_p2p_addr, env = "P2P_ADDR")]
         p2p_addr: NetAddr,
     },
     /// Set x25519 encryption key for a validator.
@@ -411,7 +412,7 @@ pub(crate) enum Commands {
     /// Update p2p address for a validator.
     UpdateP2pAddr {
         /// The p2p address in host:port format
-        #[clap(long, value_parser = parse::parse_net_addr, env = "P2P_ADDR")]
+        #[clap(long, value_parser = p2p_addr::parse_p2p_addr, env = "P2P_ADDR")]
         p2p_addr: NetAddr,
     },
     /// Approve stake table contract to move tokens

--- a/staking-cli/src/p2p_addr.rs
+++ b/staking-cli/src/p2p_addr.rs
@@ -1,0 +1,76 @@
+//! Validation of the p2p address a validator registers in the stake table.
+
+use hotshot_types::addr::NetAddr;
+use tokio::net::lookup_host;
+
+use crate::output::output_warn;
+
+/// The longest address the stake table contract accepts.
+const MAX_ADDR_LEN: usize = 512;
+
+/// Parse a p2p address to register in the stake table.
+///
+/// [`NetAddr::validate`] holds the rules for the address itself; what is added here is
+/// what the stake table asks of one: it fits the contract's length limit, and it names a
+/// port a peer can connect to, which a missing port does not. An address that prints
+/// differently to how it was written is registered in the form it prints in, and the
+/// caller is told so, since that is the string that lands on chain.
+pub fn parse_p2p_addr(s: &str) -> Result<NetAddr, String> {
+    let addr: NetAddr = s.parse().map_err(|e| format!("`{s}`: {e}"))?;
+    addr.validate().map_err(|e| format!("`{s}`: {e}"))?;
+
+    if addr.port() == 0 {
+        return Err(format!("`{s}`: port 0 is not a port a peer can connect to"));
+    }
+
+    let registered = addr.to_string();
+    if registered.len() > MAX_ADDR_LEN {
+        return Err(format!(
+            "`{s}` is {} bytes long, the stake table contract accepts at most {MAX_ADDR_LEN}",
+            registered.len()
+        ));
+    }
+
+    if registered != s {
+        output_warn(format!("`{s}` will be registered as `{registered}`"));
+    }
+
+    Ok(addr)
+}
+
+/// Warn about an address that is well-formed but that other validators are unlikely to
+/// reach. Not an error: a name may resolve only once the node is deployed.
+pub(crate) async fn warn_if_unreachable(addr: &NetAddr) {
+    if !addr.is_probably_global() {
+        output_warn(format!(
+            "`{addr}` is not publicly routable, other validators will not be able to connect to it"
+        ));
+        return;
+    }
+    if addr.is_ip() {
+        return;
+    }
+
+    let resolved = match lookup_host(addr.to_string()).await {
+        Ok(addrs) => addrs.collect::<Vec<_>>(),
+        Err(err) => {
+            output_warn(format!("`{addr}` does not resolve: {err}"));
+            return;
+        },
+    };
+
+    if resolved.is_empty() {
+        output_warn(format!("`{addr}` does not resolve to any address"));
+        return;
+    }
+
+    if !resolved
+        .iter()
+        .any(|a| NetAddr::from((a.ip().to_canonical(), a.port())).is_probably_global())
+    {
+        output_warn(format!(
+            "`{addr}` resolves only to addresses that are not publicly routable, other validators \
+             will not be able to connect to it"
+        ))
+    }
+}

--- a/staking-cli/src/p2p_addr.rs
+++ b/staking-cli/src/p2p_addr.rs
@@ -3,7 +3,7 @@
 use hotshot_types::addr::NetAddr;
 use tokio::net::lookup_host;
 
-use crate::output::output_warn;
+use crate::output::{output_error, output_warn};
 
 /// The longest address the stake table contract accepts.
 const MAX_ADDR_LEN: usize = 512;
@@ -38,15 +38,13 @@ pub fn parse_p2p_addr(s: &str) -> Result<NetAddr, String> {
     Ok(addr)
 }
 
-/// Warn about an address that is well-formed but that other validators are unlikely to
-/// reach. Not an error: a name may resolve only once the node is deployed.
-pub(crate) async fn warn_if_unreachable(addr: &NetAddr) {
+pub(crate) async fn check_if_reachable(addr: &NetAddr) {
     if !addr.is_probably_global() {
-        output_warn(format!(
+        output_error(format!(
             "`{addr}` is not publicly routable, other validators will not be able to connect to it"
         ));
-        return;
     }
+
     if addr.is_ip() {
         return;
     }
@@ -54,23 +52,21 @@ pub(crate) async fn warn_if_unreachable(addr: &NetAddr) {
     let resolved = match lookup_host(addr.to_string()).await {
         Ok(addrs) => addrs.collect::<Vec<_>>(),
         Err(err) => {
-            output_warn(format!("`{addr}` does not resolve: {err}"));
-            return;
+            output_error(format!("`{addr}` does not resolve: {err}"));
         },
     };
 
     if resolved.is_empty() {
-        output_warn(format!("`{addr}` does not resolve to any address"));
-        return;
+        output_error(format!("`{addr}` does not resolve to any address"));
     }
 
     if !resolved
         .iter()
         .any(|a| NetAddr::from((a.ip().to_canonical(), a.port())).is_probably_global())
     {
-        output_warn(format!(
-            "`{addr}` resolves only to addresses that are not publicly routable, other validators \
-             will not be able to connect to it"
+        output_error(format!(
+            "`{addr}` resolves to addresses that are not publicly routable, other validators will \
+             not be able to connect to it"
         ))
     }
 }

--- a/staking-cli/src/parse.rs
+++ b/staking-cli/src/parse.rs
@@ -2,7 +2,6 @@ use std::{fmt::Display, str::FromStr as _};
 
 use derive_more::{Add, From};
 use hotshot_types::{
-    addr::NetAddr,
     light_client::StateSignKey,
     signature_key::{BLSPrivKey, BLSPubKey},
     x25519,
@@ -31,11 +30,6 @@ pub fn parse_x25519_key(s: &str) -> Result<x25519::PublicKey, String> {
 
 pub fn parse_x25519_priv_key(s: &str) -> Result<x25519::SecretKey, Tb64Error> {
     TaggedBase64::parse(s)?.try_into()
-}
-
-pub fn parse_net_addr(s: &str) -> Result<NetAddr, String> {
-    s.parse()
-        .map_err(|e| format!("Invalid network address (expected host:port): {e}"))
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Add)]

--- a/staking-cli/tests/cli.rs
+++ b/staking-cli/tests/cli.rs
@@ -1798,6 +1798,7 @@ async fn test_cli_all_operations_manual_inspect(
             .arg(key.to_string())
             .arg("--p2p-addr")
             .arg("10.0.0.1:9090")
+            .arg("--skip-reachability-check")
             .assert()
             .success()
             .get_output()
@@ -1823,6 +1824,7 @@ async fn test_cli_all_operations_manual_inspect(
             .arg("update-p2p-addr")
             .arg("--p2p-addr")
             .arg("192.168.1.1:7070")
+            .arg("--skip-reachability-check")
             .assert()
             .success()
             .get_output()
@@ -2395,6 +2397,7 @@ async fn test_cli_export_calldata_all_operations_manual_inspect() -> Result<()> 
         .arg(system.x25519_public_key_str())
         .arg("--p2p-addr")
         .arg("127.0.0.1:8080")
+        .arg("--skip-reachability-check")
         .assert()
         .success()
         .get_output()
@@ -2982,6 +2985,7 @@ async fn test_cli_update_network_config() -> Result<()> {
         .arg(key.to_string())
         .arg("--p2p-addr")
         .arg("10.0.0.1:9090")
+        .arg("--skip-reachability-check")
         .assert()
         .success();
 
@@ -3015,8 +3019,26 @@ async fn test_cli_update_p2p_addr() -> Result<()> {
         .arg("update-p2p-addr")
         .arg("--p2p-addr")
         .arg("192.168.1.1:7070")
+        .arg("--skip-reachability-check")
         .assert()
         .success();
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_cli_update_p2p_addr_unreachable() -> Result<()> {
+    let system = TestSystem::deploy_version(StakeTableContractVersion::V3).await?;
+    system.register_validator().await?;
+
+    system
+        .cmd(Signer::Mnemonic)
+        .arg("update-p2p-addr")
+        .arg("--p2p-addr")
+        .arg("192.168.1.1:7070")
+        .assert()
+        .failure()
+        .stderr(str::contains("not publicly routable"));
 
     Ok(())
 }

--- a/staking-cli/tests/common/mod.rs
+++ b/staking-cli/tests/common/mod.rs
@@ -71,7 +71,8 @@ impl<'a> TestCommand<'a> {
                 .arg("--x25519-key")
                 .arg(self.system.x25519_public_key_str())
                 .arg("--p2p-addr")
-                .arg("127.0.0.1:8080");
+                .arg("127.0.0.1:8080")
+                .arg("--skip-reachability-check");
         }
         self
     }


### PR DESCRIPTION
`NetAddr` displayed an IPv6 address as `::1:9977`, which nothing else accepts and which separates the port from the last group with the same character that separates the groups. `Display` now writes `[::1]:9977`.

Parsing stays as lax as it was. That means a `NetAddr` can hold a host no peer will reach. `NetAddr::validate` is the check parsing leaves out, applied where an address arrives from someone who can still be told to correct it. It checks neither the port nor the length of the whole name: a missing port and port 0 are one value after parsing, and DNS's 253 characters and the contract's 512 bytes differ, so the length belongs to whoever accepts the address.

Serialization and commitments are unchanged. `main` serialized `to_string()` while `Display` was unbracketed; this branch serializes via `unbracketed_string()`, which gives the same string, and `RegisteredValidator::commit` uses it too.

What does change is the address the staking CLI registers, now `[2001:db8::1]:9977` for IPv6. Existing nodes read it though, since `from_str` has already stripped brackets before.

Also, `Network::create` binds now by destructuring `NetAddr` instead of parsing `Display` output, and `Party` compares peer IPs canonically so an IPv4 address delivered in IPv6 form matches.

For users: the staking CLI now rejects a malformed `--p2p-addr`, port 0, and an address over 512 bytes, and says so when the registered form differs from what was typed. It warns without failing when the address is not routeable or does not resolve. The node validates `--cliquenet-bind-address` and `--cliquenet-advertise-address` at startup, and rejects port 0 for the latter.