### PR TITLE
fix(new-protocol): don't fake a payload size for fetched proposals

### DIFF
--- a/crates/espresso/types/src/v0/impls/block/full_payload/ns_table.rs
+++ b/crates/espresso/types/src/v0/impls/block/full_payload/ns_table.rs
@@ -183,7 +183,7 @@ impl NsTable {
     ///
     /// Checks conditions 1-3 of [`NsTable::validate`]. Those conditions can be
     /// checked by looking only at the contents of the [`NsTable`].
-    fn validate_deserialization_invariants(&self) -> Result<(), NsTableValidationError> {
+    pub(crate) fn validate_deserialization_invariants(&self) -> Result<(), NsTableValidationError> {
         use NsTableValidationError::*;
 
         // Byte length for a table with `x` entries must be exactly `x *

--- a/crates/espresso/types/src/v0/impls/state.rs
+++ b/crates/espresso/types/src/v0/impls/state.rs
@@ -450,12 +450,15 @@ impl ValidatedState {
 #[derive(Debug)]
 pub(crate) struct Proposal<'a> {
     header: &'a Header,
-    block_size: u32,
+    /// Payload byte length from the VID share. `None` for a proposal fetched
+    /// from a peer without one; the checks that need it are skipped, a quorum
+    /// having already run them when it certified the proposal.
+    block_size: Option<u32>,
 }
 
 #[cfg_attr(not(feature = "node"), allow(dead_code))]
 impl<'a> Proposal<'a> {
-    pub(crate) fn new(header: &'a Header, block_size: u32) -> Self {
+    pub(crate) fn new(header: &'a Header, block_size: Option<u32>) -> Self {
         Self { header, block_size }
     }
     /// The L1 head block number in the proposal must be non-decreasing relative
@@ -712,7 +715,10 @@ impl<'a> ValidatedTransition<'a> {
     /// Validate that proposal block size does not exceed configured
     /// `ChainConfig.max_block_size`.
     fn validate_block_size(&self) -> Result<(), ProposalValidationError> {
-        let block_size = self.proposal.block_size as u64;
+        let Some(block_size) = self.proposal.block_size else {
+            return Ok(());
+        };
+        let block_size = block_size as u64;
         if block_size > *self.expected_chain_config.max_block_size {
             return Err(ProposalValidationError::MaxBlockSizeExceeded {
                 max_block_size: self.expected_chain_config.max_block_size,
@@ -729,8 +735,11 @@ impl<'a> ValidatedTransition<'a> {
         let Some(amount) = self.proposal.header.fee_info().amount() else {
             return Err(ProposalValidationError::SomeFeeAmountOutOfRange);
         };
+        let Some(block_size) = self.proposal.block_size else {
+            return Ok(());
+        };
 
-        if amount < self.expected_chain_config.base_fee * U256::from(self.proposal.block_size) {
+        if amount < self.expected_chain_config.base_fee * U256::from(block_size) {
             return Err(ProposalValidationError::InsufficientFee {
                 max_block_size: self.expected_chain_config.max_block_size,
                 base_fee: self.expected_chain_config.base_fee,
@@ -815,14 +824,16 @@ impl<'a> ValidatedTransition<'a> {
 
         Ok(())
     }
-    /// Proxy to [`super::NsTable::validate()`].
+    /// Proxy to [`super::NsTable::validate()`]. Without a payload size only
+    /// the size-independent invariants can be checked.
     fn validate_namespace_table(&self) -> Result<(), ProposalValidationError> {
-        self.proposal
-            .header
-            .ns_table()
+        let ns_table = self.proposal.header.ns_table();
+        match self.proposal.block_size {
             // Should be safe since `u32` will always fit in a `usize`.
-            .validate(&PayloadByteLen(self.proposal.block_size as usize))
-            .map_err(ProposalValidationError::from)
+            Some(block_size) => ns_table.validate(&PayloadByteLen(block_size as usize)),
+            None => ns_table.validate_deserialization_invariants(),
+        }
+        .map_err(ProposalValidationError::from)
     }
 
     /// Validate that the total rewards distributed in the proposed header matches the actual distributed amount.
@@ -1314,7 +1325,7 @@ impl HotShotState<SeqTypes> for ValidatedState {
         instance: &Self::Instance,
         parent_leaf: &Leaf2,
         proposed_header: &Header,
-        payload_byte_len: u32,
+        payload_byte_len: Option<u32>,
         version: Version,
         view_number: u64,
     ) -> Result<(Self, Self::Delta), Self::Error> {
@@ -1803,7 +1814,7 @@ mod test {
         let (header, block_size) = tx.into_mock_header().await;
 
         // Success Case
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         // Note we are using the same header for parent and proposal,
         // this may be OK depending on what we are testing.
         ValidatedTransition::mock(NodeState::mock_v2(), &header, proposal)
@@ -1811,7 +1822,7 @@ mod test {
             .unwrap();
 
         // Error Case
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         let err = proposal.validate_l1_head(u64::MAX).unwrap_err();
         assert_eq!(ProposalValidationError::DecrementingL1Head, err);
     }
@@ -1824,14 +1835,14 @@ mod test {
         let (header, block_size) = tx.into_mock_header().await;
 
         // Success Case
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         ValidatedTransition::mock(instance.clone(), &header, proposal)
             .validate_builder_fee()
             .unwrap();
 
         // Error Case
         let header = header.invalid_builder_signature();
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         let err = ValidatedTransition::mock(instance, &header, proposal)
             .validate_builder_fee()
             .unwrap_err();
@@ -1853,13 +1864,13 @@ mod test {
         let (header, block_size) = tx.into_mock_header().await;
 
         // Success Case
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         ValidatedTransition::mock(instance.clone(), &header, proposal)
             .validate_chain_config()
             .unwrap();
 
         // Error Case
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         let expected_chain_config = ChainConfig {
             max_block_size: BlockSize(3333),
             ..instance.chain_config
@@ -1894,7 +1905,7 @@ mod test {
         let (header, block_size) = tx.into_mock_header().await;
 
         // Error Case
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         let err = ValidatedTransition::mock(instance.clone(), &header, proposal)
             .validate_block_size()
             .unwrap_err();
@@ -1909,7 +1920,7 @@ mod test {
         );
 
         // Success Case
-        let proposal = Proposal::new(&header, 1);
+        let proposal = Proposal::new(&header, Some(1));
         ValidatedTransition::mock(instance, &header, proposal)
             .validate_block_size()
             .unwrap()
@@ -1926,7 +1937,7 @@ mod test {
             ..state.chain_config.resolve().unwrap()
         });
 
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         let err = ValidatedTransition::mock(instance.clone(), &header, proposal)
             .validate_fee()
             .unwrap_err();
@@ -1950,7 +1961,7 @@ mod test {
         let tx = Transaction::of_size(10);
         let (parent, block_size) = tx.into_mock_header().await;
 
-        let proposal = Proposal::new(&parent, block_size);
+        let proposal = Proposal::new(&parent, Some(block_size));
         let err = ValidatedTransition::mock(instance.clone(), &parent, proposal)
             .validate_height()
             .unwrap_err();
@@ -1968,7 +1979,7 @@ mod test {
         // Success case. Increment height on proposal.
         let mut header = parent.clone();
         *header.height_mut() += 1;
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
 
         ValidatedTransition::mock(instance, &parent, proposal)
             .validate_height()
@@ -1981,7 +1992,7 @@ mod test {
         let (parent, block_size) = tx.into_mock_header().await;
 
         // Error case
-        let proposal = Proposal::new(&parent, block_size);
+        let proposal = Proposal::new(&parent, Some(block_size));
         let proposal_timestamp = proposal.header.timestamp();
         let err = proposal.validate_timestamp_non_dec(u64::MAX).unwrap_err();
 
@@ -1996,7 +2007,7 @@ mod test {
         );
 
         // Success case (genesis timestamp is `0`).
-        let proposal = Proposal::new(&parent, block_size);
+        let proposal = Proposal::new(&parent, Some(block_size));
         proposal.validate_timestamp_non_dec(0).unwrap();
     }
 
@@ -2008,7 +2019,7 @@ mod test {
 
         let header = parent.clone();
         // Error case.
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         let proposal_timestamp = header.timestamp();
 
         let mock_time = OffsetDateTime::now_utc().unix_timestamp() as u64;
@@ -2033,7 +2044,7 @@ mod test {
 
         let mut header = parent.clone();
         header.set_timestamp(timestamp - 13, timestamp_millis - 13_000);
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
 
         let err = proposal.validate_timestamp_drift(time).unwrap_err();
         tracing::info!(%err, "task failed successfully");
@@ -2049,15 +2060,15 @@ mod test {
         // Success cases.
         let mut header = parent.clone();
         header.set_timestamp(timestamp, timestamp_millis);
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         proposal.validate_timestamp_drift(time).unwrap();
 
         header.set_timestamp(timestamp - 11, timestamp_millis - 11_000);
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         proposal.validate_timestamp_drift(time).unwrap();
 
         header.set_timestamp(timestamp - 12, timestamp_millis - 12_000);
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         proposal.validate_timestamp_drift(time).unwrap();
     }
 
@@ -2068,13 +2079,13 @@ mod test {
         let (header, block_size) = Transaction::of_size(10).into_mock_header().await;
 
         // Success case.
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         ValidatedTransition::mock(instance.clone(), &header, proposal)
             .validate_fee_merkle_tree()
             .unwrap();
 
         // Error case.
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
 
         let mut fee_merkle_tree = instance.genesis_state.fee_merkle_tree;
         fee_merkle_tree
@@ -2102,13 +2113,13 @@ mod test {
         let (header, block_size) = Transaction::of_size(10).into_mock_header().await;
 
         // Success case.
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         ValidatedTransition::mock(instance.clone(), &header, proposal)
             .validate_block_merkle_tree()
             .unwrap();
 
         // Error case.
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         let mut block_merkle_tree = instance.genesis_state.block_merkle_tree;
         block_merkle_tree.push(header.commitment()).unwrap();
         block_merkle_tree
@@ -2137,13 +2148,13 @@ mod test {
         let (header, block_size) = tx.into_mock_header().await;
 
         // Success case.
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         ValidatedTransition::mock(NodeState::mock_v2(), &header, proposal)
             .validate_namespace_table()
             .unwrap();
 
         // Error case
-        let proposal = Proposal::new(&header, 40);
+        let proposal = Proposal::new(&header, Some(40));
         let err = ValidatedTransition::mock(NodeState::mock_v2(), &header, proposal)
             .validate_namespace_table()
             .unwrap_err();
@@ -2154,6 +2165,20 @@ mod test {
             ProposalValidationError::InvalidNsTable(InvalidFinalOffset),
             err
         );
+    }
+
+    /// A proposal fetched without a VID share has no payload size. The checks
+    /// that need one are skipped instead of run against a made-up length.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_validation_without_block_size() {
+        let tx = Transaction::of_size(10);
+        let (header, _block_size) = tx.into_mock_header().await;
+
+        let proposal = Proposal::new(&header, None);
+        let transition = ValidatedTransition::mock(NodeState::mock_v2(), &header, proposal);
+        transition.validate_namespace_table().unwrap();
+        transition.validate_block_size().unwrap();
+        transition.validate_fee().unwrap();
     }
 
     #[test_log::test]
@@ -2365,7 +2390,7 @@ mod test {
         let validated_transition = ValidatedTransition::new(
             validated_state.clone(),
             &header,
-            Proposal::new(&proposed_header, block_size),
+            Proposal::new(&proposed_header, Some(block_size)),
             Some(actual_total),
             version(0, 4),
             validation_start_time,
@@ -2389,7 +2414,7 @@ mod test {
         ValidatedTransition::new(
             validated_state.clone(),
             &header,
-            Proposal::new(&proposed_header, block_size),
+            Proposal::new(&proposed_header, Some(block_size)),
             Some(actual_total),
             version(0, 4),
             validation_start_time,
@@ -2415,7 +2440,7 @@ mod test {
         std::thread::sleep(Duration::from_secs(13));
 
         // Validation fails if we pass the current timestamp (emulates issue before fix)
-        let proposal_without_fix = Proposal::new(&header, block_size);
+        let proposal_without_fix = Proposal::new(&header, Some(block_size));
         let err = ValidatedTransition::new(
             instance.genesis_state.clone(),
             &parent,
@@ -2435,7 +2460,7 @@ mod test {
         ));
 
         // Validation succeeds if we pass a validation start timestamp
-        let proposal = Proposal::new(&header, block_size);
+        let proposal = Proposal::new(&header, Some(block_size));
         ValidatedTransition::new(
             instance.genesis_state.clone(),
             &parent,
@@ -2500,7 +2525,7 @@ mod test {
                 &instance,
                 &parent_leaf,
                 &proposed_header,
-                0, /* payload_byte_len */
+                Some(0), /* payload_byte_len */
                 FEE_VERSION,
                 0, /* view_number */
             )

--- a/crates/hotshot/example-types/src/state_types.rs
+++ b/crates/hotshot/example-types/src/state_types.rs
@@ -102,7 +102,7 @@ impl<TYPES: NodeType> ValidatedState<TYPES> for TestValidatedState {
         instance: &Self::Instance,
         _parent_leaf: &Leaf2<TYPES>,
         _proposed_header: &TYPES::BlockHeader,
-        _payload_byte_len: u32,
+        _payload_byte_len: Option<u32>,
         _version: Version,
         _view_number: u64,
     ) -> Result<(Self, Self::Delta), Self::Error> {

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -1205,7 +1205,7 @@ impl<T: NodeType> Consensus<T> {
             }
         }
 
-        self.request_state(&proposal, payload_size, outbox);
+        self.request_state(&proposal, Some(payload_size), outbox);
 
         outbox.push_back(ConsensusOutput::ProposalValidated {
             proposal: signed_proposal,
@@ -1248,7 +1248,7 @@ impl<T: NodeType> Consensus<T> {
     fn request_state(
         &self,
         proposal: &Proposal<T>,
-        payload_size: u32,
+        payload_size: Option<u32>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) {
         outbox.push_back(ConsensusOutput::RequestState(StateRequest {
@@ -1262,19 +1262,20 @@ impl<T: NodeType> Consensus<T> {
         }));
     }
 
-    /// A fetched proposal may have no share. A quorum already certified it,
-    /// size checks included, so zero only skips this node's block-size checks.
-    fn payload_size_for(&self, proposal: &Proposal<T>) -> u32 {
+    /// A fetched proposal arrives without this node's share; one parked for
+    /// the view still supplies the payload size. Without either the size is
+    /// unknown, and the state manager validates without the size checks.
+    fn payload_size_for(&self, proposal: &Proposal<T>) -> Option<u32> {
         let view = proposal.view_number();
         if let Some(share) = self.vid_shares.get(&view) {
-            return share.payload_byte_len();
+            return Some(share.payload_byte_len());
         }
         let VidCommitment::V2(commitment) = proposal.block_header.payload_commitment() else {
-            return 0;
+            return None;
         };
         self.unpaired_vid_shares
             .get(&(view, commitment))
-            .map_or(0, |share| share.payload_byte_len())
+            .map(|share| share.payload_byte_len())
     }
 
     fn request_block_and_header_if_next_leader(

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -40,7 +40,9 @@ pub struct StateRequest<T: NodeType> {
     pub block: BlockNumber,
     pub proposal: Proposal<T>,
     pub parent_commitment: Commitment<Leaf2<T>>,
-    pub payload_size: u32,
+    /// Payload byte length from a VID share. `None` for a proposal fetched
+    /// without one; the validator skips the checks that need it.
+    pub payload_size: Option<u32>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -719,7 +719,9 @@ async fn test_leader_sends_proposal() {
     );
 }
 
-/// A fetched proposal gets its state validated like a gossiped one.
+/// A fetched proposal gets its state validated like a gossiped one. With no
+/// share for the view the request carries no payload size, rather than a
+/// fake one the validator would reject.
 #[tokio::test]
 async fn test_fetched_proposal_requests_state() {
     let test_data = TestData::new(2).await;
@@ -734,9 +736,36 @@ async fn test_fetched_proposal_requests_state() {
     assert!(
         any(harness.outputs(), |o| matches!(
             o,
-            ConsensusOutput::RequestState(r) if r.view == ViewNumber::new(1)
+            ConsensusOutput::RequestState(r)
+                if r.view == ViewNumber::new(1) && r.payload_size.is_none()
         )),
-        "state validation must be requested for a fetched proposal"
+        "state validation must be requested for a fetched proposal, without a payload size"
+    );
+}
+
+/// A share parked for the view supplies a fetched proposal's payload size.
+#[tokio::test]
+async fn test_fetched_proposal_takes_size_from_parked_share() {
+    let test_data = TestData::new(2).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+    let mut harness = ConsensusHarness::new(0).await;
+
+    let share = test_data.views[0].vid_share_for(&node_key);
+    let payload_size = share.payload_byte_len();
+    harness.apply(ConsensusInput::VidShare(share)).await;
+    harness
+        .apply(ConsensusInput::FetchedProposal(
+            test_data.views[0].proposal_message(),
+        ))
+        .await;
+
+    assert!(
+        any(harness.outputs(), |o| matches!(
+            o,
+            ConsensusOutput::RequestState(r)
+                if r.view == ViewNumber::new(1) && r.payload_size == Some(payload_size)
+        )),
+        "the parked share's payload size must reach the state request"
     );
 }
 

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -33,7 +33,7 @@ fn make_state_request(view: &TestView) -> StateRequest<TestTypes> {
         block: BlockHeader::<TestTypes>::block_number(&proposal.block_header).into(),
         proposal: proposal.clone(),
         parent_commitment: proposal.justify_qc.data().leaf_commit,
-        payload_size: 0,
+        payload_size: Some(0),
     }
 }
 

--- a/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
@@ -359,7 +359,7 @@ pub(crate) async fn update_shared_state<TYPES: NodeType>(
             &instance_state,
             &parent,
             &proposed_leaf.block_header().clone(),
-            vid_share.data.payload_byte_len(),
+            Some(vid_share.data.payload_byte_len()),
             version,
             *view_number,
         )

--- a/crates/hotshot/types/src/traits/states.rs
+++ b/crates/hotshot/types/src/traits/states.rs
@@ -56,6 +56,9 @@ pub trait ValidatedState<TYPES: NodeType>:
     ///
     /// # Arguments
     /// * `instance` - Immutable instance-level state.
+    /// * `payload_byte_len` - Size of the block payload, from the VID share. `None` when the
+    ///   proposal was fetched from a peer without one; checks that need the size are skipped,
+    ///   a quorum having already run them when it certified the proposal.
     ///
     /// # Errors
     ///
@@ -65,7 +68,7 @@ pub trait ValidatedState<TYPES: NodeType>:
         instance: &Self::Instance,
         parent_leaf: &Leaf2<TYPES>,
         proposed_header: &TYPES::BlockHeader,
-        payload_byte_len: u32,
+        payload_byte_len: Option<u32>,
         version: Version,
         view_number: u64,
     ) -> impl Future<Output = Result<(Self, Self::Delta), Self::Error>> + Send;


### PR DESCRIPTION
## Problem

Nodes on the newest release (`20260826`) log

```
Invalid Block Header: Invalid namespace table: InvalidFinalOffset
```

after fetching a missing parent proposal. #4865 started validating the state of fetched proposals and, since a fetched proposal has no VID share, passed `payload_size = 0` on the theory that zero only disabled the block-size checks. It also feeds `NsTable::validate`, whose condition 4 requires the table's final offset to equal the payload length — so every non-empty fetched block failed validation and fell back to a `from_header` stub, which is the catchup churn #4865 set out to remove.

## Fix

Make the payload size `Option<u32>` through `ValidatedState::validate_and_apply_header`:

- `Proposal.block_size` in the espresso validator becomes `Option<u32>`. `validate_block_size` and `validate_fee` return `Ok` when it is `None`; `validate_namespace_table` still runs the size-independent invariants (entry alignment, monotone offsets, unique ns ids) and skips only the final-offset comparison. The fee-amount-in-range check runs regardless.
- New protocol: `payload_size_for` returns `Option<u32>` (own share, then a parked share, else `None`); the incorrect "zero only skips block-size checks" comment is gone. The gossip path passes `Some(share.payload_byte_len())`.
- Legacy vote path and `hotshot-example-types`: mechanical `Some(..)` / signature updates.

A quorum already ran the skipped checks when it certified the proposal. Gossiped proposals are validated exactly as before.

## Tests

- `test_validation_without_block_size` (espresso-types): `None` passes the ns-table, block-size and fee checks on a real non-empty block.
- `test_fetched_proposal_requests_state` now asserts the state request carries `payload_size: None`; new `test_fetched_proposal_takes_size_from_parked_share` asserts a parked share's size is used.
- No serializable type changed, so no `reference` vectors to update.

## Review focus

`ValidatedTransition::validate_block_size` / `validate_fee` / `validate_namespace_table` in `crates/espresso/types/src/v0/impls/state.rs`, and `payload_size_for` in `crates/hotshot/new-protocol/src/consensus.rs`.

## Not in this PR

Dependents of a fetched proposal still queue behind its in-flight validation on `main`; the deadline-based stub in `c70ba922cca` (`origin/fix/fetched-proposal-state`) is the general answer to that and is left separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
