### PR TITLE
fix(new-protocol): adopt parked proposals; validate fetched ones without a payload size

### DIFF
--- a/crates/espresso/types/src/v0/impls/state.rs
+++ b/crates/espresso/types/src/v0/impls/state.rs
@@ -1623,7 +1623,9 @@ mod test {
     use super::*;
     use crate::{
         BlockSize, FeeAccountProof, FeeMerkleProof, Leaf, Payload, TimestampMillis, Transaction,
-        eth_signature_key::EthKeyPair, mock::MockStateCatchup, v0_1, v0_2, v0_3, v0_4, v0_5, v0_6,
+        eth_signature_key::{BuilderSignature, EthKeyPair},
+        mock::MockStateCatchup,
+        v0_1, v0_2, v0_3, v0_4, v0_5, v0_6,
     };
 
     impl Transaction {
@@ -1734,34 +1736,38 @@ mod test {
                 self.metadata(),
             )
             .unwrap();
+            self.with_fee(fee_info, Some(sig))
+        }
 
+        /// Replaces the fee info and builder signature.
+        fn with_fee(&self, fee_info: FeeInfo, builder_signature: Option<BuilderSignature>) -> Self {
             match self {
-                Header::V1(_) => panic!(
-                    "You called `Header.invalid_builder_signature()` on unimplemented version (v1)"
-                ),
+                Header::V1(_) => {
+                    panic!("You called `Header.with_fee()` on unimplemented version (v1)")
+                },
                 Header::V2(parent) => Header::V2(v0_2::Header {
                     fee_info,
-                    builder_signature: Some(sig),
+                    builder_signature,
                     ..parent.clone()
                 }),
                 Header::V3(parent) => Header::V3(v0_3::Header {
                     fee_info,
-                    builder_signature: Some(sig),
+                    builder_signature,
                     ..parent.clone()
                 }),
                 Header::V4(parent) => Header::V4(v0_4::Header {
                     fee_info,
-                    builder_signature: Some(sig),
+                    builder_signature,
                     ..parent.clone()
                 }),
                 Header::V5(parent) => Header::V5(v0_5::Header {
                     fee_info,
-                    builder_signature: Some(sig),
+                    builder_signature,
                     ..parent.clone()
                 }),
                 Header::V6(parent) => Header::V6(v0_6::Header {
                     fee_info,
-                    builder_signature: Some(sig),
+                    builder_signature,
                     ..parent.clone()
                 }),
             }
@@ -2185,19 +2191,53 @@ mod test {
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_validation_without_payload_size_skips_size_checks() {
-        // A proposal adopted without its VID share carries no payload size;
-        // the size-dependent checks must not fail against a made-up size.
-        let tx = Transaction::of_size(10);
-        let (header, _block_size) = tx.into_mock_header().await;
+        use NsTableValidationError::InvalidFinalOffset;
+        // A proposal adopted without its VID share carries no payload size. Under
+        // this chain config every size-dependent check rejects the block once a
+        // size is supplied.
+        let tx = Transaction::of_size(20);
+        let (header, block_size) = tx.into_mock_header().await;
+        let instance = NodeState::mock_v2().with_chain_config(ChainConfig {
+            max_block_size: BlockSize::from_integer(10).unwrap(),
+            base_fee: 1000.into(),
+            ..ValidatedState::default().chain_config.resolve().unwrap()
+        });
 
-        let transition = ValidatedTransition::mock(
-            NodeState::mock_v2(),
+        let sized = ValidatedTransition::mock(
+            instance.clone(),
             &header,
-            Proposal::without_size(&header),
+            Proposal::new(&header, block_size),
         );
-        transition.validate_namespace_table().unwrap();
-        transition.validate_block_size().unwrap();
-        transition.validate_fee().unwrap();
+        assert!(matches!(
+            sized.validate_block_size(),
+            Err(ProposalValidationError::MaxBlockSizeExceeded { .. })
+        ));
+        assert!(matches!(
+            sized.validate_fee(),
+            Err(ProposalValidationError::InsufficientFee { .. })
+        ));
+        // Standing in a size of zero, as the fetch path once did, rejects every
+        // non-empty block.
+        let zero_sized =
+            ValidatedTransition::mock(instance.clone(), &header, Proposal::new(&header, 0));
+        assert_eq!(
+            ProposalValidationError::InvalidNsTable(InvalidFinalOffset),
+            zero_sized.validate_namespace_table().unwrap_err()
+        );
+
+        let sizeless =
+            ValidatedTransition::mock(instance.clone(), &header, Proposal::without_size(&header));
+        sizeless.validate_block_size().unwrap();
+        sizeless.validate_fee().unwrap();
+        sizeless.validate_namespace_table().unwrap();
+
+        // Fee presence does not depend on the size and is still checked.
+        let fee_account = EthKeyPair::random().fee_account();
+        let header = header.with_fee(FeeInfo::new(fee_account, FeeAmount(U256::MAX)), None);
+        let err = ValidatedTransition::mock(instance, &header, Proposal::without_size(&header))
+            .validate_fee()
+            .unwrap_err();
+        assert_eq!(ProposalValidationError::SomeFeeAmountOutOfRange, err);
     }
 
     #[test_log::test]

--- a/crates/espresso/types/src/v0/impls/state.rs
+++ b/crates/espresso/types/src/v0/impls/state.rs
@@ -450,13 +450,28 @@ impl ValidatedState {
 #[derive(Debug)]
 pub(crate) struct Proposal<'a> {
     header: &'a Header,
-    block_size: u32,
+    /// `None` when this node does not hold the payload; see [`Self::without_size`].
+    block_size: Option<u32>,
 }
 
 #[cfg_attr(not(feature = "node"), allow(dead_code))]
 impl<'a> Proposal<'a> {
     pub(crate) fn new(header: &'a Header, block_size: u32) -> Self {
-        Self { header, block_size }
+        Self {
+            header,
+            block_size: Some(block_size),
+        }
+    }
+
+    /// A proposal whose payload size this node does not know, e.g. one fetched
+    /// from a peer without a VID share. Only valid for a proposal a quorum has
+    /// already certified, which vouches for the checks this skips: block size,
+    /// fee and namespace table.
+    pub(crate) fn without_size(header: &'a Header) -> Self {
+        Self {
+            header,
+            block_size: None,
+        }
     }
     /// The L1 head block number in the proposal must be non-decreasing relative
     /// to the parent.
@@ -712,7 +727,10 @@ impl<'a> ValidatedTransition<'a> {
     /// Validate that proposal block size does not exceed configured
     /// `ChainConfig.max_block_size`.
     fn validate_block_size(&self) -> Result<(), ProposalValidationError> {
-        let block_size = self.proposal.block_size as u64;
+        let Some(block_size) = self.proposal.block_size else {
+            return Ok(());
+        };
+        let block_size = block_size as u64;
         if block_size > *self.expected_chain_config.max_block_size {
             return Err(ProposalValidationError::MaxBlockSizeExceeded {
                 max_block_size: self.expected_chain_config.max_block_size,
@@ -729,8 +747,11 @@ impl<'a> ValidatedTransition<'a> {
         let Some(amount) = self.proposal.header.fee_info().amount() else {
             return Err(ProposalValidationError::SomeFeeAmountOutOfRange);
         };
+        let Some(block_size) = self.proposal.block_size else {
+            return Ok(());
+        };
 
-        if amount < self.expected_chain_config.base_fee * U256::from(self.proposal.block_size) {
+        if amount < self.expected_chain_config.base_fee * U256::from(block_size) {
             return Err(ProposalValidationError::InsufficientFee {
                 max_block_size: self.expected_chain_config.max_block_size,
                 base_fee: self.expected_chain_config.base_fee,
@@ -817,11 +838,14 @@ impl<'a> ValidatedTransition<'a> {
     }
     /// Proxy to [`super::NsTable::validate()`].
     fn validate_namespace_table(&self) -> Result<(), ProposalValidationError> {
+        let Some(block_size) = self.proposal.block_size else {
+            return Ok(());
+        };
         self.proposal
             .header
             .ns_table()
             // Should be safe since `u32` will always fit in a `usize`.
-            .validate(&PayloadByteLen(self.proposal.block_size as usize))
+            .validate(&PayloadByteLen(block_size as usize))
             .map_err(ProposalValidationError::from)
     }
 
@@ -1314,7 +1338,7 @@ impl HotShotState<SeqTypes> for ValidatedState {
         instance: &Self::Instance,
         parent_leaf: &Leaf2,
         proposed_header: &Header,
-        payload_byte_len: u32,
+        payload_byte_len: Option<u32>,
         version: Version,
         view_number: u64,
     ) -> Result<(Self, Self::Delta), Self::Error> {
@@ -1358,7 +1382,10 @@ impl HotShotState<SeqTypes> for ValidatedState {
             let validated_state = ValidatedTransition::new(
                 validated_state,
                 parent_leaf.block_header(),
-                Proposal::new(proposed_header, payload_byte_len),
+                match payload_byte_len {
+                    Some(len) => Proposal::new(proposed_header, len),
+                    None => Proposal::without_size(proposed_header),
+                },
                 total_rewards_distributed,
                 version,
                 validation_start_time,
@@ -2156,6 +2183,23 @@ mod test {
         );
     }
 
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_validation_without_payload_size_skips_size_checks() {
+        // A proposal adopted without its VID share carries no payload size;
+        // the size-dependent checks must not fail against a made-up size.
+        let tx = Transaction::of_size(10);
+        let (header, _block_size) = tx.into_mock_header().await;
+
+        let transition = ValidatedTransition::mock(
+            NodeState::mock_v2(),
+            &header,
+            Proposal::without_size(&header),
+        );
+        transition.validate_namespace_table().unwrap();
+        transition.validate_block_size().unwrap();
+        transition.validate_fee().unwrap();
+    }
+
     #[test_log::test]
     fn test_charge_fee() {
         let src = FeeAccount::generated_from_seed_indexed([0; 32], 0).0;
@@ -2500,7 +2544,7 @@ mod test {
                 &instance,
                 &parent_leaf,
                 &proposed_header,
-                0, /* payload_byte_len */
+                Some(0), /* payload_byte_len */
                 FEE_VERSION,
                 0, /* view_number */
             )

--- a/crates/hotshot/example-types/src/state_types.rs
+++ b/crates/hotshot/example-types/src/state_types.rs
@@ -102,7 +102,7 @@ impl<TYPES: NodeType> ValidatedState<TYPES> for TestValidatedState {
         instance: &Self::Instance,
         _parent_leaf: &Leaf2<TYPES>,
         _proposed_header: &TYPES::BlockHeader,
-        _payload_byte_len: u32,
+        _payload_byte_len: Option<u32>,
         _version: Version,
         _view_number: u64,
     ) -> Result<(Self, Self::Delta), Self::Error> {

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -954,16 +954,14 @@ impl<T: NodeType> Consensus<T> {
     ///
     /// The decide inputs (`proposals`, `certs`, `certs2`, deferred certs,
     /// `decided_views`) survive down to [`Self::decide_floor`] so a late
-    /// Cert2 can still decide a gap view.
+    /// Cert2 can still decide a gap view. Parked proposal halves survive as
+    /// long, so such a Cert2 can adopt one instead of fetching.
     pub fn gc(&mut self, scope: GcScope) {
         match scope {
             GcScope::Local(view) => {
                 let c = Commitment::default_commitment_no_preimage();
-                let vc = VidCommitment2::default();
                 let floor = self.decide_floor();
                 self.headers = self.headers.split_off(&(view, c));
-                self.unpaired_proposals = self.unpaired_proposals.split_off(&(view, vc));
-                self.unpaired_vid_shares = self.unpaired_vid_shares.split_off(&(view, vc));
                 self.proposed_views = self.proposed_views.split_off(&view);
                 self.states_verified = self.states_verified.split_off(&view);
                 self.timeout_certs = self.timeout_certs.split_off(&view);
@@ -979,6 +977,8 @@ impl<T: NodeType> Consensus<T> {
                 self.certs2 = self.certs2.split_off(&keep_from);
                 self.decided_views = self.decided_views.split_off(&keep_from);
                 self.proposals = self.proposals.split_off(&keep_from);
+                self.unpaired_proposals = self.unpaired_proposals.split_off(&(keep_from, vc));
+                self.unpaired_vid_shares = self.unpaired_vid_shares.split_off(&(keep_from, vc));
                 self.vote1_parent = self.vote1_parent.split_off(&keep_from);
                 self.leaves = self.leaves.split_off(&view);
                 self.signed_proposals = self.signed_proposals.split_off(&view);
@@ -1089,19 +1089,11 @@ impl<T: NodeType> Consensus<T> {
         vid_share: VidDisperseShare2<T>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) -> Protocol {
-        let view = proposal.view_number();
         outbox.push_back(ConsensusOutput::ProposalPaired {
             proposal: proposal.proposal.clone(),
             vid_share: vid_share.clone(),
         });
-        // Handle first: a parked older proposal may be this one's parent, which
-        // `request_parent_proposal_if_missing` adopts rather than fetches.
-        let result = self.handle_proposal_with_vid_share(sender, proposal, vid_share, outbox);
-        // Parked halves for this and older views can no longer pair.
-        let vc = VidCommitment2::default();
-        self.unpaired_proposals = self.unpaired_proposals.split_off(&(view + 1, vc));
-        self.unpaired_vid_shares = self.unpaired_vid_shares.split_off(&(view + 1, vc));
-        result
+        self.handle_proposal_with_vid_share(sender, proposal, vid_share, outbox)
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -1242,17 +1234,19 @@ impl<T: NodeType> Consensus<T> {
         let proposal = signed_proposal.data.clone();
         let view = proposal.view_number;
         if view <= self.last_decided_view {
-            debug!(%view, "fetched proposal at or below decided view; discarding");
+            debug!(%view, "certified proposal at or below decided view; discarding");
             return;
         }
         if self.proposals.contains_key(&view) {
-            debug!(%view, "fetched proposal already present; discarding");
+            debug!(%view, "certified proposal already present; discarding");
             return;
         }
         self.leaves.insert(view, proposal.clone().into());
         self.signed_proposals.insert(view, signed_proposal);
-        self.request_parent_proposal_if_missing(&proposal, outbox);
+        // Stored before the parent lookup, which can re-enter here by adopting a
+        // parked parent; the store is what bounds that recursion.
         self.proposals.insert(view, proposal.clone());
+        self.request_parent_proposal_if_missing(&proposal, outbox);
         self.adopt_certified_drb(view);
 
         let payload_size = self.payload_size_for(&proposal);
@@ -1262,6 +1256,9 @@ impl<T: NodeType> Consensus<T> {
 
     /// Adopt the live proposal parked for `view` awaiting this node's VID
     /// share, if it is the leaf `leaf_commit` names. Returns whether one was adopted.
+    ///
+    /// The proposal stays parked: a share arriving later still pairs with it and
+    /// runs the live path, the only one that stores the share for `maybe_vote_1`.
     fn adopt_unpaired_proposal(
         &mut self,
         view: ViewNumber,

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -689,23 +689,7 @@ impl<T: NodeType> Consensus<T> {
                     view = %message.proposal.data.view_number,
                     "apply: fetched proposal"
                 );
-                self.handle_fetched_proposal(message, outbox);
-                // The fetched proposal itself may now be decidable (e.g. cert2
-                // arrived first and triggered the fetch).
-                self.maybe_decide(view, outbox);
-                // Views extending the fetched one may be blocked on it
-                let views_extending_fetched: Vec<ViewNumber> = self
-                    .proposals
-                    .range(view + 1..)
-                    .filter(|(_, proposal)| proposal.justify_qc.view_number() == view)
-                    .map(|(extending_view, _)| *extending_view)
-                    .collect();
-                for extending_view in views_extending_fetched {
-                    self.maybe_vote_1(extending_view, outbox);
-                    self.maybe_vote_2_and_update_lock(extending_view, outbox);
-                    self.maybe_decide(extending_view, outbox);
-                }
-                self.maybe_propose(view + 1, outbox);
+                self.adopt_certified_proposal(message, outbox);
                 return;
             },
             ConsensusInput::Certificate1(certificate) => {
@@ -1105,16 +1089,19 @@ impl<T: NodeType> Consensus<T> {
         vid_share: VidDisperseShare2<T>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) -> Protocol {
-        // Parked halves for this and older views can no longer pair.
         let view = proposal.view_number();
-        let vc = VidCommitment2::default();
-        self.unpaired_proposals = self.unpaired_proposals.split_off(&(view + 1, vc));
-        self.unpaired_vid_shares = self.unpaired_vid_shares.split_off(&(view + 1, vc));
         outbox.push_back(ConsensusOutput::ProposalPaired {
             proposal: proposal.proposal.clone(),
             vid_share: vid_share.clone(),
         });
-        self.handle_proposal_with_vid_share(sender, proposal, vid_share, outbox)
+        // Handle first: a parked older proposal may be this one's parent, which
+        // `request_parent_proposal_if_missing` adopts rather than fetches.
+        let result = self.handle_proposal_with_vid_share(sender, proposal, vid_share, outbox);
+        // Parked halves for this and older views can no longer pair.
+        let vc = VidCommitment2::default();
+        self.unpaired_proposals = self.unpaired_proposals.split_off(&(view + 1, vc));
+        self.unpaired_vid_shares = self.unpaired_vid_shares.split_off(&(view + 1, vc));
+        result
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -1159,7 +1146,7 @@ impl<T: NodeType> Consensus<T> {
             return Protocol::Abort;
         }
 
-        let payload_size = vid_share.payload_byte_len();
+        let payload_size = Some(vid_share.payload_byte_len());
 
         // Store the proposal before the DRB check so it is not lost when
         // the DRB is not yet available (e.g. a node catching up after a
@@ -1217,8 +1204,36 @@ impl<T: NodeType> Consensus<T> {
         Protocol::Continue
     }
 
+    /// Take in a proposal this node did not receive live together with its
+    /// VID share: one fetched from a peer, or one parked in
+    /// `unpaired_proposals` that a certificate has since vouched for.
     #[instrument(level = "debug", skip_all)]
-    fn handle_fetched_proposal(
+    fn adopt_certified_proposal(
+        &mut self,
+        message: ProposalMessage<T, Validated>,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) {
+        let view = message.proposal.data.view_number;
+        self.store_certified_proposal(message, outbox);
+        // The proposal itself may now be decidable (e.g. cert2 arrived first
+        // and triggered the fetch).
+        self.maybe_decide(view, outbox);
+        // Views extending it may be blocked on it.
+        let extending_views: Vec<ViewNumber> = self
+            .proposals
+            .range(view + 1..)
+            .filter(|(_, proposal)| proposal.justify_qc.view_number() == view)
+            .map(|(extending_view, _)| *extending_view)
+            .collect();
+        for extending_view in extending_views {
+            self.maybe_vote_1(extending_view, outbox);
+            self.maybe_vote_2_and_update_lock(extending_view, outbox);
+            self.maybe_decide(extending_view, outbox);
+        }
+        self.maybe_propose(view + 1, outbox);
+    }
+
+    fn store_certified_proposal(
         &mut self,
         message: ProposalMessage<T, Validated>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
@@ -1245,10 +1260,33 @@ impl<T: NodeType> Consensus<T> {
         self.request_block_and_header_if_next_leader(&proposal, outbox);
     }
 
+    /// Adopt the live proposal parked for `view` awaiting this node's VID
+    /// share, if it is the leaf `leaf_commit` names. Returns whether one was adopted.
+    fn adopt_unpaired_proposal(
+        &mut self,
+        view: ViewNumber,
+        leaf_commit: Commitment<Leaf2<T>>,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) -> bool {
+        let range = (view, VidCommitment2::default())..(view + 1, VidCommitment2::default());
+        let Some(message) = self
+            .unpaired_proposals
+            .range(range)
+            .map(|(_, (_, message))| message)
+            .find(|message| proposal_commitment(&message.proposal.data) == leaf_commit)
+            .cloned()
+        else {
+            return false;
+        };
+        debug!(%view, "adopting live proposal parked without a vid share");
+        self.adopt_certified_proposal(message, outbox);
+        true
+    }
+
     fn request_state(
         &self,
         proposal: &Proposal<T>,
-        payload_size: u32,
+        payload_size: Option<u32>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) {
         outbox.push_back(ConsensusOutput::RequestState(StateRequest {
@@ -1262,19 +1300,20 @@ impl<T: NodeType> Consensus<T> {
         }));
     }
 
-    /// A fetched proposal may have no share. A quorum already certified it,
-    /// size checks included, so zero only skips this node's block-size checks.
-    fn payload_size_for(&self, proposal: &Proposal<T>) -> u32 {
+    /// The payload size of an adopted proposal, if a share for it has arrived.
+    /// `None` makes state validation skip the checks that need the size; a
+    /// quorum already certified the proposal, so they have been run elsewhere.
+    fn payload_size_for(&self, proposal: &Proposal<T>) -> Option<u32> {
         let view = proposal.view_number();
         if let Some(share) = self.vid_shares.get(&view) {
-            return share.payload_byte_len();
+            return Some(share.payload_byte_len());
         }
         let VidCommitment::V2(commitment) = proposal.block_header.payload_commitment() else {
-            return 0;
+            return None;
         };
         self.unpaired_vid_shares
             .get(&(view, commitment))
-            .map_or(0, |share| share.payload_byte_len())
+            .map(|share| share.payload_byte_len())
     }
 
     fn request_block_and_header_if_next_leader(
@@ -1366,12 +1405,16 @@ impl<T: NodeType> Consensus<T> {
     }
 
     fn request_parent_proposal_if_missing(
-        &self,
+        &mut self,
         proposal: &Proposal<T>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) {
         let parent_view = proposal.justify_qc.view_number();
-        if parent_view > self.last_decided_view && !self.proposals.contains_key(&parent_view) {
+        let leaf_commit = proposal.justify_qc.data().leaf_commit;
+        if parent_view > self.last_decided_view
+            && !self.proposals.contains_key(&parent_view)
+            && !self.adopt_unpaired_proposal(parent_view, leaf_commit, outbox)
+        {
             warn!(
                 view = %proposal.view_number,
                 %parent_view,
@@ -1379,7 +1422,7 @@ impl<T: NodeType> Consensus<T> {
             );
             outbox.push_back(ConsensusOutput::RequestMissingProposal {
                 view: parent_view,
-                leaf_commit: proposal.justify_qc.data().leaf_commit,
+                leaf_commit,
             });
         }
     }
@@ -1416,14 +1459,15 @@ impl<T: NodeType> Consensus<T> {
                 certificate.cert().clone(),
             ));
         }
-        if view > self.last_decided_view && !self.proposals.contains_key(&view) {
-            warn!(%view, "have certificate2 but no proposal; requesting fetch");
-            outbox.push_back(ConsensusOutput::RequestMissingProposal {
-                view,
-                leaf_commit: certificate.data.leaf_commit,
-            });
-        }
+        let leaf_commit = certificate.data.leaf_commit;
         self.certs2.insert(view, certificate.into_cert());
+        if view > self.last_decided_view
+            && !self.proposals.contains_key(&view)
+            && !self.adopt_unpaired_proposal(view, leaf_commit, outbox)
+        {
+            warn!(%view, "have certificate2 but no proposal; requesting fetch");
+            outbox.push_back(ConsensusOutput::RequestMissingProposal { view, leaf_commit });
+        }
         Protocol::Continue
     }
 

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -1198,31 +1198,68 @@ impl<T: NodeType> Consensus<T> {
 
     /// Take in a proposal this node did not receive live together with its
     /// VID share: one fetched from a peer, or one parked in
-    /// `unpaired_proposals` that a certificate has since vouched for.
+    /// `unpaired_proposals` that a certificate has since vouched for. Its
+    /// parked ancestors come with it, oldest first, so each finds its parent
+    /// stored rather than fetching it.
     #[instrument(level = "debug", skip_all)]
     fn adopt_certified_proposal(
         &mut self,
         message: ProposalMessage<T, Validated>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) {
-        let view = message.proposal.data.view_number;
-        self.store_certified_proposal(message, outbox);
-        // The proposal itself may now be decidable (e.g. cert2 arrived first
-        // and triggered the fetch).
-        self.maybe_decide(view, outbox);
-        // Views extending it may be blocked on it.
-        let extending_views: Vec<ViewNumber> = self
-            .proposals
-            .range(view + 1..)
-            .filter(|(_, proposal)| proposal.justify_qc.view_number() == view)
-            .map(|(extending_view, _)| *extending_view)
-            .collect();
-        for extending_view in extending_views {
-            self.maybe_vote_1(extending_view, outbox);
-            self.maybe_vote_2_and_update_lock(extending_view, outbox);
-            self.maybe_decide(extending_view, outbox);
+        let chain = self.parked_ancestors(message);
+        if chain.len() > 1 {
+            debug!(ancestors = chain.len() - 1, "adopting parked ancestors");
         }
-        self.maybe_propose(view + 1, outbox);
+        for message in chain.into_iter().rev() {
+            let view = message.proposal.data.view_number;
+            self.store_certified_proposal(message, outbox);
+            // The proposal itself may now be decidable (e.g. cert2 arrived first
+            // and triggered the fetch).
+            self.maybe_decide(view, outbox);
+            // Views extending it may be blocked on it.
+            let extending_views: Vec<ViewNumber> = self
+                .proposals
+                .range(view + 1..)
+                .filter(|(_, proposal)| proposal.justify_qc.view_number() == view)
+                .map(|(extending_view, _)| *extending_view)
+                .collect();
+            for extending_view in extending_views {
+                self.maybe_vote_1(extending_view, outbox);
+                self.maybe_vote_2_and_update_lock(extending_view, outbox);
+                self.maybe_decide(extending_view, outbox);
+            }
+            self.maybe_propose(view + 1, outbox);
+        }
+    }
+
+    /// `message` followed by its parked ancestors, nearest first, up to the
+    /// first parent this node already holds or has nothing parked for.
+    ///
+    /// A loop, not recursion through `request_parent_proposal_if_missing`: the
+    /// chain is as long as the run of views parked without a share.
+    fn parked_ancestors(
+        &self,
+        message: ProposalMessage<T, Validated>,
+    ) -> Vec<ProposalMessage<T, Validated>> {
+        let mut chain = vec![message];
+        loop {
+            let proposal = &chain.last().expect("starts non-empty").proposal.data;
+            let view = proposal.view_number;
+            let parent_view = proposal.justify_qc.view_number();
+            let leaf_commit = proposal.justify_qc.data().leaf_commit;
+            if parent_view >= view
+                || parent_view <= self.last_decided_view
+                || self.proposals.contains_key(&parent_view)
+            {
+                break;
+            }
+            let Some(parent) = self.parked_proposal(parent_view, leaf_commit) else {
+                break;
+            };
+            chain.push(parent);
+        }
+        chain
     }
 
     fn store_certified_proposal(
@@ -1243,9 +1280,10 @@ impl<T: NodeType> Consensus<T> {
         }
         self.leaves.insert(view, proposal.clone().into());
         self.signed_proposals.insert(view, signed_proposal);
-        // Stored before the parent lookup, which can re-enter here by adopting a
-        // parked parent; the store is what bounds that recursion.
         self.proposals.insert(view, proposal.clone());
+        // Parked ancestors are stored ahead of this proposal
+        // (`adopt_certified_proposal`), so this only fetches a parent nothing
+        // parked can supply.
         self.request_parent_proposal_if_missing(&proposal, outbox);
         self.adopt_certified_drb(view);
 
@@ -1265,19 +1303,27 @@ impl<T: NodeType> Consensus<T> {
         leaf_commit: Commitment<Leaf2<T>>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) -> bool {
-        let range = (view, VidCommitment2::default())..(view + 1, VidCommitment2::default());
-        let Some(message) = self
-            .unpaired_proposals
-            .range(range)
-            .map(|(_, (_, message))| message)
-            .find(|message| proposal_commitment(&message.proposal.data) == leaf_commit)
-            .cloned()
-        else {
+        let Some(message) = self.parked_proposal(view, leaf_commit) else {
             return false;
         };
         debug!(%view, "adopting live proposal parked without a vid share");
         self.adopt_certified_proposal(message, outbox);
         true
+    }
+
+    /// The live proposal parked for `view` awaiting this node's VID share, if
+    /// it is the leaf `leaf_commit` names.
+    fn parked_proposal(
+        &self,
+        view: ViewNumber,
+        leaf_commit: Commitment<Leaf2<T>>,
+    ) -> Option<ProposalMessage<T, Validated>> {
+        let range = (view, VidCommitment2::default())..(view + 1, VidCommitment2::default());
+        self.unpaired_proposals
+            .range(range)
+            .map(|(_, (_, message))| message)
+            .find(|message| proposal_commitment(&message.proposal.data) == leaf_commit)
+            .cloned()
     }
 
     fn request_state(
@@ -1408,20 +1454,25 @@ impl<T: NodeType> Consensus<T> {
     ) {
         let parent_view = proposal.justify_qc.view_number();
         let leaf_commit = proposal.justify_qc.data().leaf_commit;
-        if parent_view > self.last_decided_view
-            && !self.proposals.contains_key(&parent_view)
-            && !self.adopt_unpaired_proposal(parent_view, leaf_commit, outbox)
-        {
-            warn!(
-                view = %proposal.view_number,
-                %parent_view,
-                "parent proposal missing; requesting fetch"
-            );
-            outbox.push_back(ConsensusOutput::RequestMissingProposal {
-                view: parent_view,
-                leaf_commit,
-            });
+        if parent_view <= self.last_decided_view || self.proposals.contains_key(&parent_view) {
+            return;
         }
+        // Only a parent behind the proposal is adopted; adopting for a forward
+        // QC could re-enter adoption without end.
+        if parent_view < proposal.view_number
+            && self.adopt_unpaired_proposal(parent_view, leaf_commit, outbox)
+        {
+            return;
+        }
+        warn!(
+            view = %proposal.view_number,
+            %parent_view,
+            "parent proposal missing; requesting fetch"
+        );
+        outbox.push_back(ConsensusOutput::RequestMissingProposal {
+            view: parent_view,
+            leaf_commit,
+        });
     }
 
     #[instrument(level = "debug", skip_all)]

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -40,7 +40,7 @@ pub struct StateRequest<T: NodeType> {
     pub block: BlockNumber,
     pub proposal: Proposal<T>,
     pub parent_commitment: Commitment<Leaf2<T>>,
-    pub payload_size: u32,
+    pub payload_size: Option<u32>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -734,9 +734,78 @@ async fn test_fetched_proposal_requests_state() {
     assert!(
         any(harness.outputs(), |o| matches!(
             o,
+            ConsensusOutput::RequestState(r)
+                if r.view == ViewNumber::new(1) && r.payload_size.is_none()
+        )),
+        "state validation must be requested for a fetched proposal, with the payload size unknown"
+    );
+}
+
+/// Regression: a Cert2 for a view whose proposal arrived live but whose VID
+/// share did not must adopt the parked proposal instead of refetching it.
+#[tokio::test]
+async fn test_cert2_adopts_unpaired_live_proposal() {
+    let test_data = TestData::new(2).await;
+    let mut harness = ConsensusHarness::new(0).await;
+    let tv = &test_data.views[0];
+
+    harness
+        .apply(ConsensusInput::Proposal(
+            tv.leader_public_key,
+            tv.proposal_message(),
+        ))
+        .await;
+    harness.apply(tv.cert2_input()).await;
+
+    assert!(
+        !any(harness.outputs(), |o| matches!(
+            o,
+            ConsensusOutput::RequestMissingProposal { view, .. } if *view == ViewNumber::new(1)
+        )),
+        "a parked live proposal must not be refetched"
+    );
+    assert!(
+        any(harness.outputs(), |o| matches!(
+            o,
+            ConsensusOutput::RequestState(r)
+                if r.view == ViewNumber::new(1) && r.payload_size.is_none()
+        )),
+        "the parked proposal must be state-validated without a payload size"
+    );
+}
+
+/// Regression: a live proposal whose parent arrived live without its VID
+/// share must adopt the parked parent instead of refetching it.
+#[tokio::test]
+async fn test_live_proposal_adopts_unpaired_parent() {
+    let test_data = TestData::new(2).await;
+    let mut harness = ConsensusHarness::new(0).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+    let parent = &test_data.views[0];
+
+    harness
+        .apply(ConsensusInput::Proposal(
+            parent.leader_public_key,
+            parent.proposal_message(),
+        ))
+        .await;
+    harness
+        .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
+        .await;
+
+    assert!(
+        !any(harness.outputs(), |o| matches!(
+            o,
+            ConsensusOutput::RequestMissingProposal { view, .. } if *view == ViewNumber::new(1)
+        )),
+        "a parked live parent must not be refetched"
+    );
+    assert!(
+        any(harness.outputs(), |o| matches!(
+            o,
             ConsensusOutput::RequestState(r) if r.view == ViewNumber::new(1)
         )),
-        "state validation must be requested for a fetched proposal"
+        "the parked parent must be state-validated"
     );
 }
 

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -819,6 +819,55 @@ async fn test_live_proposal_adopts_unpaired_parent() {
     );
 }
 
+/// A Cert2 for the tip of a run of parked proposals adopts the whole run,
+/// oldest first, and fetches only the parent nothing parked can supply.
+#[tokio::test]
+async fn test_cert2_adopts_chain_of_parked_proposals() {
+    let test_data = TestData::new(4).await;
+    let mut harness = ConsensusHarness::new(0).await;
+    // Views 2, 3 and 4 arrive without shares; view 1 never arrives.
+    for tv in &test_data.views[1..] {
+        harness
+            .apply(ConsensusInput::Proposal(
+                tv.leader_public_key,
+                tv.proposal_message(),
+            ))
+            .await;
+    }
+    harness.apply(test_data.views[3].cert2_input()).await;
+
+    let requested: Vec<u64> = harness
+        .outputs()
+        .iter()
+        .filter_map(|o| match o {
+            ConsensusOutput::RequestState(r) if r.payload_size.is_none() => Some(*r.view),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        requested,
+        vec![2, 3, 4],
+        "the parked run must be adopted oldest first, each without a payload size"
+    );
+    let root_parent = proposal_commitment(&test_data.views[0].proposal.data);
+    assert_eq!(
+        count_matching(harness.outputs(), |o| matches!(
+            o,
+            ConsensusOutput::RequestMissingProposal { .. }
+        )),
+        1,
+        "only the missing root parent is fetched"
+    );
+    assert!(
+        any(harness.outputs(), |o| matches!(
+            o,
+            ConsensusOutput::RequestMissingProposal { view, leaf_commit }
+                if *view == ViewNumber::new(1) && *leaf_commit == root_parent
+        )),
+        "the fetch is for the root's parent"
+    );
+}
+
 /// A parked proposal is adopted only when it is the leaf the certificate
 /// names; a Cert2 for another leaf at that view must still fetch.
 #[tokio::test]

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -15,6 +15,7 @@ use hotshot_types::{
 
 use super::common::utils::{TestData, TestView};
 use crate::{
+    cert_verifier::ValidCert,
     consensus::{ConsensusInput, ConsensusOutput},
     coordinator::GcScope,
     helpers::proposal_commitment,
@@ -755,6 +756,10 @@ async fn test_cert2_adopts_unpaired_live_proposal() {
             tv.proposal_message(),
         ))
         .await;
+    // Cert1 moves the node on, and the coordinator GCs on that view change,
+    // before the cert2 forms.
+    harness.apply(tv.cert1_input()).await;
+    harness.consensus.gc(GcScope::Local(ViewNumber::new(2)));
     harness.apply(tv.cert2_input()).await;
 
     assert!(
@@ -789,6 +794,10 @@ async fn test_live_proposal_adopts_unpaired_parent() {
             parent.proposal_message(),
         ))
         .await;
+    // The node has advanced, and the coordinator GC'd, by the time the child
+    // arrives.
+    harness.apply(parent.cert1_input()).await;
+    harness.consensus.gc(GcScope::Local(ViewNumber::new(2)));
     harness
         .apply_pair(test_data.views[1].proposal_input_consensus(&node_key))
         .await;
@@ -803,9 +812,51 @@ async fn test_live_proposal_adopts_unpaired_parent() {
     assert!(
         any(harness.outputs(), |o| matches!(
             o,
+            ConsensusOutput::RequestState(r)
+                if r.view == ViewNumber::new(1) && r.payload_size.is_none()
+        )),
+        "the parked parent must be state-validated without a payload size"
+    );
+}
+
+/// A parked proposal is adopted only when it is the leaf the certificate
+/// names; a Cert2 for another leaf at that view must still fetch.
+#[tokio::test]
+async fn test_cert2_for_other_leaf_does_not_adopt_parked_proposal() {
+    let test_data = TestData::new(2).await;
+    let mut harness = ConsensusHarness::new(0).await;
+    let tv = &test_data.views[0];
+    let other_leaf = proposal_commitment(&test_data.views[1].proposal.data);
+
+    harness
+        .apply(ConsensusInput::Proposal(
+            tv.leader_public_key,
+            tv.proposal_message(),
+        ))
+        .await;
+    let mut cert2 = tv.cert2.clone();
+    cert2.data.leaf_commit = other_leaf;
+    harness
+        .apply(ConsensusInput::Certificate2(ValidCert::new(
+            cert2,
+            tv.epoch_number,
+        )))
+        .await;
+
+    assert!(
+        any(harness.outputs(), |o| matches!(
+            o,
+            ConsensusOutput::RequestMissingProposal { view, leaf_commit }
+                if *view == ViewNumber::new(1) && *leaf_commit == other_leaf
+        )),
+        "the certified leaf must be fetched"
+    );
+    assert!(
+        !any(harness.outputs(), |o| matches!(
+            o,
             ConsensusOutput::RequestState(r) if r.view == ViewNumber::new(1)
         )),
-        "the parked parent must be state-validated"
+        "the uncertified parked proposal must not be adopted"
     );
 }
 

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -33,7 +33,7 @@ fn make_state_request(view: &TestView) -> StateRequest<TestTypes> {
         block: BlockHeader::<TestTypes>::block_number(&proposal.block_header).into(),
         proposal: proposal.clone(),
         parent_commitment: proposal.justify_qc.data().leaf_commit,
-        payload_size: 0,
+        payload_size: None,
     }
 }
 

--- a/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
+++ b/crates/hotshot/task-impls/src/quorum_vote/handlers.rs
@@ -359,7 +359,7 @@ pub(crate) async fn update_shared_state<TYPES: NodeType>(
             &instance_state,
             &parent,
             &proposed_leaf.block_header().clone(),
-            vid_share.data.payload_byte_len(),
+            Some(vid_share.data.payload_byte_len()),
             version,
             *view_number,
         )

--- a/crates/hotshot/types/src/traits/states.rs
+++ b/crates/hotshot/types/src/traits/states.rs
@@ -56,6 +56,9 @@ pub trait ValidatedState<TYPES: NodeType>:
     ///
     /// # Arguments
     /// * `instance` - Immutable instance-level state.
+    /// * `payload_byte_len` - Size of the block payload, or `None` when the caller does not
+    ///   hold it. Pass `None` only for a proposal a quorum has already certified: the
+    ///   implementation skips the checks that depend on the payload size.
     ///
     /// # Errors
     ///
@@ -65,7 +68,7 @@ pub trait ValidatedState<TYPES: NodeType>:
         instance: &Self::Instance,
         parent_leaf: &Leaf2<TYPES>,
         proposed_header: &TYPES::BlockHeader,
-        payload_byte_len: u32,
+        payload_byte_len: Option<u32>,
         version: Version,
         view_number: u64,
     ) -> impl Future<Output = Result<(Self, Self::Delta), Self::Error>> + Send;


### PR DESCRIPTION
## Problem

Seen on decaf `query_0` after deploying a build containing #4865 (`20260826`): the node never converged after a restart, rejecting valid certified proposals and failing every leader slot.

Two issues compounded:

1. **Fetched proposals were validated with payload size `0`.** `payload_size_for()` returned `0` when the node held no VID share for a fetched proposal, and `validate_namespace_table` then checked the ns-table final offset against `PayloadByteLen(0)` — `InvalidFinalOffset` for every non-empty block. The failed validation left a `from_header` stub in place of the parent, so every descendant was stuck too. (`state validation failed … InvalidFinalOffset`, ×16 on the affected node, never on any node running `20260819`.)
2. **Live proposals parked without a share were refetched.** `handle_certificate2` and `request_parent_proposal_if_missing` only consulted `self.proposals`; a proposal that arrived live but was waiting in `unpaired_proposals` for its VID share counted as missing and triggered a `RequestMissingProposal` — 271 fetches in 25 minutes for views the node had already received. The fetched copy then went through path (1).

## Fix

**Unknown payload size is `Option<u32>`, not a sentinel.**
- `ValidatedState::validate_and_apply_header` takes `payload_byte_len: Option<u32>`; `None` is documented as "only for a quorum-certified proposal; size-dependent checks are skipped".
- espresso-types: `Proposal::without_size(header)`; `validate_block_size`, `validate_fee` (fee presence still checked) and `validate_namespace_table` return `Ok(())` when the size is unknown.
- new-protocol: `payload_size_for()` returns `Option<u32>`; `StateRequest.payload_size: Option<u32>`; live proposals pass `Some(share.payload_byte_len())`.

**Parked live proposals are adopted, not refetched.**
- New `adopt_unpaired_proposal(view, leaf_commit)` finds the parked proposal whose commitment matches the certificate / justify-QC and runs it through the same path as a fetched proposal (`adopt_certified_proposal`, which now also owns the post-processing that used to live in the `FetchedProposal` dispatch arm). The entry stays parked so a late share can still pair with it — that is the only path that fills `vid_shares`.
- `handle_certificate2` and `request_parent_proposal_if_missing` try adoption before emitting `RequestMissingProposal`. Log lines for a true miss are unchanged.
- `certs2.insert` moves ahead of the adoption so `maybe_decide` inside it sees the cert, matching the fetched flow.

**Parked halves survive until the decide floor** (second commit, from review).
- Adoption only fires if the proposal is still parked when the certificate arrives. Previously the view-change GC dropped parked halves below the current view, and pairing a newer proposal dropped older ones — so by the time a Cert2 for view V formed (after the Cert1 that moved the node to V+1) the parked proposal was gone and the node fetched anyway. Both adoption paths were effectively dead in production.
- `unpaired_proposals` / `unpaired_vid_shares` now GC with `proposals` at `decide_floor()`; `on_proposal_paired` no longer evicts older parked halves. Bounded the same way `proposals` is (DECIDE_BUFFER views past the decided view, per distinct payload commitment).
- Adoption is a loop, not recursion (third commit): `adopt_certified_proposal` collects the parked ancestor chain up front (`parked_ancestors`, strictly decreasing views) and stores it oldest first, so every child finds its parent stored and `request_parent_proposal_if_missing` never re-enters adoption. Previously the depth was the length of the run of views parked without a share, on a 2 MiB tokio worker stack. A forward-pointing QC is never adopted for.

## Tests

- `tests/consensus.rs`: `test_fetched_proposal_requests_state` asserts `payload_size.is_none()`; `test_cert2_adopts_unpaired_live_proposal` and `test_live_proposal_adopts_unpaired_parent` apply Cert1 and run the view-change GC before the certificate / child, as the coordinator does (they fail without the retention change); new `test_cert2_for_other_leaf_does_not_adopt_parked_proposal` (a Cert2 naming another leaf must still fetch) and `test_cert2_adopts_chain_of_parked_proposals` (a Cert2 for the tip of a three-view parked run adopts all three oldest first and fetches only the root's missing parent).
- espresso-types `state.rs`: `test_validation_without_payload_size_skips_size_checks` uses a chain config under which `validate_block_size` and `validate_fee` reject with a size, shows the zero-size stand-in fails the ns-table check, then that `without_size` passes all three; also that a missing fee amount is still `SomeFeeAmountOutOfRange` without a size.
- `cargo test -p hotshot-new-protocol --lib`: 235 passed except `restarts::restart_all_nodes_at_epoch_boundary`, which is flaky on this branch **and on its base** with the same signature (see below). `cargo test -p espresso-types --features testing --lib -- state::test::test_validation`: 12 passed. Clippy `-D warnings` clean on all touched packages.

### Pre-existing flake: `restarts::restart_all_nodes_at_epoch_boundary`

Fails ~50% locally with `Timeout`, identically on this branch, on the branch without the review commits, and on the parent commit (`f26c0e754d0`); CI masks it via nextest `retries = 2`. Mechanism, from a debug-logged failure: the runner restarts all nodes the instant view 10 (the epoch boundary) decides, so the restarted nodes come back with `decide_floor_view = 10`. `handle_certificate2` then drops the boundary Cert2 as `view <= decide_floor()` (guard from #4617) and `seed_parent` does not seed `certs2`, so no leader can form `next_epoch_justify_qc` for view 11 and every view times out with `missing=next_epoch_justify_qc`. Whether the view-10 decide was persisted before the shutdown decides pass/fail. Unrelated to this PR; needs its own fix (seed the anchor's Cert2, or let the boundary Cert2 through the floor guard).

## Where to focus

- The safety argument for skipping `validate_fee` / `validate_block_size` / `validate_namespace_table` under `None`: the only caller passing `None` is the fetched/adopted path, and a proposal reaches it only via a Cert2 or a child's justify QC, i.e. a quorum already ran those checks.
- The GC change: parked halves now live as long as `proposals`. A share arriving late for an old parked proposal now pairs and runs the live path for that view; `wants_proposal_for_view` / `is_safe` gate it as for any late proposal.

Should be backported to `release-20260819` alongside #4867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
