### PR TITLE
fix(ci): pin foundry to v1.7.1 for contract docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,10 @@ jobs:
 
       - name: Install Foundry
         uses: ./.github/actions/install-foundry
+        with:
+          # forge doc emits a vocs site instead of mdbook sources since v1.8.0
+          # TODO: remove and migrate when nix dev shell is on 1.8
+          version: v1.7.1
 
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@mdbook


### PR DESCRIPTION
forge doc was migrated to vocs in foundry v1.8.0 and no longer emits docs/src/SUMMARY.md, breaking the mdbook build in just doc-contracts. v1.7.1 matches the version pinned in flake.nix.
