### PR TITLE
fix: remove broken panic on L1 failure

### DIFF
--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -2008,14 +2008,6 @@ pub(crate) fn compute_block_reward(
     Ok(block_reward_u256.into())
 }
 
-#[derive(Error, Debug)]
-/// Error representing fail cases for retrieving the stake table.
-#[cfg_attr(not(feature = "node"), allow(dead_code))]
-enum GetStakeTablesError {
-    #[error("Error fetching from L1: {0}")]
-    L1ClientFetchError(anyhow::Error),
-}
-
 #[cfg(any(test, feature = "testing"))]
 impl super::v0_3::StakeTable {
     /// Generate a `StakeTable` with `n` members.

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -1,11 +1,12 @@
+#[cfg(any(feature = "node", test))]
+use std::time::Duration;
 use std::{
     cmp::{max, min},
     collections::{HashMap, HashSet},
     str::FromStr,
-    time::{Duration, Instant},
 };
 #[cfg(feature = "node")]
-use std::{future::Future, sync::Arc};
+use std::{future::Future, sync::Arc, time::Instant};
 
 #[cfg(feature = "node")]
 use alloy::{
@@ -31,6 +32,7 @@ use async_lock::Mutex as AsyncMutex;
 use async_lock::RwLock as AsyncRwLock;
 use bigdecimal::BigDecimal;
 use committable::{Commitment, Committable, RawCommitmentBuilder};
+#[cfg(feature = "node")]
 use futures::future::BoxFuture;
 #[cfg(feature = "node")]
 use hotshot_contract_adapter::sol_types::{
@@ -52,6 +54,7 @@ use hotshot_types::{
     traits::signature_key::SignatureKey as _,
     x25519,
 };
+#[cfg(feature = "node")]
 use humantime::format_duration;
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -59,6 +62,7 @@ use num_traits::{FromPrimitive, Zero};
 use thiserror::Error;
 #[cfg(feature = "node")]
 use tokio::spawn;
+#[cfg(feature = "node")]
 use tokio::time::sleep;
 #[cfg(feature = "node")]
 use tracing::Instrument;
@@ -1279,6 +1283,14 @@ impl Fetcher {
                             tracing::debug!("events={events:?}");
                             break;
                         },
+                        Err(e) if is_l1_retry_budget_exhausted(&e) => {
+                            tracing::error!(
+                                "L1 retry budget exhausted fetching stake table at block \
+                                 {finalized_block:?}; deferring until the next update in \
+                                 {update_delay:?}. err={e:#}",
+                            );
+                            break;
+                        },
                         Err(e) => {
                             tracing::error!(
                                 "Error fetching stake table at block {finalized_block:?}. err= \
@@ -1480,10 +1492,10 @@ impl Fetcher {
                         Ok(init_block) => break init_block.to::<u64>(),
                         Err(err) => {
                             if start.elapsed() >= max_retry_duration {
-                                panic!(
+                                return Err(StakeTableError::L1RetryBudgetExhausted(format!(
                                     "Failed to retrieve initial block after `{}`: {err}",
                                     format_duration(max_retry_duration)
-                                );
+                                )));
                             }
                             tracing::warn!(%err, "Failed to retrieve initial block, retrying...");
                             sleep(retry_delay).await;
@@ -1538,7 +1550,7 @@ impl Fetcher {
                     })
                 },
             )
-            .await;
+            .await?;
 
             let chunk_events = logs
                 .into_iter()
@@ -1882,13 +1894,13 @@ impl Fetcher {
     }
 }
 
-#[cfg_attr(not(feature = "node"), allow(dead_code))]
+#[cfg(feature = "node")]
 async fn retry<F, T, E>(
     retry_delay: Duration,
     max_duration: Duration,
     operation_name: &str,
     mut operation: F,
-) -> T
+) -> Result<T, StakeTableError>
 where
     F: FnMut() -> BoxFuture<'static, Result<T, E>>,
     E: std::fmt::Display,
@@ -1896,10 +1908,10 @@ where
     let start = Instant::now();
     loop {
         match operation().await {
-            Ok(result) => return result,
+            Ok(result) => return Ok(result),
             Err(err) => {
                 if start.elapsed() >= max_duration {
-                    panic!(
+                    return Err(StakeTableError::L1RetryBudgetExhausted(format!(
                         r#"
                     Failed to complete operation `{operation_name}` after `{}`.
                     error: {err}
@@ -1917,13 +1929,26 @@ where
                     - Add multiple RPC providers
                     - Use a different RPC provider with higher rate limits."#,
                         format_duration(max_duration)
-                    );
+                    )));
                 }
                 tracing::warn!(%err, "Retrying `{operation_name}` after error");
                 sleep(retry_delay).await;
             },
         }
     }
+}
+
+/// Whether `err` (or a wrapped cause anywhere in its chain) is
+/// [`StakeTableError::L1RetryBudgetExhausted`]. The caller has already retried for the full
+/// budget and must not retry in place.
+#[cfg(feature = "node")]
+fn is_l1_retry_budget_exhausted(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<StakeTableError>(),
+            Some(StakeTableError::L1RetryBudgetExhausted(_))
+        )
+    })
 }
 
 /// Calculates the stake ratio `p` and reward rate `R(p)`.
@@ -2250,6 +2275,7 @@ mod tests {
         stake_table::{StakeTableContractVersion, sign_address_bls},
     };
     use hotshot_types::{light_client::StateKeyPair, signature_key::BLSKeyPair};
+    use http::StatusCode;
     use pretty_assertions::assert_matches;
     use rstest::rstest;
     use versions::{
@@ -3425,6 +3451,80 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    /// A JSON-RPC error body that every request receives, simulating a provider that never
+    /// recovers.
+    const DEAD_PROVIDER_BODY: &str =
+        r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"boom"}}"#;
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_retry_returns_error_when_budget_exhausted() {
+        let dead_provider = test_server::serve_fixed(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "application/json",
+            DEAD_PROVIDER_BODY,
+        )
+        .await;
+
+        let l1 = L1ClientOptions {
+            l1_events_max_retry_duration: Duration::ZERO,
+            l1_retry_delay: Duration::from_millis(1),
+            ..Default::default()
+        }
+        .connect(vec![dead_provider])
+        .expect("unable to construct l1 client");
+
+        // `from_block` is provided so the contract's `initializedAtBlock` call is skipped and
+        // the error comes from `retry`'s `eth_getLogs` loop instead.
+        let err = Fetcher::fetch_events_from_contract(l1, Address::ZERO, Some(0), 1)
+            .await
+            .expect_err("provider never recovers");
+
+        assert_matches!(err, StakeTableError::L1RetryBudgetExhausted(_));
+        let message = err.to_string();
+        assert!(message.contains("boom"), "{message}");
+        assert!(
+            message.contains("ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE"),
+            "{message}"
+        );
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_initialized_at_block_returns_error_when_budget_exhausted() {
+        let dead_provider = test_server::serve_fixed(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "application/json",
+            DEAD_PROVIDER_BODY,
+        )
+        .await;
+
+        let l1 = L1ClientOptions {
+            l1_events_max_retry_duration: Duration::ZERO,
+            l1_retry_delay: Duration::from_millis(1),
+            ..Default::default()
+        }
+        .connect(vec![dead_provider])
+        .expect("unable to construct l1 client");
+
+        let err = Fetcher::fetch_events_from_contract(l1, Address::ZERO, None, 1)
+            .await
+            .expect_err("provider never recovers");
+
+        assert_matches!(err, StakeTableError::L1RetryBudgetExhausted(_));
+    }
+
+    #[test]
+    fn test_is_l1_retry_budget_exhausted() {
+        let bare: anyhow::Error =
+            StakeTableError::L1RetryBudgetExhausted("budget gone".to_string()).into();
+        assert!(is_l1_retry_budget_exhausted(&bare));
+
+        let wrapped = bare.context("while fetching stake table events");
+        assert!(is_l1_retry_budget_exhausted(&wrapped));
+
+        let unrelated = anyhow::anyhow!("connection reset");
+        assert!(!is_l1_retry_budget_exhausted(&unrelated));
     }
 
     /// Pins the block reward each hardcoded initial supply produces.

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -3425,14 +3425,13 @@ mod tests {
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    #[should_panic]
-    async fn test_large_max_events_range_panic() {
+    async fn test_large_max_events_range_exhausts_budget() {
         // decaf stake table contract address
         let contract_address = "0x40304fbe94d5e7d1492dd90c53a2d63e8506a037";
 
         let l1 = L1ClientOptions {
             l1_events_max_retry_duration: Duration::from_secs(30),
-            // max block range for public node rpc is 50000 so this should result in a panic
+            // max block range for public node rpc is 50000, so every chunk is rejected
             l1_events_max_block_range: 10_u64.pow(9),
             l1_retry_delay: Duration::from_secs(1),
             ..Default::default()
@@ -3443,14 +3442,16 @@ mod tests {
         .expect("unable to construct l1 client");
 
         let latest_block = l1.provider.get_block_number().await.unwrap();
-        let _events = Fetcher::fetch_events_from_contract(
+        let err = Fetcher::fetch_events_from_contract(
             l1,
             contract_address.parse().unwrap(),
             None,
             latest_block,
         )
         .await
-        .unwrap();
+        .expect_err("the configured block range exceeds the provider limit");
+
+        assert_matches!(err, StakeTableError::L1RetryBudgetExhausted(_));
     }
 
     /// A JSON-RPC error body that every request receives, simulating a provider that never

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "node", test))]
+#[cfg(feature = "node")]
 use std::time::Duration;
 use std::{
     cmp::{max, min},
@@ -1492,10 +1492,11 @@ impl Fetcher {
                         Ok(init_block) => break init_block.to::<u64>(),
                         Err(err) => {
                             if start.elapsed() >= max_retry_duration {
-                                return Err(StakeTableError::L1RetryBudgetExhausted(format!(
-                                    "Failed to retrieve initial block after `{}`: {err}",
-                                    format_duration(max_retry_duration)
-                                )));
+                                return Err(StakeTableError::L1RetryBudgetExhausted {
+                                    operation: "initializedAtBlock".to_string(),
+                                    budget: format_duration(max_retry_duration).to_string(),
+                                    cause: err.to_string(),
+                                });
                             }
                             tracing::warn!(%err, "Failed to retrieve initial block, retrying...");
                             sleep(retry_delay).await;
@@ -1832,11 +1833,10 @@ impl Fetcher {
         let events = match self
             .fetch_and_store_stake_table_events(address, l1_finalized_block_info.number())
             .await
-            .map_err(GetStakeTablesError::L1ClientFetchError)
         {
             Ok(events) => events,
             Err(e) => {
-                bail!("failed to fetch stake table events {e:?}");
+                return Err(e.context("failed to fetch stake table events"));
             },
         };
 
@@ -1911,25 +1911,11 @@ where
             Ok(result) => return Ok(result),
             Err(err) => {
                 if start.elapsed() >= max_duration {
-                    return Err(StakeTableError::L1RetryBudgetExhausted(format!(
-                        r#"
-                    Failed to complete operation `{operation_name}` after `{}`.
-                    error: {err}
-
-
-                    This might be caused by:
-                    - The current block range being too large for your RPC provider.
-                    - The event query returning more data than your RPC allows as
-                      some RPC providers limit the number of events returned.
-                    - RPC provider outage
-
-                    Suggested solution:
-                    - Reduce the value of the environment variable
-                      `ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE` to query smaller ranges.
-                    - Add multiple RPC providers
-                    - Use a different RPC provider with higher rate limits."#,
-                        format_duration(max_duration)
-                    )));
+                    return Err(StakeTableError::L1RetryBudgetExhausted {
+                        operation: operation_name.to_string(),
+                        budget: format_duration(max_duration).to_string(),
+                        cause: err.to_string(),
+                    });
                 }
                 tracing::warn!(%err, "Retrying `{operation_name}` after error");
                 sleep(retry_delay).await;
@@ -1946,7 +1932,7 @@ fn is_l1_retry_budget_exhausted(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         matches!(
             cause.downcast_ref::<StakeTableError>(),
-            Some(StakeTableError::L1RetryBudgetExhausted(_))
+            Some(StakeTableError::L1RetryBudgetExhausted { .. })
         )
     })
 }
@@ -2275,9 +2261,9 @@ mod tests {
         stake_table::{StakeTableContractVersion, sign_address_bls},
     };
     use hotshot_types::{light_client::StateKeyPair, signature_key::BLSKeyPair};
-    use http::StatusCode;
     use pretty_assertions::assert_matches;
     use rstest::rstest;
+    use test_server::StatusCode;
     use versions::{
         DRB_AND_HEADER_UPGRADE_VERSION, EPOCH_REWARD_VERSION, EPOCH_VERSION, NEW_PROTOCOL_VERSION,
     };
@@ -3424,36 +3410,6 @@ mod tests {
         .await;
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    async fn test_large_max_events_range_exhausts_budget() {
-        // decaf stake table contract address
-        let contract_address = "0x40304fbe94d5e7d1492dd90c53a2d63e8506a037";
-
-        let l1 = L1ClientOptions {
-            l1_events_max_retry_duration: Duration::from_secs(30),
-            // max block range for public node rpc is 50000, so every chunk is rejected
-            l1_events_max_block_range: 10_u64.pow(9),
-            l1_retry_delay: Duration::from_secs(1),
-            ..Default::default()
-        }
-        .connect(vec![
-            "https://ethereum-sepolia.publicnode.com".parse().unwrap(),
-        ])
-        .expect("unable to construct l1 client");
-
-        let latest_block = l1.provider.get_block_number().await.unwrap();
-        let err = Fetcher::fetch_events_from_contract(
-            l1,
-            contract_address.parse().unwrap(),
-            None,
-            latest_block,
-        )
-        .await
-        .expect_err("the configured block range exceeds the provider limit");
-
-        assert_matches!(err, StakeTableError::L1RetryBudgetExhausted(_));
-    }
-
     /// A JSON-RPC error body that every request receives, simulating a provider that never
     /// recovers.
     const DEAD_PROVIDER_BODY: &str =
@@ -3482,13 +3438,40 @@ mod tests {
             .await
             .expect_err("provider never recovers");
 
-        assert_matches!(err, StakeTableError::L1RetryBudgetExhausted(_));
+        assert_matches!(err, StakeTableError::L1RetryBudgetExhausted { .. });
         let message = err.to_string();
         assert!(message.contains("boom"), "{message}");
         assert!(
             message.contains("ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE"),
             "{message}"
         );
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_retry_exhausts_budget_after_retrying() {
+        let dead_provider = test_server::serve_fixed(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "application/json",
+            DEAD_PROVIDER_BODY,
+        )
+        .await;
+
+        let l1 = L1ClientOptions {
+            l1_events_max_retry_duration: Duration::from_millis(50),
+            l1_retry_delay: Duration::from_millis(5),
+            ..Default::default()
+        }
+        .connect(vec![dead_provider])
+        .expect("unable to construct l1 client");
+
+        // `from_block` is provided so the contract's `initializedAtBlock` call is skipped and
+        // the error comes from `retry`'s `eth_getLogs` loop, which must run for at least one
+        // `l1_retry_delay` before the nonzero budget elapses.
+        let err = Fetcher::fetch_events_from_contract(l1, Address::ZERO, Some(0), 1)
+            .await
+            .expect_err("provider never recovers");
+
+        assert_matches!(err, StakeTableError::L1RetryBudgetExhausted { .. });
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
@@ -3512,13 +3495,17 @@ mod tests {
             .await
             .expect_err("provider never recovers");
 
-        assert_matches!(err, StakeTableError::L1RetryBudgetExhausted(_));
+        assert_matches!(err, StakeTableError::L1RetryBudgetExhausted { .. });
     }
 
     #[test]
     fn test_is_l1_retry_budget_exhausted() {
-        let bare: anyhow::Error =
-            StakeTableError::L1RetryBudgetExhausted("budget gone".to_string()).into();
+        let bare: anyhow::Error = StakeTableError::L1RetryBudgetExhausted {
+            operation: "test operation".to_string(),
+            budget: "1s".to_string(),
+            cause: "budget gone".to_string(),
+        }
+        .into();
         assert!(is_l1_retry_budget_exhausted(&bare));
 
         let wrapped = bare.context("while fetching stake table events");

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -59,6 +59,7 @@ use humantime::format_duration;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use num_traits::{FromPrimitive, Zero};
+use thiserror::Error;
 #[cfg(feature = "node")]
 use tokio::spawn;
 #[cfg(feature = "node")]
@@ -1282,7 +1283,7 @@ impl Fetcher {
                             tracing::debug!("events={events:?}");
                             break;
                         },
-                        Err(e) if is_l1_retry_budget_exhausted(&e) => {
+                        Err(e @ FetchEventsError::BudgetExhausted(_)) => {
                             tracing::error!(
                                 "L1 retry budget exhausted fetching stake table at block \
                                  {finalized_block:?}; deferring until the next update in \
@@ -1318,7 +1319,7 @@ impl Fetcher {
         &self,
         contract: Address,
         to_block: u64,
-    ) -> anyhow::Result<Vec<(EventKey, StakeTableEvent)>> {
+    ) -> Result<Vec<(EventKey, StakeTableEvent)>, FetchEventsError> {
         let (read_l1_offset, persistence_events) = {
             let persistence_lock = self.persistence.lock().await;
             persistence_lock.load_events(0, to_block).await?
@@ -1341,10 +1342,12 @@ impl Fetcher {
             })
             .transpose()?;
 
-        ensure!(
-            Some(to_block) >= from_block,
-            "to_block {to_block:?} is less than from_block {from_block:?}"
-        );
+        if from_block.is_some_and(|from_block| from_block > to_block) {
+            return Err(anyhow::anyhow!(
+                "to_block {to_block:?} is less than from_block {from_block:?}"
+            )
+            .into());
+        }
 
         tracing::info!(%to_block, from_block = ?from_block, "Fetching events from contract");
 
@@ -1354,7 +1357,8 @@ impl Fetcher {
             from_block,
             to_block,
         )
-        .await?;
+        .await
+        .map_err(FetchEventsError::from)?;
 
         // Store only the new events fetched from L1 contract
         tracing::info!(
@@ -1829,15 +1833,10 @@ impl Fetcher {
             );
         };
 
-        let events = match self
+        let events = self
             .fetch_and_store_stake_table_events(address, l1_finalized_block_info.number())
             .await
-        {
-            Ok(events) => events,
-            Err(e) => {
-                return Err(e.context("failed to fetch stake table events"));
-            },
-        };
+            .context("failed to fetch stake table events")?;
 
         // Selection runs at the epoch root header's protocol version: that header's
         // `next_stake_table_hash` was computed under the active-set rules in effect at the root,
@@ -1923,17 +1922,28 @@ where
     }
 }
 
-/// Whether `err` (or a wrapped cause anywhere in its chain) is
-/// [`StakeTableError::L1RetryBudgetExhausted`]. The caller has already retried for the full
-/// budget and must not retry in place.
+/// Why [`Fetcher::fetch_and_store_stake_table_events`] failed, split by what the caller should do
+/// next.
 #[cfg(feature = "node")]
-fn is_l1_retry_budget_exhausted(err: &anyhow::Error) -> bool {
-    err.chain().any(|cause| {
-        matches!(
-            cause.downcast_ref::<StakeTableError>(),
-            Some(StakeTableError::L1RetryBudgetExhausted { .. })
-        )
-    })
+#[derive(Debug, Error)]
+pub enum FetchEventsError {
+    /// The L1 retry budget ran out. The fetch already retried for
+    /// `ESPRESSO_L1_EVENTS_MAX_RETRY_DURATION`, so retrying in place only spins.
+    #[error(transparent)]
+    BudgetExhausted(StakeTableError),
+    /// Storage, locking, or a block range a later attempt will serve.
+    #[error(transparent)]
+    Retriable(#[from] anyhow::Error),
+}
+
+#[cfg(feature = "node")]
+impl From<StakeTableError> for FetchEventsError {
+    fn from(err: StakeTableError) -> Self {
+        match err {
+            err @ StakeTableError::L1RetryBudgetExhausted { .. } => Self::BudgetExhausted(err),
+            err => Self::Retriable(err.into()),
+        }
+    }
 }
 
 /// Calculates the stake ratio `p` and reward rate `R(p)`.
@@ -3487,23 +3497,6 @@ mod tests {
             .expect_err("provider never recovers");
 
         assert_matches!(err, StakeTableError::L1RetryBudgetExhausted { .. });
-    }
-
-    #[test]
-    fn test_is_l1_retry_budget_exhausted() {
-        let bare: anyhow::Error = StakeTableError::L1RetryBudgetExhausted {
-            operation: "test operation".to_string(),
-            budget: "1s".to_string(),
-            cause: "budget gone".to_string(),
-        }
-        .into();
-        assert!(is_l1_retry_budget_exhausted(&bare));
-
-        let wrapped = bare.context("while fetching stake table events");
-        assert!(is_l1_retry_budget_exhausted(&wrapped));
-
-        let unrelated = anyhow::anyhow!("connection reset");
-        assert!(!is_l1_retry_budget_exhausted(&unrelated));
     }
 
     /// Pins the block reward each hardcoded initial supply produces.

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -59,7 +59,6 @@ use humantime::format_duration;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use num_traits::{FromPrimitive, Zero};
-use thiserror::Error;
 #[cfg(feature = "node")]
 use tokio::spawn;
 #[cfg(feature = "node")]

--- a/crates/espresso/types/src/v0/v0_1/l1.rs
+++ b/crates/espresso/types/src/v0/v0_1/l1.rs
@@ -178,11 +178,11 @@ pub struct L1ClientOptions {
     )]
     pub stake_table_update_interval: Duration,
 
-    /// Maximum duration to retry fetching L1 events before panicking.
+    /// Maximum duration to retry fetching L1 events before giving up.
     ///
-    /// This prevents infinite retries by panicking if the total number of retries exceed the maximum duration.
+    /// This prevents infinite retries by returning `StakeTableError::L1RetryBudgetExhausted` if the total number of retries exceed the maximum duration.
     /// This is helpful in cases where the RPC block range limit or the event return limit is hit,
-    /// or if there is an outage. In such cases, panicking ensures that the node operator can take
+    /// or if there is an outage. In such cases, the error ensures that the node operator can take
     /// action instead of the node getting stuck indefinitely. This is necessary because the stake table is constructed
     /// from the fetched events, and is required for node to participate in consensus.
     #[clap(

--- a/crates/espresso/types/src/v0/v0_1/l1.rs
+++ b/crates/espresso/types/src/v0/v0_1/l1.rs
@@ -186,6 +186,17 @@ pub struct L1ClientOptions {
     /// cases, the error ensures that the node operator can take action instead of the node getting
     /// stuck indefinitely. This is necessary because the stake table is constructed from the
     /// fetched events, and is required for node to participate in consensus.
+    ///
+    /// A budget exhaustion is usually caused by one of:
+    /// - The current block range being too large for the RPC provider.
+    /// - The event query returning more data than the RPC allows, since some providers limit the
+    ///   number of events returned.
+    /// - An RPC provider outage.
+    ///
+    /// To recover:
+    /// - Reduce `ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE` to query smaller ranges.
+    /// - Add multiple RPC providers.
+    /// - Switch to a provider with higher rate limits.
     #[clap(
         long,
         env = "ESPRESSO_L1_EVENTS_MAX_RETRY_DURATION",

--- a/crates/espresso/types/src/v0/v0_1/l1.rs
+++ b/crates/espresso/types/src/v0/v0_1/l1.rs
@@ -180,11 +180,12 @@ pub struct L1ClientOptions {
 
     /// Maximum duration to retry fetching L1 events before giving up.
     ///
-    /// This prevents infinite retries by returning `StakeTableError::L1RetryBudgetExhausted` if the total number of retries exceed the maximum duration.
-    /// This is helpful in cases where the RPC block range limit or the event return limit is hit,
-    /// or if there is an outage. In such cases, the error ensures that the node operator can take
-    /// action instead of the node getting stuck indefinitely. This is necessary because the stake table is constructed
-    /// from the fetched events, and is required for node to participate in consensus.
+    /// This prevents infinite retries: once the retries exceed the maximum duration the fetch
+    /// fails with `StakeTableError::L1RetryBudgetExhausted`. This is helpful in cases where the
+    /// RPC block range limit or the event return limit is hit, or if there is an outage. In such
+    /// cases, the error ensures that the node operator can take action instead of the node getting
+    /// stuck indefinitely. This is necessary because the stake table is constructed from the
+    /// fetched events, and is required for node to participate in consensus.
     #[clap(
         long,
         env = "ESPRESSO_L1_EVENTS_MAX_RETRY_DURATION",

--- a/crates/espresso/types/src/v0/v0_3/stake_table.rs
+++ b/crates/espresso/types/src/v0/v0_3/stake_table.rs
@@ -492,8 +492,16 @@ pub enum StakeTableError {
     EventSortingError(#[from] EventSortingError),
     /// An L1 operation kept failing until its retry budget ran out. Terminal: the caller has
     /// already retried for `ESPRESSO_L1_EVENTS_MAX_RETRY_DURATION` and must not retry in place.
-    #[error("{0}")]
-    L1RetryBudgetExhausted(String),
+    #[error(
+        "L1 operation `{operation}` kept failing for {budget}: {cause}. Check that \
+         ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE is within the provider's `eth_getLogs` limit, and \
+         configure more than one L1 provider"
+    )]
+    L1RetryBudgetExhausted {
+        operation: String,
+        budget: String,
+        cause: String,
+    },
 }
 
 #[derive(Debug, Error)]

--- a/crates/espresso/types/src/v0/v0_3/stake_table.rs
+++ b/crates/espresso/types/src/v0/v0_3/stake_table.rs
@@ -490,6 +490,10 @@ pub enum StakeTableError {
     StakeTableEventDecodeError(#[from] alloy::sol_types::Error),
     #[error("Stake table events sorting error: {0}")]
     EventSortingError(#[from] EventSortingError),
+    /// An L1 operation kept failing until its retry budget ran out. Terminal: the caller has
+    /// already retried for `ESPRESSO_L1_EVENTS_MAX_RETRY_DURATION` and must not retry in place.
+    #[error("{0}")]
+    L1RetryBudgetExhausted(String),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
On 2026-08-09 the hourly stake-table `update_loop` panicked on 11 mainnet validators after 20 minutes of `eth_getLogs`
failures. A panic inside `tokio::spawn` unwinds only the spawned task, so the process kept running with a dead updater
and a frozen `stake_table_events_l1_block` watermark, and nothing respawns it. 12 h 35 m later the epoch-518 boundary
needed the backfill that had not been happening, `add_epoch_root` panicked in turn, and 11 nodes wedged until manual
restart. 968 views missed on 2026-08-10 (5.88 %).

### This PR:

* Converts both L1 retry-budget panics to `StakeTableError::L1RetryBudgetExhausted`: the `eth_getLogs` chunk loop in
  `retry`, and the `initializedAtBlock` lookup, which sits outside `retry` and so was missed by the error path.
* Makes `update_loop` survive one. Budget exhaustion breaks to the next hourly tick; every other error keeps the
  existing 1 s retry. Without the split, converting the panic turns a persistent failure into a 1 Hz error loop; with
  the split keyed on any error, a transient store failure would freeze the watermark for an hour where today it clears
  in one second.
* Makes the variant structured (`operation`, `budget`, `cause`) with a single-line `Display`. It previously carried a
  14-line string built for `panic!`'s payload, which a log pipeline splits into 14 records, 13 of them without context.
  The diagnosis and remediation list moved to the `l1_events_max_retry_duration` doc comment, where `--help` shows it.
* Propagates from `Fetcher::fetch` with `.context(..)` instead of flattening through `GetStakeTablesError`'s `{:?}`,
  which destroyed the typed error for callers upstream. That leaves `GetStakeTablesError` unused, so it is deleted.
* Deletes `test_large_max_events_range_exhausts_budget`, which hit `ethereum-sepolia.publicnode.com` for 30 s under the
  default nextest profile (two retries) and duplicates `test_retry_returns_error_when_budget_exhausted`, which asserts
  the same variant offline in milliseconds.

### This PR does not:

* Exit the process when L1 stays broken past the budget. That needs the budget revisited first: 20 m is far shorter
  than the ~12.6 h of slack a mainnet node has between deriving an epoch's stake table and needing it to vote, so
  exiting on it today would turn a rideable provider outage into a crash loop. Follow-up PR.
* Add metrics. `stake_table_events_l1_block`, a last-success timestamp, and an update-loop-running gauge are what make
  the failure visible at minute 1 instead of hour 12.6, and they are their own PR.
* Change the `next_stake_table_hash` mismatch panic at `committee.rs:996`. Different failure class.
* Escape the 1 s retry for two other deterministic errors that reach it: the `ensure!(Some(to_block) >= from_block)`
  guard, which fires after a failover to a lagging provider until it catches up, and
  `StakeTableError::InvalidCommission`, which is permanent for a given log.

### Key places to review:

* `impls/stake_table.rs`, the `Err(e) if is_l1_retry_budget_exhausted(&e)` arm in `update_loop`. The deferral is keyed
  on the variant, not on any error, for the reason above.
* `impls/stake_table.rs`, `Fetcher::fetch`. `.context(..)` rather than `bail!("{e:?}")` keeps the typed error in the
  chain so `is_l1_retry_budget_exhausted` still answers correctly upstream.
* `add_epoch_root` now returns an error where it used to abort its task, so callers that previously lost the task
  silently see the failure. `crates/hotshot/hotshot/src/lib.rs:1378-1390` still discards the startup `add_epoch_root`
  error; pre-existing, and it carries its own `REVIEW NOTE`.

### Things tested

New tests, all offline against `crates/test-server`:

| Test | Covers |
| ---- | ------ |
| `test_retry_returns_error_when_budget_exhausted` | `retry` returns the variant; the message names the cause and `ESPRESSO_L1_EVENTS_MAX_BLOCK_RANGE` |
| `test_retry_exhausts_budget_after_retrying` | The retry loop itself, 50 ms budget over a 5 ms delay |
| `test_initialized_at_block_returns_error_when_budget_exhausted` | The panic that sat outside `retry` |
| `test_is_l1_retry_budget_exhausted` | Bare, `.context()`-wrapped, and unrelated errors |

Run locally beyond CI:

```
cargo nextest run -p espresso-types --features testing -E 'test(reference)'
```

32 passed. `StakeTableError` gained a variant in `v0_3/stake_table.rs`, so the reference vectors were re-checked.

`cargo clippy` needs `--no-deps` until the pre-existing `clippy::never_loop` at
`crates/hotshot/new-protocol/src/network.rs:140` is fixed.