### PR TITLE
fix(ci): find the main compile-metrics baseline

### DIFF
--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -40,6 +40,7 @@ Examples:
 import argparse
 import json
 import logging
+import math
 import re
 import shutil
 import subprocess
@@ -88,14 +89,18 @@ CRATE_BYTES_MIN = 256 * 1024
 INSTANTIATIONS_MIN = 50
 TOP_CRATES = 25
 TOP_BASES = 25
-TOP_MOVERS = 10
+# Metric families, in reading order. Compile cost first, then what the binary weighs. The
+# per-family caps bound the whole comment: a Cargo.lock bump moves hundreds of rows at once, and
+# a comment that long is unreadable and runs into GitHub's 65 kB limit on a comment body.
+FAMILIES = ("cpu-s", "bytes", "text_bytes", "symbols", "instantiations")
+FAMILY_ROWS = 6
+FAMILY_IMPROVEMENTS = 3
+RED = " 🔴"
+GREEN = " 🟢"
 TOP_BINARIES = 10
 TOP_UNITS = 20
 TOP_FEATURE_ROWS = 25
 MOVER_MIN_PCT = 0.5
-# A Cargo.lock bump moves hundreds of rows at once, and a comment that long is unreadable and
-# runs into GitHub's 65 kB limit on a comment body.
-MOVER_ROWS = 40
 # How far back `local` looks for a run that still has its artifacts. A push starts a run that has
 # none yet, and rerunning a workflow adds another, so the newest is regularly not the reportable
 # one.
@@ -132,11 +137,18 @@ class Change:
 
     @property
     def delta_pct(self) -> float:
-        return (self.current - self.main) / self.main * 100 if self.main else 0.0
+        """Unbounded when the baseline is zero, so a newly built unit ranks as the cost it is."""
+        if not self.main:
+            return math.inf if self.current else 0.0
+        return (self.current - self.main) / self.main * 100
 
     @property
     def regressed(self) -> bool:
         return self.delta_pct > self.threshold_pct
+
+    @property
+    def improved(self) -> bool:
+        return self.delta_pct < -self.threshold_pct
 
 
 @dataclass(frozen=True)
@@ -758,9 +770,14 @@ def compare(main: dict[str, Any], current: dict[str, Any]) -> list[Change]:
                 changes.append(
                     Change(job, job, label, before[key], now[key], threshold)
                 )
-        for unit, cpu in now.get("units", {}).items():
-            was = before.get("units", {}).get(unit)
-            if was is not None and was >= UNIT_MIN_S:
+        # The union, not this run's keys: a unit that stopped being built is exactly what a
+        # compile-time change sets out to produce, and it has no entry here to iterate.
+        was_units = before.get("units", {})
+        now_units = now.get("units", {})
+        for unit in sorted(set(was_units) | set(now_units)):
+            was = was_units.get(unit, 0.0)
+            cpu = now_units.get(unit, 0.0)
+            if max(was, cpu) >= UNIT_MIN_S:
                 changes.append(Change(job, unit, "cpu-s", was, cpu, UNIT_CPU_PCT))
         for binary, sizes in now.get("binaries", {}).items():
             was_sizes = before.get("binaries", {}).get(binary)
@@ -833,34 +850,99 @@ def fmt_name(name: str) -> str:
     return "`" + name.replace("|", "\\|") + "`"
 
 
-def mover_table(rows: list[Change]) -> list[str]:
+def mark(change: Change) -> str:
+    if change.regressed:
+        return RED
+    if change.improved:
+        return GREEN
+    return ""
+
+
+def fmt_delta(change: Change) -> str:
+    """`new` rather than `+inf%`, for a unit the baseline never built."""
+    return "new" if not change.main else f"{change.delta_pct:+.1f}%"
+
+
+@dataclass(frozen=True)
+class Merged:
+    """Rows that moved identically, reported once.
+
+    Four vtable slots of one `dyn Error` impl are four rows carrying the same number, and a
+    single change to what a binary links moves every one of them together.
+    """
+
+    change: Change
+    count: int
+
+    @property
+    def label(self) -> str:
+        rest = f" +{self.count - 1} more" if self.count > 1 else ""
+        return fmt_name(self.change.name) + rest
+
+
+def collapse(changes: list[Change]) -> list[Merged]:
+    groups: dict[tuple[str, str, float, float], list[Change]] = {}
+    for change in changes:
+        key = (change.scope, change.metric, change.main, change.current)
+        groups.setdefault(key, []).append(change)
+    return [Merged(rows[0], len(rows)) for rows in groups.values()]
+
+
+def mover_table(rows: list[Merged]) -> list[str]:
     if not rows:
         return []
     lines = [
-        "| job | unit or binary | metric | main | this run | change |",
-        "|---|---|---|---:|---:|---:|",
+        "| job | unit or binary | main | this run | change |",
+        "|---|---|---:|---:|---:|",
     ]
-    for change in rows:
-        mark = " :warning:" if change.regressed else ""
+    for row in rows:
+        change = row.change
         lines.append(
-            f"| {change.scope} | {fmt_name(change.name)} | {change.metric} "
+            f"| {change.scope} | {row.label} "
             f"| {fmt_metric(change.metric, change.main)} "
-            f"| {fmt_metric(change.metric, change.current)} | {change.delta_pct:+.1f}%{mark} |"
+            f"| {fmt_metric(change.metric, change.current)} "
+            f"| {fmt_delta(change)}{mark(change)} |"
         )
     return lines
 
 
-def top_movers(changes: list[Change]) -> tuple[list[Change], int]:
-    """Every regression, then the largest remaining moves, capped; and how many were dropped."""
-    regressed = [c for c in changes if c.regressed]
-    rest = sorted(
-        (c for c in changes if not c.regressed), key=lambda c: -abs(c.delta_pct)
-    )
-    rows = sorted(
-        regressed + rest[: max(0, TOP_MOVERS - len(regressed))],
-        key=lambda c: -c.delta_pct,
-    )
-    return rows[:MOVER_ROWS], max(0, len(rows) - MOVER_ROWS)
+def family_tables(changes: list[Change]) -> list[str]:
+    """One table per metric, because a percentage does not compare seconds against bytes.
+
+    Ranking the four families together put a 79 -> 83 instantiation count above a crate that
+    gained a minute of compile time. Improvements ride along in each table: a change that removes
+    work has nowhere else to show up.
+    """
+    families: dict[str, list[Change]] = {}
+    for change in changes:
+        families.setdefault(change.metric, []).append(change)
+    lines = []
+    for metric in sorted(families, key=family_order):
+        regressions = collapse(
+            sorted(
+                (c for c in families[metric] if c.regressed), key=lambda c: -c.delta_pct
+            )
+        )
+        improvements = collapse(
+            sorted(
+                (c for c in families[metric] if c.improved), key=lambda c: c.delta_pct
+            )
+        )
+        shown = regressions[:FAMILY_ROWS] + improvements[:FAMILY_IMPROVEMENTS]
+        if not shown:
+            continue
+        dropped = (len(regressions) - len(regressions[:FAMILY_ROWS])) + (
+            len(improvements) - len(improvements[:FAMILY_IMPROVEMENTS])
+        )
+        summary = f"**{metric}**: {len(regressions)} over threshold, {len(improvements)} improved."
+        if dropped:
+            summary += f" {dropped} rows not shown."
+        lines += ["", summary, ""] + mover_table(shown)
+    return lines
+
+
+def family_order(metric: str) -> tuple[int, str]:
+    return (FAMILIES.index(metric) if metric in FAMILIES else len(FAMILIES), metric)
 
 
 def fmt_bytes(count: float) -> str:
@@ -972,10 +1054,9 @@ def state_tables(current: dict[str, Any]) -> list[str]:
 
 
 def fmt_cell(change: Change) -> str:
-    mark = " :warning:" if change.regressed else ""
     return (
         f"{fmt_metric(change.metric, change.main)} -> "
-        f"{fmt_metric(change.metric, change.current)} ({change.delta_pct:+.1f}%){mark}"
+        f"{fmt_metric(change.metric, change.current)} ({fmt_delta(change)}){mark(change)}"
     )
 
 
@@ -1005,19 +1086,17 @@ def comparison_tables(changes: list[Change]) -> list[str]:
     if any(len(metrics) < len(JOB_COLUMNS) for metrics in by_job.values()):
         lines += ["", f"{NOT_COMPARED}: missing from this run or from the baseline."]
 
-    movers, dropped = top_movers(
+    families = family_tables(
         [
             c
             for c in changes
             if c.metric not in JOB_COLUMNS and abs(c.delta_pct) >= MOVER_MIN_PCT
         ]
     )
-    lines.append("")
-    lines += mover_table(movers) or [
-        f"No unit or binary moved by more than {MOVER_MIN_PCT:g} %."
+    lines += families or [
+        "",
+        f"No unit or binary moved by more than {MOVER_MIN_PCT:g} %.",
     ]
-    if dropped:
-        lines += ["", f"{dropped} further rows over threshold, not shown."]
     return lines
 
 

--- a/scripts/nextest-ci
+++ b/scripts/nextest-ci
@@ -575,14 +575,19 @@ def cmd_stats_fetch(args: argparse.Namespace) -> int:
                 "branch=main",
                 "-F",
                 "event=push",
-                # No status filter. Every conclusion counts: a run with a hard test
-                # failure is conclusion=failure, but its stats artifact is exactly what
-                # we want. In-progress runs count too, because the job that uploads the
+                # No status filter. A run with a hard test failure is conclusion=failure,
+                # but its stats artifact is exactly what we want. In-progress runs have no
+                # conclusion at all and count too, because the job that uploads the
                 # artifact finishes long before the slowest job in the run does, and
                 # excluding them hid a freshly published baseline for hours after every
                 # merge to main. Runs with nothing uploaded yet are skipped below.
+                #
+                # Over-fetch, because a run admitted this way may still have nothing to
+                # contribute: test.yml uploads its stats artifact only once every shard is
+                # done, so an in-progress run of it occupies a slot without filling one.
+                # The list is truncated back to max_runs after the artifact lookup.
                 "-F",
-                f"per_page={args.max_runs}",
+                f"per_page={min(100, args.max_runs * 2)}",
             ]
         )
         if not isinstance(runs_data, dict):
@@ -600,7 +605,7 @@ def cmd_stats_fetch(args: argparse.Namespace) -> int:
                     workflow_runs,
                 )
             )
-        aggregated = [e for e in entries if e is not None]
+        aggregated = [e for e in entries if e is not None][: args.max_runs]
 
         args.out.write_text(
             json.dumps({"runs": aggregated}, indent=2, sort_keys=False) + "\n"

--- a/scripts/nextest-ci
+++ b/scripts/nextest-ci
@@ -384,8 +384,18 @@ def write_empty_runs(out: Path) -> None:
 def fetch_run_entry(repo: str, run: dict, artifact_name: str) -> dict | None:
     run_id = run["id"]
     try:
+        # `name` filters server-side. Without it the endpoint returns only the first page
+        # of 30, and a build run uploads more artifacts than that, so the baseline was
+        # invisible depending on where it landed in the list.
         artifacts_data = gh_json(
-            ["api", f"repos/{repo}/actions/runs/{run_id}/artifacts"]
+            [
+                "api",
+                "-X",
+                "GET",
+                f"repos/{repo}/actions/runs/{run_id}/artifacts",
+                "-f",
+                f"name={artifact_name}",
+            ]
         )
         artifacts = (
             artifacts_data.get("artifacts", [])
@@ -565,12 +575,12 @@ def cmd_stats_fetch(args: argparse.Namespace) -> int:
                 "branch=main",
                 "-F",
                 "event=push",
-                # All completed conclusions: a run with a hard test failure is
-                # conclusion=failure, but its stats artifact is exactly what we
-                # want. Runs that died before testing have no artifact and are
-                # skipped below.
-                "-F",
-                "status=completed",
+                # No status filter. Every conclusion counts: a run with a hard test
+                # failure is conclusion=failure, but its stats artifact is exactly what
+                # we want. In-progress runs count too, because the job that uploads the
+                # artifact finishes long before the slowest job in the run does, and
+                # excluding them hid a freshly published baseline for hours after every
+                # merge to main. Runs with nothing uploaded yet are skipped below.
                 "-F",
                 f"per_page={args.max_runs}",
             ]
@@ -580,7 +590,7 @@ def cmd_stats_fetch(args: argparse.Namespace) -> int:
         workflow_runs = runs_data.get("workflow_runs", [])
         # Defend against GitHub not guaranteeing newest-first ordering.
         workflow_runs.sort(key=lambda r: r.get("created_at", ""), reverse=True)
-        log.info("found %d completed main runs", len(workflow_runs))
+        log.info("found %d main runs", len(workflow_runs))
 
         with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
             # map preserves input order, so history stays newest-first.

--- a/scripts/py.just
+++ b/scripts/py.just
@@ -1,4 +1,4 @@
-scripts := "nextest-ci compile-metrics test_compile_metrics.py"
+scripts := "nextest-ci compile-metrics test_compile_metrics.py test_nextest_ci.py"
 
 fmt *args:
     ruff format {{scripts}} {{args}}

--- a/scripts/test_compile_metrics.py
+++ b/scripts/test_compile_metrics.py
@@ -6,6 +6,7 @@ Everything here is a pure function over literals, so no build, no artifact and n
 """
 
 import importlib.util
+import math
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -142,6 +143,90 @@ class CriticalPath(unittest.TestCase):
 
     def test_empty(self):
         self.assertEqual(cm.critical_path([]), [])
+
+
+def job(units=None, binaries=None):
+    return {"units": units or {}, "binaries": binaries or {}}
+
+
+def compare(main_units, current_units):
+    return cm.compare(
+        {"jobs": {"j": job(main_units)}}, {"jobs": {"j": job(current_units)}}
+    )
+
+
+class CompareUnits(unittest.TestCase):
+    """A unit that stops being built is the whole point of a compile-time change."""
+
+    def test_unit_gone_from_this_run(self):
+        (change,) = compare({"dropped lib": 40.0}, {})
+        self.assertEqual((change.main, change.current), (40.0, 0.0))
+        self.assertEqual(change.delta_pct, -100.0)
+
+    def test_unit_new_in_this_run(self):
+        (change,) = compare({}, {"added lib": 40.0})
+        self.assertEqual((change.main, change.current), (0.0, 40.0))
+        self.assertTrue(change.regressed)
+
+    def test_short_unit_stays_out_either_way(self):
+        self.assertEqual(compare({"tiny lib": 1.0}, {}), [])
+        self.assertEqual(compare({}, {"tiny lib": 1.0}), [])
+
+    def test_unit_in_both_is_compared(self):
+        (change,) = compare({"kept lib": 40.0}, {"kept lib": 60.0})
+        self.assertEqual((change.main, change.current), (40.0, 60.0))
+
+
+class DeltaPct(unittest.TestCase):
+    def test_growth_from_nothing_is_unbounded(self):
+        self.assertEqual(
+            cm.Change("j", "n", "cpu-s", 0.0, 5.0, 15.0).delta_pct, math.inf
+        )
+
+    def test_nothing_to_nothing_is_flat(self):
+        self.assertEqual(cm.Change("j", "n", "cpu-s", 0.0, 0.0, 15.0).delta_pct, 0.0)
+
+
+class Collapse(unittest.TestCase):
+    """Four vtable slots of one `dyn Error` impl always move together."""
+
+    def test_identical_deltas_merge(self):
+        rows = [
+            cm.Change("j", f"bin: base{i}", "instantiations", 50, 93, 5.0)
+            for i in range(4)
+        ]
+        (merged,) = cm.collapse(rows)
+        self.assertEqual(merged.count, 4)
+        self.assertEqual(merged.change.name, "bin: base0")
+
+    def test_different_values_stay_apart(self):
+        rows = [
+            cm.Change("j", "bin: a", "instantiations", 50, 93, 5.0),
+            cm.Change("j", "bin: b", "instantiations", 50, 94, 5.0),
+        ]
+        self.assertEqual(len(cm.collapse(rows)), 2)
+
+    def test_different_jobs_stay_apart(self):
+        rows = [
+            cm.Change("j1", "bin: a", "instantiations", 50, 93, 5.0),
+            cm.Change("j2", "bin: a", "instantiations", 50, 93, 5.0),
+        ]
+        self.assertEqual(len(cm.collapse(rows)), 2)
+
+
+class Mark(unittest.TestCase):
+    def test_regression_is_red(self):
+        self.assertEqual(
+            cm.mark(cm.Change("j", "n", "cpu-s", 10.0, 20.0, 15.0)), cm.RED
+        )
+
+    def test_improvement_is_green(self):
+        self.assertEqual(
+            cm.mark(cm.Change("j", "n", "cpu-s", 20.0, 10.0, 15.0)), cm.GREEN
+        )
+
+    def test_within_the_band_is_unmarked(self):
+        self.assertEqual(cm.mark(cm.Change("j", "n", "cpu-s", 10.0, 10.1, 15.0)), "")
 
 
 class FmtName(unittest.TestCase):

--- a/scripts/test_nextest_ci.py
+++ b/scripts/test_nextest_ci.py
@@ -40,33 +40,34 @@ def run(run_id, status, created_at):
 class StatsFetch(unittest.TestCase):
     """The baseline artifact is uploaded hours before the run it belongs to finishes."""
 
-    def fetch(self, runs, with_artifact):
+    def fetch(self, runs, with_artifact, expired=(), max_runs=5):
+        def field(args, name):
+            prefix = f"{name}="
+            return next(
+                (a.split("=", 1)[1] for a in args if a.startswith(prefix)), None
+            )
+
         def gh_json(args):
             path = next(a for a in args if a.startswith("repos/"))
             if path.endswith("/artifacts"):
                 run_id = int(path.split("/runs/")[1].split("/")[0])
-                listed = (
-                    [*EXTRA_ARTIFACTS, {"name": ARTIFACT, "expired": False}]
-                    if run_id in with_artifact
-                    else list(EXTRA_ARTIFACTS)
-                )
+                listed = list(EXTRA_ARTIFACTS)
+                if run_id in with_artifact:
+                    listed.append({"name": ARTIFACT, "expired": run_id in expired})
                 # The endpoint returns one page of 30 unless `name=` narrows it, and a
                 # build run has more artifacts than that.
-                wanted = next(
-                    (a.split("=", 1)[1] for a in args if a.startswith("name=")), None
-                )
+                wanted = field(args, "name")
                 if wanted is not None:
                     listed = [a for a in listed if a["name"] == wanted]
                 return {"artifacts": listed[:PAGE_SIZE]}
-            # The endpoint filters server-side, so a `status=` the caller sends is not
-            # something the test can ignore.
-            wanted = next(
-                (a.split("=", 1)[1] for a in args if a.startswith("status=")), None
-            )
+            # Both filters are applied server-side, so neither is something the test can
+            # ignore: `status` decides which runs exist, `per_page` how many come back.
             listed = runs["workflow_runs"]
-            if wanted:
-                listed = [r for r in listed if r["status"] == wanted]
-            return {"workflow_runs": listed}
+            status = field(args, "status")
+            if status:
+                listed = [r for r in listed if r["status"] == status]
+            per_page = field(args, "per_page")
+            return {"workflow_runs": listed[: int(per_page)] if per_page else listed}
 
         with tempfile.TemporaryDirectory() as td:
             out = Path(td) / "main.json"
@@ -74,7 +75,7 @@ class StatsFetch(unittest.TestCase):
                 workflow="build.yml",
                 artifact_name=ARTIFACT,
                 out=out,
-                max_runs=5,
+                max_runs=max_runs,
                 concurrency=2,
             )
             with (
@@ -110,6 +111,39 @@ class StatsFetch(unittest.TestCase):
             with_artifact=set(),
         )
         self.assertEqual(found, [])
+
+    def test_expired_artifact_is_skipped(self):
+        """Retention is 90 days and the window reaches past it."""
+        found = self.fetch(
+            runs_response(run(4, "completed", "2026-05-01T10:00:00Z")),
+            with_artifact={4},
+            expired={4},
+        )
+        self.assertEqual(found, [])
+
+    def test_in_progress_runs_do_not_displace_usable_ones(self):
+        """test.yml uploads its stats artifact only once every shard is done, so an
+        in-progress run of it can occupy a slot but never fill one."""
+        listed = [
+            run(100 + i, "in_progress", f"2026-08-31T1{i}:00:00Z") for i in range(5)
+        ] + [run(200 + i, "completed", f"2026-08-2{i}T10:00:00Z") for i in range(5)]
+        found = self.fetch(
+            runs_response(*listed),
+            with_artifact={200 + i for i in range(5)},
+            max_runs=5,
+        )
+        self.assertEqual(found, [{"run": 204 - i} for i in range(5)])
+
+    def test_window_is_capped_at_max_runs(self):
+        listed = [
+            run(300 + i, "completed", f"2026-08-2{i}T10:00:00Z") for i in range(6)
+        ]
+        found = self.fetch(
+            runs_response(*listed),
+            with_artifact={300 + i for i in range(6)},
+            max_runs=3,
+        )
+        self.assertEqual(len(found), 3)
 
 
 if __name__ == "__main__":

--- a/scripts/test_nextest_ci.py
+++ b/scripts/test_nextest_ci.py
@@ -1,0 +1,116 @@
+"""Tests for `nextest-ci` behaviour that only shows up against the GitHub API.
+
+`gh` is stubbed, so no network. Run with:
+
+    just py::test
+"""
+
+import argparse
+import importlib.util
+import json
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).with_name("nextest-ci")
+_spec = importlib.util.spec_from_loader(
+    "nextest_ci", SourceFileLoader("nextest_ci", str(SCRIPT))
+)
+assert _spec is not None
+nc = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(nc)
+
+ARTIFACT = "compile-metrics-build"
+PAGE_SIZE = 30
+# A build run uploads a docker digest artifact per image, so the baseline is not on page one.
+EXTRA_ARTIFACTS = [{"name": f"digests-{i}", "expired": False} for i in range(PAGE_SIZE)]
+
+
+def runs_response(*runs):
+    return {"workflow_runs": list(runs)}
+
+
+def run(run_id, status, created_at):
+    return {"id": run_id, "status": status, "created_at": created_at}
+
+
+class StatsFetch(unittest.TestCase):
+    """The baseline artifact is uploaded hours before the run it belongs to finishes."""
+
+    def fetch(self, runs, with_artifact):
+        def gh_json(args):
+            path = next(a for a in args if a.startswith("repos/"))
+            if path.endswith("/artifacts"):
+                run_id = int(path.split("/runs/")[1].split("/")[0])
+                listed = (
+                    [*EXTRA_ARTIFACTS, {"name": ARTIFACT, "expired": False}]
+                    if run_id in with_artifact
+                    else list(EXTRA_ARTIFACTS)
+                )
+                # The endpoint returns one page of 30 unless `name=` narrows it, and a
+                # build run has more artifacts than that.
+                wanted = next(
+                    (a.split("=", 1)[1] for a in args if a.startswith("name=")), None
+                )
+                if wanted is not None:
+                    listed = [a for a in listed if a["name"] == wanted]
+                return {"artifacts": listed[:PAGE_SIZE]}
+            # The endpoint filters server-side, so a `status=` the caller sends is not
+            # something the test can ignore.
+            wanted = next(
+                (a.split("=", 1)[1] for a in args if a.startswith("status=")), None
+            )
+            listed = runs["workflow_runs"]
+            if wanted:
+                listed = [r for r in listed if r["status"] == wanted]
+            return {"workflow_runs": listed}
+
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "main.json"
+            args = argparse.Namespace(
+                workflow="build.yml",
+                artifact_name=ARTIFACT,
+                out=out,
+                max_runs=5,
+                concurrency=2,
+            )
+            with (
+                mock.patch.object(nc, "resolve_repo", return_value="owner/repo"),
+                mock.patch.object(nc, "gh_json", side_effect=gh_json),
+                mock.patch.object(
+                    nc, "download_artifact", side_effect=lambda _r, i, _a: {"run": i}
+                ),
+            ):
+                self.assertEqual(nc.cmd_stats_fetch(args), 0)
+            return json.loads(out.read_text())["runs"]
+
+    def test_in_progress_run_with_the_artifact_is_used(self):
+        found = self.fetch(
+            runs_response(run(2, "in_progress", "2026-08-31T10:00:00Z")),
+            with_artifact={2},
+        )
+        self.assertEqual(found, [{"run": 2}])
+
+    def test_newest_first_regardless_of_status(self):
+        found = self.fetch(
+            runs_response(
+                run(1, "completed", "2026-08-28T10:00:00Z"),
+                run(2, "in_progress", "2026-08-31T10:00:00Z"),
+            ),
+            with_artifact={1, 2},
+        )
+        self.assertEqual(found, [{"run": 2}, {"run": 1}])
+
+    def test_run_without_the_artifact_is_skipped(self):
+        found = self.fetch(
+            runs_response(run(3, "queued", "2026-08-31T11:00:00Z")),
+            with_artifact=set(),
+        )
+        self.assertEqual(found, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two reasons a pull request reported "No main-branch baseline available yet" even after main had published one.

`stats-fetch` asked the runs endpoint for `status=completed`. The job that uploads the baseline finishes long before the slowest job in a main run does, so a freshly published baseline stayed invisible for hours after every merge. Runs with nothing uploaded yet were already skipped by the artifact lookup, so the status filter bought nothing.

`fetch_run_entry` then listed a run's artifacts unpaginated and scanned the result. A build run uploads 64 artifacts and the endpoint returns 30, so `compile-metrics-build` was never in the response. Filtering by `name` server-side removes the pagination question entirely.
