### PR TITLE
feat(ci): track cargo llvm-lines for espresso-node

### DIFF
--- a/.github/workflows/llvm-lines.yml
+++ b/.github/workflows/llvm-lines.yml
@@ -1,0 +1,202 @@
+name: LLVM lines
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - scripts/llvm-lines
+      - .github/workflows/llvm-lines.yml
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  llvm-lines:
+    name: llvm-lines (${{ matrix.profile }})
+    # issue_comment: only for a "/llvm-lines" comment on a PR from a trusted author.
+    # A folded (`>`) block scalar here would add a trailing newline around ${{ }}, which makes
+    # GitHub evaluate the whole `if:` as a non-empty string (always truthy) instead of a bool.
+    if: ${{ github.event_name != 'issue_comment'
+      || (github.event.issue.pull_request
+      && contains(github.event.comment.body, '/llvm-lines')
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [test, release]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # issue_comment has no pull_request context to check out by default, so pin to the PR's
+          # merge ref; other events keep actions/checkout's default (the triggering ref).
+          ref: >-
+            ${{ github.event_name == 'issue_comment'
+            && format('refs/pull/{0}/merge', github.event.issue.number)
+            || '' }}
+      - uses: rui314/setup-mold@v1
+
+      - name: Install Protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Enable Rust Caching
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v3-rust
+          shared-key: llvm-lines-${{ matrix.profile }}
+          # Not github.ref == 'refs/heads/main': on issue_comment that ref is still main even
+          # though the checkout above is the PR merge ref, which would poison the shared cache
+          # key that main runs restore from.
+          save-if: >
+            ${{ github.event_name == 'push'
+            || github.event_name == 'workflow_dispatch' }}
+
+      # Not in taiki-e/install-action's manifests, unlike most other cargo subcommands used here.
+      - name: Install cargo-llvm-lines
+        run: cargo install cargo-llvm-lines --locked
+
+      - name: Run cargo llvm-lines
+        run: |
+          cargo llvm-lines -p espresso-node --bin espresso-node \
+            --profile ${{ matrix.profile }} > llvm-lines-${{ matrix.profile }}.txt
+
+      # Directly after the build, so an unrelated step failing in between cannot cost the metrics.
+      - name: Collect llvm-lines metrics
+        continue-on-error: true
+        run: |
+          python3 scripts/llvm-lines collect llvm-lines-${{ matrix.profile }}.txt \
+            --profile ${{ matrix.profile }} \
+            --out llvm-lines-metrics-${{ matrix.profile }}.json
+
+      - name: Upload llvm-lines metrics
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: llvm-lines-metrics-${{ matrix.profile }}
+          path: llvm-lines-metrics-${{ matrix.profile }}.json
+          retention-days: ${{ github.event_name == 'push' && 90 || 14 }}
+
+      # Separate artifact on purpose: the report job downloads llvm-lines-metrics-* and would
+      # otherwise pull tallies it never reads. This one is for answering questions later, by hand.
+      - name: Upload raw llvm-lines output
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: llvm-lines-raw-${{ matrix.profile }}
+          path: llvm-lines-${{ matrix.profile }}.txt
+          retention-days: ${{ github.event_name == 'push' && 90 || 14 }}
+
+  report:
+    name: Report
+    needs: llvm-lines
+    # needs.llvm-lines.result != 'skipped': a skipped need still satisfies !cancelled(), so
+    # without this the untrusted-comment gate on llvm-lines would not stop report from running.
+    if: ${{ !cancelled() && needs.llvm-lines.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    # Reporter only: failures here must not fail the workflow.
+    continue-on-error: true
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Same ref override as the llvm-lines job above.
+          ref: >-
+            ${{ github.event_name == 'issue_comment'
+            && format('refs/pull/{0}/merge', github.event.issue.number)
+            || '' }}
+
+      - name: Download llvm-lines metrics
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: llvm-lines-metrics-*
+          path: metrics-artifacts
+
+      - name: Merge llvm-lines metrics
+        continue-on-error: true
+        run: |
+          python3 scripts/llvm-lines merge metrics-artifacts \
+            --sha "${{ github.sha }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --out llvm-lines.json
+
+      # Only the newest run is compared against; the other four are how far back to look for a
+      # main run that published a baseline at all. Absent baseline is normal until the first main
+      # run of this workflow completes.
+      - name: Fetch main llvm-lines metrics
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/nextest-ci stats-fetch \
+            --workflow llvm-lines.yml \
+            --artifact-name llvm-lines \
+            --max-runs 5 \
+            --out main-llvm-lines.json
+
+      - name: Render report
+        continue-on-error: true
+        run: |
+          args=(llvm-lines.json --title "LLVM lines: espresso-node")
+          if [ -s main-llvm-lines.json ]; then
+            args+=(--main-stats main-llvm-lines.json)
+          fi
+          python3 scripts/llvm-lines report "${args[@]}" \
+            | tee report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post/update PR comment
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'issue_comment' }}
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: llvm-lines
+          path: report.md
+          number: ${{ github.event_name == 'issue_comment' && github.event.issue.number || null }}
+
+  publish:
+    name: Publish baseline
+    needs: llvm-lines
+    # !cancelled() so one failed matrix leg on main does not freeze the baseline artifact.
+    if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download llvm-lines metrics
+        uses: actions/download-artifact@v8
+        with:
+          pattern: llvm-lines-metrics-*
+          path: metrics-artifacts
+
+      - name: Merge llvm-lines metrics
+        run: |
+          python3 scripts/llvm-lines merge metrics-artifacts \
+            --sha "${{ github.sha }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --out llvm-lines.json
+
+      # Named "llvm-lines", not "llvm-lines-metrics-*": this is the baseline that
+      # `scripts/nextest-ci stats-fetch` looks up, not one of the per-matrix-leg artifacts.
+      - name: Upload baseline
+        uses: actions/upload-artifact@v7
+        with:
+          name: llvm-lines
+          path: llvm-lines.json
+          retention-days: 90

--- a/.github/workflows/llvm-lines.yml
+++ b/.github/workflows/llvm-lines.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run cargo llvm-lines
         run: |
-          cargo llvm-lines -p espresso-node --bin espresso-node \
+          cargo llvm-lines -p espresso-node --lib \
             --profile ${{ matrix.profile }} > llvm-lines-${{ matrix.profile }}.txt
 
       # Directly after the build, so an unrelated step failing in between cannot cost the metrics.

--- a/justfile
+++ b/justfile
@@ -81,6 +81,10 @@ fix *args:
 compile-metrics *args:
     scripts/compile-metrics local {{args}}
 
+# LLVM lines report for a pull request, revision, or run, as CI renders it
+llvm-lines *args:
+    scripts/llvm-lines local {{args}}
+
 lint *args:
     just clippy {{args}} -- -D warnings
 

--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -1405,9 +1405,12 @@ def align(markdown: str) -> str:
 
 
 def capture(*command: str) -> str:
-    return subprocess.run(
-        command, capture_output=True, text=True, check=True
-    ).stdout.strip()
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"`{' '.join(command)}` exited {result.returncode}: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
 
 
 def run_quiet(*command: str) -> int:

--- a/scripts/llvm-lines
+++ b/scripts/llvm-lines
@@ -430,6 +430,16 @@ def pr_branch(pr: int | None) -> str:
     return json.loads(capture(*view, "--json", "headRefName"))["headRefName"]
 
 
+def missing_workflow_message(error: str, workflow: str) -> str:
+    """`error` as-is, unless it is the 404 `gh run list --workflow` gives before the workflow
+    file has landed on the default branch, in which case a message that says so plainly."""
+    if "HTTP 404" in error:
+        return (
+            f"{workflow} is not on the default branch yet, so gh cannot list its runs"
+        )
+    return error
+
+
 def newest_with_metrics(selector: list[str]) -> Target | None:
     """The newest matching run whose artifacts are still there.
 
@@ -437,20 +447,23 @@ def newest_with_metrics(selector: list[str]) -> Target | None:
     and a run old enough has lost its artifacts to retention. Listing the names is one cheap call
     against a download of every artifact in the run.
     """
-    runs = json.loads(
-        capture(
-            "gh",
-            "run",
-            "list",
-            "--workflow",
-            WORKFLOW,
-            *selector,
-            "--limit",
-            str(RUN_CANDIDATES),
-            "--json",
-            "databaseId,url,headSha",
+    try:
+        runs = json.loads(
+            capture(
+                "gh",
+                "run",
+                "list",
+                "--workflow",
+                WORKFLOW,
+                *selector,
+                "--limit",
+                str(RUN_CANDIDATES),
+                "--json",
+                "databaseId,url,headSha",
+            )
         )
-    )
+    except RuntimeError as error:
+        raise RuntimeError(missing_workflow_message(str(error), WORKFLOW)) from error
     for run in runs:
         if has_metrics(run["databaseId"]):
             return Target(run["headSha"], run["databaseId"], run["url"])
@@ -540,9 +553,12 @@ def align(markdown: str) -> str:
 
 
 def capture(*command: str) -> str:
-    return subprocess.run(
-        command, capture_output=True, text=True, check=True
-    ).stdout.strip()
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"`{' '.join(command)}` exited {result.returncode}: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
 
 
 def run_quiet(*command: str) -> int:

--- a/scripts/llvm-lines
+++ b/scripts/llvm-lines
@@ -61,6 +61,12 @@ REF_PREFIX_RE = re.compile(r"^(?:[&*]+\s*(?:mut|const)?\s*|dyn\s+)+")
 # the name, since it is the one place a `>` closes nothing. A function-pointer self type
 # (`fn(u8) -> u8`) would otherwise look closed one bracket early.
 ARROW = "\x00"
+# v0 mangling's per-crate disambiguator, e.g. `std[1e3c4ec04c5261a9]::rt::lang_start`: it changes
+# with the toolchain and build settings, so left in, no function name would ever match between a
+# run and the main baseline. Anchored on an identifier character before it and on being all hex,
+# so a real slice or array type (`[u8]`, `[T; 4]`) is never touched: neither is hex-only, and `[T;
+# 4]` also is not immediately preceded by an identifier.
+DISAMBIGUATOR_RE = re.compile(r"(?<=\w)\[[0-9a-f]{7,16}\]")
 
 RUN_CANDIDATES = 10
 TOP_FUNCTIONS = 500
@@ -73,10 +79,16 @@ NO_BASELINE = "No main-branch baseline available yet; showing absolute numbers o
 # collect
 
 
+def strip_disambiguators(name: str) -> str:
+    return DISAMBIGUATOR_RE.sub("", name)
+
+
 def parse_table(text: str) -> tuple[int, int, list[tuple[str, int, int]]]:
     """(total lines, total copies, [(function, lines, copies), ...]), TOTAL row excluded.
 
     Raises if there is no TOTAL row, which is what an empty or truncated capture looks like.
+    Names are normalized here, once, so both the stored function name and crate attribution see
+    the same text.
     """
     total_lines = None
     total_copies = 0
@@ -85,7 +97,8 @@ def parse_table(text: str) -> tuple[int, int, list[tuple[str, int, int]]]:
         match = ROW_RE.match(line)
         if match is None:
             continue
-        lines, copies, name = int(match[1]), int(match[2]), match[3].strip()
+        lines, copies = int(match[1]), int(match[2])
+        name = strip_disambiguators(match[3].strip())
         if name == TOTAL_NAME:
             total_lines, total_copies = lines, copies
             continue

--- a/scripts/llvm-lines
+++ b/scripts/llvm-lines
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+r"""LLVM-lines metrics for CI: collect, merge, and compare `cargo llvm-lines` output.
+
+`cargo llvm-lines` counts, per monomorphized function, how many LLVM IR lines and copies of it
+rustc generates before optimization; the total tracks how much of a build's cost is generic
+instantiation rather than first-time codegen. This mirrors `scripts/compile-metrics`'s
+collect/merge/report/local shape for that one number, for the espresso-node binary alone.
+
+Examples:
+    # Capture cargo llvm-lines output for one profile, then turn it into metrics JSON.
+    cargo llvm-lines -p espresso-node --bin espresso-node --profile release \
+        > llvm-lines-release.txt
+    scripts/llvm-lines collect llvm-lines-release.txt --profile release \
+        --out llvm-lines-metrics-release.json
+
+    # Merge the per-profile artifacts of one run.
+    scripts/llvm-lines merge metrics-artifacts --sha "$SHA" --run-url "$RUN_URL" \
+        --out llvm-lines.json
+
+    # Compare a run against the newest main run, from `nextest-ci stats-fetch` output.
+    scripts/llvm-lines report llvm-lines.json --main-stats main-llvm-lines.json
+
+    # The report, locally, from the newest CI run that still has its artifacts.
+    scripts/llvm-lines local --pr 4888
+    scripts/llvm-lines local --rev main
+    scripts/llvm-lines local --run 33374493992
+"""
+
+import argparse
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("llvm-lines")
+
+NEXTEST_CI = Path(__file__).with_name("nextest-ci")
+WORKFLOW = "llvm-lines.yml"
+BASELINE_ARTIFACT = "llvm-lines"
+ARTIFACT_PREFIX = "llvm-lines-metrics-"
+TITLE = "LLVM lines: espresso-node"
+
+# A data row is "<lines> [(pct, pct)]  <copies> [(pct, pct)]  <name>"; the percent parens are
+# absent in some older 0.4.x releases, so they are optional rather than parsed. The header and
+# dashes rows have no leading number and never match.
+ROW_RE = re.compile(r"^\s*(\d+)(?:\s*\([^)]*\))?\s+(\d+)(?:\s*\([^)]*\))?\s+(\S.*)$")
+TOTAL_NAME = "(TOTAL)"
+# Same shape as compile-metrics's GENERIC_ARGS_RE: a generic argument list with nothing nested
+# left inside it.
+GENERIC_ARGS_RE = re.compile(r"<[^<>]*>")
+# What a self type opens with before its crate path: one or more `&`/`*` (each optionally
+# followed by `mut`/`const`), or a `dyn`, repeated so `&dyn Trait` strips in one pass.
+REF_PREFIX_RE = re.compile(r"^(?:[&*]+\s*(?:mut|const)?\s*|dyn\s+)+")
+# Same trick as compile-metrics's ARROW: masks `->` before split_qualifier/strip_generic_args see
+# the name, since it is the one place a `>` closes nothing. A function-pointer self type
+# (`fn(u8) -> u8`) would otherwise look closed one bracket early.
+ARROW = "\x00"
+
+RUN_CANDIDATES = 10
+TOP_FUNCTIONS = 500
+TOP_CRATES = 25
+TOP_FUNCTIONS_TABLE = 20
+TOP_MOVERS = 40
+NO_BASELINE = "No main-branch baseline available yet; showing absolute numbers only."
+
+
+# collect
+
+
+def parse_table(text: str) -> tuple[int, int, list[tuple[str, int, int]]]:
+    """(total lines, total copies, [(function, lines, copies), ...]), TOTAL row excluded.
+
+    Raises if there is no TOTAL row, which is what an empty or truncated capture looks like.
+    """
+    total_lines = None
+    total_copies = 0
+    rows = []
+    for line in text.splitlines():
+        match = ROW_RE.match(line)
+        if match is None:
+            continue
+        lines, copies, name = int(match[1]), int(match[2]), match[3].strip()
+        if name == TOTAL_NAME:
+            total_lines, total_copies = lines, copies
+            continue
+        rows.append((name, lines, copies))
+    if total_lines is None:
+        raise RuntimeError(f"no {TOTAL_NAME} row in llvm-lines output")
+    return total_lines, total_copies, rows
+
+
+def split_qualifier(name: str) -> tuple[str, str]:
+    """`<Vec<u8> as Drop>::drop` -> (`<Vec<u8> as Drop>`, `::drop`), else ("", name)."""
+    if not name.startswith("<"):
+        return "", name
+    depth = 0
+    for index, char in enumerate(name):
+        depth += (char == "<") - (char == ">")
+        if depth == 0:
+            return name[: index + 1], name[index + 1 :]
+    return "", name
+
+
+def strip_generic_args(name: str) -> str:
+    """Drop every argument list, innermost first, keeping any `<T as Trait>` inside."""
+    if name.startswith("<") and name.endswith(">"):
+        return f"<{strip_generic_args(name[1:-1])}>"
+    while "<" in name:
+        stripped = GENERIC_ARGS_RE.sub(
+            lambda group: group[0] if " as " in group[0] else "", name
+        )
+        if stripped == name:
+            return name
+        name = stripped
+    return name
+
+
+def function_crate(name: str) -> str:
+    """Crate a demangled function belongs to: first path segment of its defining type.
+
+    For `<Type as Trait>::method` this is `Type`'s crate: the trait says nothing about where the
+    function lives. `Type` has its own reference qualifiers and generic arguments stripped first,
+    so `<&mut alloc::vec::Vec<u8> as Drop>::drop` reads as `alloc`, not `&mut`.
+
+    cargo-llvm-lines prints generic, non-monomorphized names too, so `Type` is routinely a bare
+    type parameter (`T`, `Fut`, ...) with no path of its own; the blanket impl it names is the
+    trait's, so the trait's crate is used instead whenever the self type has none.
+    """
+    masked = name.replace("->", ARROW)
+    qualifier, rest = split_qualifier(masked)
+    if qualifier:
+        self_type, _, trait = qualifier[1:-1].partition(" as ")
+    else:
+        self_type, trait = rest, ""
+    target = REF_PREFIX_RE.sub("", self_type.strip())
+    stripped = strip_generic_args(target)
+    if qualifier and trait and "::" not in stripped:
+        stripped = strip_generic_args(trait.strip())
+    head, _, _ = stripped.partition("::")
+    return head.strip("<>&*()[] ").replace(ARROW, "->") or "?"
+
+
+def collect_metrics(profile: str, text: str) -> dict[str, Any]:
+    total_lines, total_copies, rows = parse_table(text)
+    crates: dict[str, dict[str, int]] = {}
+    for name, lines, copies in rows:
+        entry = crates.setdefault(function_crate(name), {"lines": 0, "copies": 0})
+        entry["lines"] += lines
+        entry["copies"] += copies
+    top_rows = sorted(rows, key=lambda row: -row[1])[:TOP_FUNCTIONS]
+    functions = {
+        name: {"lines": lines, "copies": copies} for name, lines, copies in top_rows
+    }
+    return {
+        "profile": profile,
+        "total_lines": total_lines,
+        "total_copies": total_copies,
+        "crates": dict(sorted(crates.items())),
+        "functions": functions,
+    }
+
+
+def cmd_collect(args: argparse.Namespace) -> int:
+    metrics = collect_metrics(args.profile, args.raw.read_text())
+    args.out.write_text(json.dumps(metrics, indent=2) + "\n")
+    log.info(
+        "%s: %d lines, %d copies over %d crates, top %d functions kept",
+        args.profile,
+        metrics["total_lines"],
+        metrics["total_copies"],
+        len(metrics["crates"]),
+        len(metrics["functions"]),
+    )
+    return 0
+
+
+# merge
+
+
+def read_json(path: Path) -> dict:
+    """A missing or truncated file costs the metrics it holds and nothing else."""
+    try:
+        return json.loads(path.read_text())
+    except Exception as error:  # noqa: BLE001
+        log.warning("ignoring %s: %s", path, error)
+        return {}
+
+
+def merge_profiles(paths: list[Path]) -> dict[str, Any]:
+    profiles = {}
+    for path in paths:
+        metrics = read_json(path)
+        if not metrics:
+            continue  # read_json has already said why
+        if "profile" not in metrics:
+            log.warning("ignoring %s: no profile field", path)
+            continue
+        profiles[metrics["profile"]] = metrics
+    return profiles
+
+
+def merged_metrics(directory: Path, sha: str, run_url: str) -> dict[str, Any]:
+    paths = sorted(directory.rglob(f"{ARTIFACT_PREFIX}*.json"))
+    if not paths:
+        raise RuntimeError(f"no {ARTIFACT_PREFIX}*.json under {directory}")
+    return {"sha": sha, "run_url": run_url, "profiles": merge_profiles(paths)}
+
+
+def cmd_merge(args: argparse.Namespace) -> int:
+    merged = merged_metrics(args.dir, args.sha, args.run_url)
+    args.out.write_text(json.dumps(merged, indent=2) + "\n")
+    log.info("wrote %s with %d profile(s)", args.out, len(merged["profiles"]))
+    return 0
+
+
+# report
+
+
+def fmt_name(name: str) -> str:
+    """A crate or function name as a table cell.
+
+    Backticked because a self-type qualifier routinely opens with `<`, which GitHub renders as an
+    unknown HTML tag and drops. A `|` still splits the row inside a code span, so it is escaped.
+    """
+    return "`" + name.replace("|", "\\|") + "`"
+
+
+def pct(main: int, current: int) -> float:
+    return (current - main) / main * 100 if main else 0.0
+
+
+def totals_table(metrics: dict[str, Any], baseline: dict[str, Any] | None) -> list[str]:
+    if baseline is None:
+        return [
+            "| metric | value |",
+            "|---|---:|",
+            f"| lines | {metrics['total_lines']:,} |",
+            f"| copies | {metrics['total_copies']:,} |",
+        ]
+    lines = [
+        "| metric | main | this run | delta | delta % |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for key, label in (("total_lines", "lines"), ("total_copies", "copies")):
+        before, after = baseline[key], metrics[key]
+        lines.append(
+            f"| {label} | {before:,} | {after:,} "
+            f"| {after - before:+,} | {pct(before, after):+.1f}% |"
+        )
+    return lines
+
+
+def crate_rows(metrics: dict[str, Any]) -> list[tuple[str, int, int]]:
+    return sorted(
+        (
+            (name, entry["lines"], entry["copies"])
+            for name, entry in metrics["crates"].items()
+        ),
+        key=lambda row: (-row[1], row[0]),
+    )
+
+
+def crates_table(metrics: dict[str, Any], baseline: dict[str, Any] | None) -> list[str]:
+    rows = crate_rows(metrics)[:TOP_CRATES]
+    if baseline is None:
+        lines = ["| crate | lines | copies |", "|---|---:|---:|"]
+        return lines + [
+            f"| {fmt_name(name)} | {crate_lines:,} | {copies:,} |"
+            for name, crate_lines, copies in rows
+        ]
+    lines = [
+        "| crate | lines | copies | delta lines | delta copies |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for name, crate_lines, copies in rows:
+        before = baseline["crates"].get(name, {"lines": 0, "copies": 0})
+        lines.append(
+            f"| {fmt_name(name)} | {crate_lines:,} | {copies:,} "
+            f"| {crate_lines - before['lines']:+,} | {copies - before['copies']:+,} |"
+        )
+    return lines
+
+
+def top_functions_table(metrics: dict[str, Any]) -> list[str]:
+    rows = sorted(metrics["functions"].items(), key=lambda item: -item[1]["lines"])
+    rows = rows[:TOP_FUNCTIONS_TABLE]
+    lines = ["| function | lines | copies |", "|---|---:|---:|"]
+    return lines + [
+        f"| {fmt_name(name)} | {v['lines']:,} | {v['copies']:,} |" for name, v in rows
+    ]
+
+
+def function_movers(
+    metrics: dict[str, Any], baseline: dict[str, Any]
+) -> list[tuple[str, int, int]]:
+    """(function, main lines, this-run lines), largest |delta| first, capped.
+
+    Only functions in the top-`TOP_FUNCTIONS` list of either side have a line count to compare;
+    a function that dropped out of both sides' lists is invisible to this diff either way.
+    """
+    names = set(metrics["functions"]) | set(baseline["functions"])
+    rows = [
+        (
+            name,
+            baseline["functions"].get(name, {"lines": 0})["lines"],
+            metrics["functions"].get(name, {"lines": 0})["lines"],
+        )
+        for name in names
+    ]
+    rows = [row for row in rows if row[1] != row[2]]
+    rows.sort(key=lambda row: (-abs(row[2] - row[1]), row[0]))
+    return rows[:TOP_MOVERS]
+
+
+def movers_table(metrics: dict[str, Any], baseline: dict[str, Any]) -> list[str]:
+    rows = function_movers(metrics, baseline)
+    if not rows:
+        return ["No function's line count moved."]
+    lines = ["| function | main | this run | delta |", "|---|---:|---:|---:|"]
+    return lines + [
+        f"| {fmt_name(name)} | {before:,} | {after:,} | {after - before:+,} |"
+        for name, before, after in rows
+    ]
+
+
+def profile_section(
+    profile: str,
+    metrics: dict[str, Any],
+    baseline: dict[str, Any] | None,
+    note: str = "",
+) -> list[str]:
+    lines = [f"### {profile}", ""]
+    if note:
+        lines += [note, ""]
+    lines += totals_table(metrics, baseline)
+    lines += ["", f"Top {TOP_CRATES} crates by lines:", ""]
+    lines += crates_table(metrics, baseline)
+    if baseline is not None:
+        lines += ["", "Functions whose line count moved the most:", ""]
+        lines += movers_table(metrics, baseline)
+    lines += ["", f"Top {TOP_FUNCTIONS_TABLE} functions by lines:", ""]
+    lines += top_functions_table(metrics)
+    lines.append("")
+    return lines
+
+
+def newest_main_run(stats: dict[str, Any]) -> dict[str, Any] | None:
+    return next(iter(stats.get("runs", [])), None)
+
+
+def report_markdown(
+    current: dict[str, Any], main: dict[str, Any] | None, title: str
+) -> str:
+    lines = [f"## {title}", ""]
+    if main is None:
+        lines += [NO_BASELINE, ""]
+    for profile, metrics in sorted(current["profiles"].items()):
+        baseline = main["profiles"].get(profile) if main else None
+        note = (
+            "No baseline for this profile on main."
+            if main is not None and baseline is None
+            else ""
+        )
+        lines += profile_section(profile, metrics, baseline, note)
+    return "\n".join(lines)
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    current = json.loads(args.metrics.read_text())
+    main = (
+        newest_main_run(json.loads(args.main_stats.read_text()))
+        if args.main_stats
+        else None
+    )
+    print(report_markdown(current, main, args.title))
+    return 0
+
+
+# local
+
+
+@dataclass(frozen=True)
+class Target:
+    sha: str
+    run_id: int
+    url: str
+
+
+def cmd_local(args: argparse.Namespace) -> int:
+    """The report for one commit, rendered from the artifacts of its CI run.
+
+    The same report CI posts, so a rendering change can be tried out without pushing.
+    """
+    target = find_target(args.pr, args.rev, args.run)
+    if target is None:
+        log.info("%s: no run with metrics artifacts", WORKFLOW)
+        return 0
+    log.info("run %d at %s", target.run_id, target.sha[:8])
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        artifacts = work / "artifacts"
+        if not download_metrics(target.run_id, artifacts):
+            log.warning("run %d: metrics artifacts vanished", target.run_id)
+            return 0
+        current = merged_metrics(artifacts, target.sha, target.url)
+        main = fetch_baseline(work / "main.json")
+    print(align(report_markdown(current, main, TITLE)))
+    return 0
+
+
+def find_target(pr: int | None, rev: str | None, run: int | None) -> Target | None:
+    if run:
+        return run_target(run)
+    selector = (
+        ["--commit", capture("git", "rev-parse", rev)]
+        if rev
+        else ["--branch", pr_branch(pr)]
+    )
+    return newest_with_metrics(selector)
+
+
+def pr_branch(pr: int | None) -> str:
+    view = ["gh", "pr", "view", *([str(pr)] if pr else [])]
+    return json.loads(capture(*view, "--json", "headRefName"))["headRefName"]
+
+
+def newest_with_metrics(selector: list[str]) -> Target | None:
+    """The newest matching run whose artifacts are still there.
+
+    The newest run is often not reportable: a push starts one whose build has not uploaded yet,
+    and a run old enough has lost its artifacts to retention. Listing the names is one cheap call
+    against a download of every artifact in the run.
+    """
+    runs = json.loads(
+        capture(
+            "gh",
+            "run",
+            "list",
+            "--workflow",
+            WORKFLOW,
+            *selector,
+            "--limit",
+            str(RUN_CANDIDATES),
+            "--json",
+            "databaseId,url,headSha",
+        )
+    )
+    for run in runs:
+        if has_metrics(run["databaseId"]):
+            return Target(run["headSha"], run["databaseId"], run["url"])
+    return None
+
+
+def has_metrics(run_id: int) -> bool:
+    names = json.loads(
+        capture(
+            "gh",
+            "api",
+            f"repos/{{owner}}/{{repo}}/actions/runs/{run_id}/artifacts",
+            "--jq",
+            "[.artifacts[].name]",
+        )
+    )
+    return any(name.startswith(ARTIFACT_PREFIX) for name in names)
+
+
+def run_target(run_id: int) -> Target:
+    run = json.loads(
+        capture("gh", "api", f"repos/{{owner}}/{{repo}}/actions/runs/{run_id}")
+    )
+    return Target(run["head_sha"], run_id, run["html_url"])
+
+
+def download_metrics(run_id: int, into: Path) -> bool:
+    into.mkdir(parents=True)
+    code = run_quiet(
+        "gh",
+        "run",
+        "download",
+        str(run_id),
+        "--pattern",
+        f"{ARTIFACT_PREFIX}*",
+        "--dir",
+        str(into),
+    )
+    return code == 0
+
+
+def fetch_baseline(out: Path) -> dict[str, Any] | None:
+    """The newest main run that published a baseline; None until the workflow has run on main."""
+    code = run_quiet(
+        sys.executable,
+        str(NEXTEST_CI),
+        "stats-fetch",
+        "--workflow",
+        WORKFLOW,
+        "--artifact-name",
+        BASELINE_ARTIFACT,
+        "--max-runs",
+        "5",
+        "--out",
+        str(out),
+    )
+    if code != 0 or not out.is_file():
+        return None
+    return newest_main_run(json.loads(out.read_text()))
+
+
+def align(markdown: str) -> str:
+    """Pad the table cells, because unpadded markdown is unreadable in a terminal.
+
+    Prettier reads stdin rather than a file, which keeps .prettierignore out of it, and the wide
+    print width stops it compacting a table instead of letting the line run long. Falls back to the
+    raw markdown when prettier is not installed.
+    """
+    if shutil.which("prettier") is None:
+        return markdown
+    result = subprocess.run(
+        [
+            "prettier",
+            "--parser",
+            "markdown",
+            "--print-width",
+            "200",
+            "--prose-wrap",
+            "preserve",
+        ],
+        input=markdown,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout if result.returncode == 0 else markdown
+
+
+def capture(*command: str) -> str:
+    return subprocess.run(
+        command, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def run_quiet(*command: str) -> int:
+    return subprocess.run(
+        command, capture_output=True, text=True, check=False
+    ).returncode
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="subcommand", required=True)
+
+    collect = sub.add_parser(
+        "collect", help="turn one profile's cargo-llvm-lines output into JSON"
+    )
+    collect.add_argument(
+        "raw", type=Path, help="captured stdout of `cargo llvm-lines ... --profile <p>`"
+    )
+    collect.add_argument("--profile", required=True, choices=("test", "release"))
+    collect.add_argument("--out", required=True, type=Path)
+    collect.set_defaults(func=cmd_collect)
+
+    merge = sub.add_parser("merge", help="merge the per-profile metrics of one run")
+    merge.add_argument(
+        "dir", type=Path, help="directory of downloaded per-profile artifacts"
+    )
+    merge.add_argument("--sha", required=True)
+    merge.add_argument("--run-url", required=True)
+    merge.add_argument("--out", required=True, type=Path)
+    merge.set_defaults(func=cmd_merge)
+
+    report = sub.add_parser("report", help="compare a run against the newest main run")
+    report.add_argument("metrics", type=Path, help="merged metrics of this run")
+    report.add_argument(
+        "--main-stats",
+        type=Path,
+        help="aggregated main runs from `nextest-ci stats-fetch`",
+    )
+    report.add_argument("--title", default=TITLE)
+    report.set_defaults(func=cmd_report)
+
+    local = sub.add_parser(
+        "local", help="render the report for a commit, from its CI artifacts"
+    )
+    target = local.add_mutually_exclusive_group()
+    target.add_argument(
+        "--pr", type=int, help="pull request number; defaults to the current branch's"
+    )
+    target.add_argument(
+        "--rev", help="git revision, resolved locally, instead of a pull request"
+    )
+    target.add_argument(
+        "--run",
+        type=int,
+        help="one workflow run id, to report on a run that is not the newest",
+    )
+    local.set_defaults(func=cmd_local)
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/py.just
+++ b/scripts/py.just
@@ -1,4 +1,4 @@
-scripts := "nextest-ci compile-metrics test_compile_metrics.py"
+scripts := "nextest-ci compile-metrics test_compile_metrics.py llvm-lines test_llvm_lines.py"
 
 fmt *args:
     ruff format {{scripts}} {{args}}

--- a/scripts/test_llvm_lines.py
+++ b/scripts/test_llvm_lines.py
@@ -37,6 +37,17 @@ TABLE_BARE_NUMBERS = """\
    772004                 8062                core::ptr::drop_in_place
 """
 
+# Verbatim rows from a real v0-mangled build: every crate path carries a `[<hex>]`
+# disambiguator that changes with the toolchain and build settings.
+TABLE_WITH_DISAMBIGUATORS = """\
+  Lines                 Copies               Function name
+  -----                 ------               -------------
+  1000                  100                  (TOTAL)
+   21 (42.0%, 42.0%)  1 (11.1%, 11.1%)  <std[1e3c4ec04c5261a9]::rt::lang_start<()>::{closure#0} as core[37f591cfbe66b0b1]::ops::function::FnOnce<()>>::call_once
+    5 (10.0%, 52.0%)  1 (11.1%, 22.2%)  main
+    2 (4.0%, 44.0%)   1 (11.1%, 33.3%)  espresso_node[4f5fb2aa37c475b]::main
+"""
+
 
 class ParseTable(unittest.TestCase):
     def test_total_extracted_and_excluded_from_rows(self):
@@ -73,6 +84,20 @@ class ParseTable(unittest.TestCase):
                 "  -----                 ------               -------------\n"
                 "   772004 (50.7%, 50.7%)   8062 (21.2%, 71.9%)  core::ptr::drop_in_place\n"
             )
+
+    def test_v0_crate_disambiguators_stripped(self):
+        _, _, rows = ll.parse_table(TABLE_WITH_DISAMBIGUATORS)
+        self.assertEqual(
+            [name for name, _, _ in rows],
+            [
+                (
+                    "<std::rt::lang_start<()>::{closure#0} as "
+                    "core::ops::function::FnOnce<()>>::call_once"
+                ),
+                "main",
+                "espresso_node::main",
+            ],
+        )
 
 
 class FunctionCrate(unittest.TestCase):
@@ -114,6 +139,44 @@ class FunctionCrate(unittest.TestCase):
             ll.function_crate("<fn(u8) -> u8 as core::ops::FnOnce<(u8,)>>::call_once"),
             "core",
         )
+
+    def test_disambiguated_impl_qualifier(self):
+        self.assertEqual(
+            ll.function_crate(
+                "<std::rt::lang_start<()>::{closure#0} as "
+                "core::ops::function::FnOnce<()>>::call_once"
+            ),
+            "std",
+        )
+
+    def test_disambiguated_plain_path(self):
+        self.assertEqual(ll.function_crate("espresso_node::main"), "espresso_node")
+
+    def test_bare_main_has_no_path_so_the_whole_name_is_the_bucket(self):
+        self.assertEqual(ll.function_crate("main"), "main")
+
+    def test_disambiguated_trait_used_by_the_bare_type_parameter_fallback(self):
+        self.assertEqual(
+            ll.function_crate("<T as core::ops::function::FnOnce<()>>::call_once"),
+            "core",
+        )
+
+
+class StripDisambiguators(unittest.TestCase):
+    def test_hex_suffix_after_an_identifier_is_removed(self):
+        self.assertEqual(
+            ll.strip_disambiguators("std[1e3c4ec04c5261a9]::rt::lang_start"),
+            "std::rt::lang_start",
+        )
+
+    def test_slice_type_is_not_a_disambiguator(self):
+        self.assertEqual(
+            ll.strip_disambiguators("<[u8] as some::Trait>::f"),
+            "<[u8] as some::Trait>::f",
+        )
+
+    def test_array_type_is_not_a_disambiguator(self):
+        self.assertEqual(ll.strip_disambiguators("[T; 4]"), "[T; 4]")
 
 
 class CollectMetrics(unittest.TestCase):

--- a/scripts/test_llvm_lines.py
+++ b/scripts/test_llvm_lines.py
@@ -146,6 +146,22 @@ class FmtName(unittest.TestCase):
         self.assertEqual(ll.fmt_name("a|b"), "`a\\|b`")
 
 
+class MissingWorkflowMessage(unittest.TestCase):
+    def test_404_on_the_workflow_endpoint_gets_a_plain_explanation(self):
+        error = (
+            "`gh run list --workflow llvm-lines.yml` exited 1: HTTP 404: "
+            "workflow llvm-lines.yml not found on the default branch (...)"
+        )
+        self.assertEqual(
+            ll.missing_workflow_message(error, "llvm-lines.yml"),
+            "llvm-lines.yml is not on the default branch yet, so gh cannot list its runs",
+        )
+
+    def test_other_errors_pass_through_unchanged(self):
+        error = "`gh run list` exited 1: HTTP 500: internal error"
+        self.assertEqual(ll.missing_workflow_message(error, "llvm-lines.yml"), error)
+
+
 class MergeProfiles(unittest.TestCase):
     def test_merges_by_profile_field_not_file_name(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_llvm_lines.py
+++ b/scripts/test_llvm_lines.py
@@ -1,0 +1,244 @@
+"""Tests for the parsing in `llvm-lines` that is not obvious from reading it.
+
+Everything here is a pure function over literals, so no build, no artifact and no network.
+
+    just py::test
+"""
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("llvm-lines")
+_spec = importlib.util.spec_from_loader(
+    "llvm_lines", SourceFileLoader("llvm_lines", str(SCRIPT))
+)
+assert _spec is not None
+ll = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(ll)
+
+
+TABLE_WITH_PERCENTS = """\
+  Lines                 Copies               Function name
+  -----                 ------               -------------
+  1523423               38041                (TOTAL)
+   772004 (50.7%, 50.7%)   8062 (21.2%, 71.9%)  core::ptr::drop_in_place
+   112342 (7.4%, 58.1%)     11 (0.0%, 71.9%)  <futures_util::stream::FuturesUnordered<Fut> as futures_core::stream::Stream>::poll_next
+"""
+
+TABLE_BARE_NUMBERS = """\
+  Lines                 Copies               Function name
+  -----                 ------               -------------
+  1523423               38041                (TOTAL)
+   772004                 8062                core::ptr::drop_in_place
+"""
+
+
+class ParseTable(unittest.TestCase):
+    def test_total_extracted_and_excluded_from_rows(self):
+        total_lines, total_copies, rows = ll.parse_table(TABLE_WITH_PERCENTS)
+        self.assertEqual((total_lines, total_copies), (1523423, 38041))
+        self.assertEqual(
+            [name for name, _, _ in rows],
+            [
+                "core::ptr::drop_in_place",
+                (
+                    "<futures_util::stream::FuturesUnordered<Fut> as "
+                    "futures_core::stream::Stream>::poll_next"
+                ),
+            ],
+        )
+
+    def test_row_values(self):
+        _, _, rows = ll.parse_table(TABLE_WITH_PERCENTS)
+        self.assertEqual(rows[0], ("core::ptr::drop_in_place", 772004, 8062))
+
+    def test_bare_number_variant(self):
+        total_lines, total_copies, rows = ll.parse_table(TABLE_BARE_NUMBERS)
+        self.assertEqual((total_lines, total_copies), (1523423, 38041))
+        self.assertEqual(rows, [("core::ptr::drop_in_place", 772004, 8062)])
+
+    def test_empty_input_raises(self):
+        with self.assertRaises(RuntimeError):
+            ll.parse_table("")
+
+    def test_no_total_row_raises(self):
+        with self.assertRaises(RuntimeError):
+            ll.parse_table(
+                "  Lines                 Copies               Function name\n"
+                "  -----                 ------               -------------\n"
+                "   772004 (50.7%, 50.7%)   8062 (21.2%, 71.9%)  core::ptr::drop_in_place\n"
+            )
+
+
+class FunctionCrate(unittest.TestCase):
+    def test_plain_path(self):
+        self.assertEqual(
+            ll.function_crate("espresso_types::v0::Header::new"), "espresso_types"
+        )
+
+    def test_impl_qualifier(self):
+        self.assertEqual(
+            ll.function_crate("<alloc::vec::Vec<u8> as core::ops::Drop>::drop"),
+            "alloc",
+        )
+
+    def test_reference_self_type(self):
+        self.assertEqual(
+            ll.function_crate("<&mut alloc::vec::Vec<u8> as core::ops::Drop>::drop"),
+            "alloc",
+        )
+
+    def test_c_symbol(self):
+        self.assertEqual(ll.function_crate("memcpy"), "memcpy")
+
+    def test_bare_type_parameter_falls_back_to_the_trait(self):
+        """`T` has no crate path of its own; the blanket impl is the trait's."""
+        self.assertEqual(
+            ll.function_crate("<T as core::convert::Into<U>>::into"), "core"
+        )
+
+    def test_bare_future_type_parameter_falls_back_to_the_trait(self):
+        self.assertEqual(
+            ll.function_crate("<Fut as futures_core::future::Future>::poll"),
+            "futures_core",
+        )
+
+    def test_arrow_in_self_type_does_not_break_qualifier_matching(self):
+        """`->` is the one `>` that closes nothing; it must not end the qualifier early."""
+        self.assertEqual(
+            ll.function_crate("<fn(u8) -> u8 as core::ops::FnOnce<(u8,)>>::call_once"),
+            "core",
+        )
+
+
+class CollectMetrics(unittest.TestCase):
+    def test_crate_tally_and_totals(self):
+        metrics = ll.collect_metrics("release", TABLE_WITH_PERCENTS)
+        self.assertEqual(metrics["profile"], "release")
+        self.assertEqual(metrics["total_lines"], 1523423)
+        self.assertEqual(metrics["total_copies"], 38041)
+        self.assertEqual(metrics["crates"]["core"], {"lines": 772004, "copies": 8062})
+        self.assertEqual(
+            metrics["crates"]["futures_util"], {"lines": 112342, "copies": 11}
+        )
+        self.assertIn(
+            "<futures_util::stream::FuturesUnordered<Fut> as "
+            "futures_core::stream::Stream>::poll_next",
+            metrics["functions"],
+        )
+
+    def test_functions_capped_to_top_500(self):
+        rows = "\n".join(f"    {n}   1  fn_{n}" for n in range(1, 600))
+        text = f"  Lines Copies Function name\n  ----- ------ -------------\n  1000000 600 (TOTAL)\n{rows}\n"
+        metrics = ll.collect_metrics("test", text)
+        self.assertEqual(len(metrics["functions"]), 500)
+        self.assertIn("fn_599", metrics["functions"])
+        self.assertNotIn("fn_1", metrics["functions"])
+
+
+class FmtName(unittest.TestCase):
+    def test_pipe_escaped(self):
+        self.assertEqual(ll.fmt_name("a|b"), "`a\\|b`")
+
+
+class MergeProfiles(unittest.TestCase):
+    def test_merges_by_profile_field_not_file_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work = Path(tmp)
+            release = {"profile": "release", "total_lines": 1, "total_copies": 1}
+            test = {"profile": "test", "total_lines": 2, "total_copies": 2}
+            (work / "llvm-lines-metrics-a.json").write_text(json.dumps(release))
+            (work / "llvm-lines-metrics-b.json").write_text(json.dumps(test))
+            merged = ll.merge_profiles(sorted(work.glob("*.json")))
+        self.assertEqual(set(merged), {"release", "test"})
+        self.assertEqual(merged["release"]["total_lines"], 1)
+
+
+class Report(unittest.TestCase):
+    def _metrics(self, total_lines, total_copies, crates, functions):
+        return {
+            "profile": "release",
+            "total_lines": total_lines,
+            "total_copies": total_copies,
+            "crates": crates,
+            "functions": functions,
+        }
+
+    def test_report_without_baseline_shows_absolute_numbers(self):
+        current = {
+            "profiles": {
+                "release": self._metrics(
+                    1000,
+                    100,
+                    {"core": {"lines": 600, "copies": 50}},
+                    {"core::foo": {"lines": 600, "copies": 50}},
+                )
+            }
+        }
+        report = ll.report_markdown(current, None, "LLVM lines")
+        self.assertIn(ll.NO_BASELINE, report)
+        self.assertIn("| lines | 1,000 |", report)
+        self.assertNotIn("delta", report)
+
+    def test_report_with_baseline_shows_delta_and_missing_function(self):
+        main_metrics = self._metrics(
+            900,
+            90,
+            {"core": {"lines": 500, "copies": 40}},
+            {"core::foo": {"lines": 500, "copies": 40}},
+        )
+        current_metrics = self._metrics(
+            1000,
+            100,
+            {"core": {"lines": 600, "copies": 50}},
+            {"core::bar": {"lines": 600, "copies": 50}},
+        )
+        current = {"profiles": {"release": current_metrics}}
+        main = {"profiles": {"release": main_metrics}}
+        report = ll.report_markdown(current, main, "LLVM lines")
+        self.assertIn("| lines | 900 | 1,000 | +100 | +11.1% |", report)
+        self.assertIn("core::foo", report)
+        self.assertIn("core::bar", report)
+
+    def test_function_movers_includes_one_sided_functions(self):
+        main_metrics = self._metrics(
+            1, 1, {}, {"only_main": {"lines": 50, "copies": 1}}
+        )
+        current_metrics = self._metrics(
+            1, 1, {}, {"only_current": {"lines": 30, "copies": 1}}
+        )
+        rows = ll.function_movers(current_metrics, main_metrics)
+        names = {name for name, _, _ in rows}
+        self.assertEqual(names, {"only_main", "only_current"})
+
+    def test_movers_table_when_nothing_moved(self):
+        metrics = self._metrics(1, 1, {}, {"core::foo": {"lines": 50, "copies": 1}})
+        self.assertEqual(
+            ll.movers_table(metrics, metrics), ["No function's line count moved."]
+        )
+
+    def test_profile_missing_from_baseline_still_shows_absolute_numbers(self):
+        current = {
+            "profiles": {
+                "release": self._metrics(
+                    1000,
+                    100,
+                    {"core": {"lines": 600, "copies": 50}},
+                    {"core::foo": {"lines": 600, "copies": 50}},
+                )
+            }
+        }
+        main = {"profiles": {}}
+        report = ll.report_markdown(current, main, "LLVM lines")
+        self.assertIn("No baseline for this profile on main.", report)
+        self.assertIn("| lines | 1,000 |", report)
+        self.assertNotIn("delta", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
New llvm-lines.yml workflow builds the espresso-node bin under the test and release profiles with cargo llvm-lines, publishes a baseline artifact on main, and reports deltas against the newest main baseline in the step summary and a sticky PR comment. Runs on main pushes, workflow_dispatch, PRs touching the script or workflow, and a /llvm-lines PR comment from a trusted author.

scripts/llvm-lines mirrors scripts/compile-metrics: collect/merge/report plus a local subcommand (just llvm-lines --pr N | --rev REV | --run ID) that renders the same report from a run's artifacts.
