### PR TITLE
fix(ci): temporarily remove PR alerts on compile metrics

### DIFF
--- a/.github/actions/compile-metrics-report/action.yml
+++ b/.github/actions/compile-metrics-report/action.yml
@@ -5,10 +5,10 @@ inputs:
     description: Workflow file whose main-branch runs hold the baseline artifact
     required: true
   baseline-artifact:
-    description: Baseline artifact this workflow publishes on main; doubles as the PR comment header
+    description: Baseline artifact this workflow publishes on main
     required: true
   title:
-    description: Heading for the summary and the comment, so three reports stay distinguishable
+    description: Heading for the summary, so three reports stay distinguishable
     required: true
 runs:
   using: composite
@@ -43,38 +43,15 @@ runs:
           --max-runs 5 \
           --out main-compile-metrics.json
 
+    # Summary only. Nothing here comments on a pull request; `/compile-metrics` does that on ask.
     - name: Render summary
-      id: render
       continue-on-error: true
       shell: bash
       env:
         TITLE: ${{ inputs.title }}
       run: |
-        args=(compile-metrics.json --pr-comment-out pr-comment.md --title "$TITLE")
+        args=(compile-metrics.json --title "$TITLE")
         if [ -s main-compile-metrics.json ]; then
           args+=(--main-stats main-compile-metrics.json)
         fi
         python3 scripts/compile-metrics report "${args[@]}" >> "$GITHUB_STEP_SUMMARY"
-        # An `if:` on hashFiles() reads non-empty for an absent file inside a composite action,
-        # so whether to comment is decided here, where -f means what it says.
-        [ -f pr-comment.md ] && echo "comment=true" >> "$GITHUB_OUTPUT" \
-                             || echo "comment=false" >> "$GITHUB_OUTPUT"
-
-    # One header per workflow, or the three reporters overwrite each other's comment.
-    - name: Post/update PR comment
-      if: steps.render.outputs.comment == 'true'
-      continue-on-error: true
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        header: ${{ inputs.baseline-artifact }}
-        path: pr-comment.md
-
-    # So a comment from an earlier push goes away once the regression it reported is gone.
-    - name: Delete stale PR comment
-      if: steps.render.outputs.comment == 'false'
-      continue-on-error: true
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        header: ${{ inputs.baseline-artifact }}
-        message: "-"
-        delete: "true"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/compile-metrics-command.yml
+++ b/.github/workflows/compile-metrics-command.yml
@@ -59,8 +59,10 @@ jobs:
           header: compile-metrics-command
           message: "`/compile-metrics` failed: ${{ env.RUN_URL }}"
 
+      # cancelled() too: `cancel-in-progress` supersedes a run without either branch firing,
+      # which would leave the previous failure notice standing over a fixed pull request.
       - name: Clear a previous failure
-        if: success()
+        if: success() || cancelled()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ github.event.issue.number }}

--- a/.github/workflows/compile-metrics-command.yml
+++ b/.github/workflows/compile-metrics-command.yml
@@ -1,0 +1,53 @@
+name: Compile metrics command
+
+# `/compile-metrics` on a pull request posts every workflow's report, whether or not anything
+# crossed a threshold. The reports are rendered from artifacts the pull request's CI runs already
+# uploaded, so nothing is rebuilt.
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: compile-metrics-command-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Compile metrics
+    # `issue_comment` fires on issues too, and runs on the default branch with a writable token,
+    # so the author needs write access to the repository.
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/compile-metrics') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR: ${{ github.event.issue.number }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Acknowledge the command
+        run: |
+          gh api --method POST --silent \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            --field content=eyes
+
+      - name: Post the reports
+        run: python3 scripts/compile-metrics local --pr "$PR" --comment
+
+      # An `issue_comment` run is not among the pull request's checks, so a failure is invisible
+      # unless it says so where the command was given.
+      - name: Report a failure
+        if: failure()
+        run: |
+          gh pr comment "$PR" --body \
+            "\`/compile-metrics\` failed: $RUN_URL"

--- a/.github/workflows/compile-metrics-command.yml
+++ b/.github/workflows/compile-metrics-command.yml
@@ -11,7 +11,9 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  # The other three reporters post their sticky comment under this; the failure reporter here
+  # must not be the one step that turns out to lack a permission.
+  pull-requests: write
 
 concurrency:
   group: compile-metrics-command-${{ github.event.issue.number }}
@@ -33,6 +35,9 @@ jobs:
       PR: ${{ github.event.issue.number }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+      # No `ref`: an `issue_comment` run gets the default branch, which is what keeps a pull
+      # request from running its own code with a writable token. So the reports render with
+      # main's thresholds, not the branch's.
       - uses: actions/checkout@v6
 
       - name: Acknowledge the command
@@ -45,9 +50,20 @@ jobs:
         run: python3 scripts/compile-metrics local --pr "$PR" --comment
 
       # An `issue_comment` run is not among the pull request's checks, so a failure is invisible
-      # unless it says so where the command was given.
+      # unless it says so where the command was given. Sticky, or every retry piles up another.
       - name: Report a failure
         if: failure()
-        run: |
-          gh pr comment "$PR" --body \
-            "\`/compile-metrics\` failed: $RUN_URL"
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.issue.number }}
+          header: compile-metrics-command
+          message: "`/compile-metrics` failed: ${{ env.RUN_URL }}"
+
+      - name: Clear a previous failure
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.issue.number }}
+          header: compile-metrics-command
+          message: "-"
+          delete: "true"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -106,3 +106,14 @@ jobs:
 
       - name: Check generated API code is up to date
         run: git diff --exit-code -- crates/espresso/api/src/generated
+
+  python-tests:
+    name: python tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # `scripts/compile-metrics` and `scripts/nextest-ci` decide what CI reports and what it
+      # alerts on, and neither was covered by any workflow.
+      - name: Run the script tests
+        run: python3 -m unittest discover -s scripts -p "test_*.py" --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -107,13 +107,16 @@ jobs:
       - name: Check generated API code is up to date
         run: git diff --exit-code -- crates/espresso/api/src/generated
 
-  python-tests:
-    name: python tests
+  python:
+    name: python
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@just
 
       # `scripts/compile-metrics` and `scripts/nextest-ci` decide what CI reports and what it
-      # alerts on, and neither was covered by any workflow.
+      # alerts on, and no workflow ran their tests. `py::lint` and `py::check` still do not run
+      # here: both need a tool installed, and nextest-ci has lint violations that belong in
+      # their own change.
       - name: Run the script tests
-        run: python3 -m unittest discover -s scripts -p "test_*.py" --verbose
+        run: just py::test

--- a/.github/workflows/slowtest.yaml
+++ b/.github/workflows/slowtest.yaml
@@ -136,7 +136,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -604,7 +604,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 

--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -34,7 +34,8 @@ Alerting:
 
     Gated rows break down a section that moved. They alert only when a section of the same
     binary regressed, since a crate's slice or a generic's count grows whenever code moves
-    between crates, including in a binary that shrank.
+    between crates, including in a binary that shrank. Only the largest crates and generic bases
+    of each binary are recorded, so a small one has no row to move.
 
     Section sizes are the only size metric that is both reproducible and about code. An identical
     tree gives identical bytes, so their band is narrow. A file size and a symbol count are
@@ -119,20 +120,20 @@ UNIT_MIN_S = 20.0
 PEAK_USED_PCT = 15.0
 PEAK_RSS_PCT = 10.0
 BINARY_PCT = 5.0
-TEXT_PCT = 2.0
-TEXT_MIN_BYTES = 100 * 1024
+SECTION_PCT = 2.0
+SECTION_MIN_BYTES = 100 * 1024
 CRATE_BYTES_MIN = 256 * 1024
 CRATE_BYTES_DELTA = 64 * 1024
 INSTANTIATIONS_MIN = 50
 INSTANTIATIONS_DELTA = 100
 TOP_CRATES = 25
 TOP_BASES = 25
-# Recorded as `<name>_bytes`.
+# Recorded as `<name>_bytes`, and reported under the section name itself.
 SECTIONS = (".text", ".rodata")
-SIZE_METRICS = tuple(f"{name.lstrip('.')}_bytes" for name in SECTIONS)
+SECTION_FIELDS = tuple(f"{name.removeprefix('.')}_bytes" for name in SECTIONS)
 # Metric families, in reading order. The per-family caps bound the whole comment: a Cargo.lock
 # bump moves hundreds of rows at once, against GitHub's 65 kB limit on a comment body.
-FAMILIES = ("cpu-s", "bytes", *SIZE_METRICS, "symbols", "crate bytes", "instantiations")
+FAMILIES = ("cpu-s", "bytes", *SECTIONS, "symbols", "crate bytes", "instantiations")
 FAMILY_ROWS = 6
 FAMILY_IMPROVEMENTS = 3
 RED = " 🔴"
@@ -167,11 +168,14 @@ JOB_METRICS = (
     ("critical_path_s", "critical path s", CRITICAL_PATH_PCT),
 )
 JOB_COLUMNS = [column for _, column, _ in JOB_METRICS]
-# Whole-binary metrics, as (field, regression threshold in %, absolute floor).
+# Whole-binary metrics, as (artifact field, reported name, threshold in %, absolute floor).
 BINARY_METRICS = (
-    ("bytes", BINARY_PCT, 0),
-    *((metric, TEXT_PCT, TEXT_MIN_BYTES) for metric in SIZE_METRICS),
-    ("symbols", BINARY_PCT, 0),
+    ("bytes", "bytes", BINARY_PCT, 0),
+    *(
+        (field, section, SECTION_PCT, SECTION_MIN_BYTES)
+        for field, section in zip(SECTION_FIELDS, SECTIONS)
+    ),
+    ("symbols", "symbols", BINARY_PCT, 0),
 )
 
 
@@ -867,12 +871,12 @@ def binary_changes(
     """
     changes = []
     sizes = []
-    for metric, threshold, floor in BINARY_METRICS:
-        if metric not in was or metric not in now:
+    for key, metric, threshold, floor in BINARY_METRICS:
+        if key not in was or key not in now:
             continue
-        change = Change(job, binary, metric, was[metric], now[metric], threshold, floor)
+        change = Change(job, binary, metric, was[key], now[key], threshold, floor)
         changes.append(change)
-        if metric in SIZE_METRICS:
+        if metric in SECTIONS:
             sizes.append(change)
     if not sizes:
         # Nothing alerts on this binary at all, so say so rather than let it go unwatched.
@@ -921,7 +925,7 @@ def fmt_value(value: float) -> str:
 def fmt_metric(metric: str, value: float) -> str:
     if metric in ("peak memory", "largest process"):
         return fmt_bytes(value * 1024)
-    if metric in ("bytes", "crate bytes", *SIZE_METRICS):
+    if metric in ("bytes", "crate bytes", *SECTIONS):
         return fmt_bytes(value)
     return fmt_value(value)
 
@@ -1041,7 +1045,7 @@ def family_tables(changes: list[Change]) -> list[str]:
         band = f"{shown[0].change.threshold_pct:g} %"
         alerts = sum(1 for row in regressions if row.change.alerting_regression)
         counts = (
-            (alerts, "over threshold"),
+            (alerts, f"{'row' if alerts == 1 else 'rows'} over threshold"),
             (len(regressions) - alerts, f"up by more than {band}"),
             (len(improvements), f"down by more than {band}"),
         )
@@ -1140,15 +1144,15 @@ def state_tables(current: dict[str, Any]) -> list[str]:
     if binaries:
         lines += [
             "",
-            "| binary | size | `.text` | symbols |",
-            "|---|---:|---:|---:|",
+            "| binary | size | " + " | ".join(f"`{s}`" for s in SECTIONS) + " |",
+            "|---|---:" + "|---:" * len(SECTIONS) + "|",
         ]
         for _, name, sizes in binaries:
-            lines.append(
-                f"| {fmt_name(name)} | {fmt_bytes(sizes['bytes'])} "
-                f"| {fmt_bytes(sizes['text_bytes'])} "
-                f"| {sizes['symbols']:,} |"
+            cells = "".join(
+                f"| {fmt_bytes(sizes[field])} " if field in sizes else "| n/a "
+                for field in SECTION_FIELDS
             )
+            lines.append(f"| {fmt_name(name)} | {fmt_bytes(sizes['bytes'])} {cells}|")
         lines += instantiation_table([(name, sizes) for _, name, sizes in binaries])
 
     units = sorted(
@@ -1188,8 +1192,8 @@ def comparison_tables(changes: list[Change]) -> list[str]:
         return ["No job in this run has a counterpart in the baseline run."]
     alerts = alert_causes(changes)
     lines = [
-        f"**{len(alerts)} over threshold** (section +{TEXT_PCT:g}% and "
-        f"{fmt_bytes(TEXT_MIN_BYTES)}, crate +{BINARY_PCT:g}% and "
+        f"**{len(alerts)} over threshold** (section +{SECTION_PCT:g}% and "
+        f"{fmt_bytes(SECTION_MIN_BYTES)}, crate +{BINARY_PCT:g}% and "
         f"{fmt_bytes(CRATE_BYTES_DELTA)}, generic +{BINARY_PCT:g}% and "
         f"{INSTANTIATIONS_DELTA}, peak memory +{PEAK_USED_PCT:g}%, largest process "
         f"+{PEAK_RSS_PCT:g}%). One count per regression, however many binaries and "

--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -38,7 +38,9 @@ Alerting:
     of each binary are recorded, so a small one has no row to move.
 
     Section sizes are the only size metric that is both reproducible and about code. An identical
-    tree gives identical bytes, so their band is narrow. A file size and a symbol count are
+    tree gives identical bytes. The floor does most of the work: a percentage alone fires on
+    whichever binary is smallest rather than on whichever change is largest, and one change adds
+    the same code to a utility binary and to the node. A file size and a symbol count are
     reproducible too but track the symbol table, which moves with the dependency graph while the
     code holds still. Timing is wall time under whatever parallelism, runner and dependency cache
     the job drew, and moves by tens of percent between runs of an identical tree.
@@ -121,7 +123,7 @@ PEAK_USED_PCT = 15.0
 PEAK_RSS_PCT = 10.0
 BINARY_PCT = 5.0
 SECTION_PCT = 2.0
-SECTION_MIN_BYTES = 100 * 1024
+SECTION_MIN_BYTES = 1024 * 1024
 CRATE_BYTES_MIN = 256 * 1024
 CRATE_BYTES_DELTA = 64 * 1024
 INSTANTIATIONS_MIN = 50

--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -15,11 +15,13 @@ per package across the whole build, so a feature enabled on one leaf crate is co
 build that reaches it; the diff against main is the only visible sign of it.
 
 Alerting:
-    Every run writes a report to its step summary. It becomes a pull request comment only when a
-    metric that alerts crosses its band. The bands and floors are the constants below, and the
+    Every run writes a report to its step summary. Nothing comments on a pull request on its
+    own: the numbers are worth tracking before they are worth interrupting anyone over, so
+    `/compile-metrics` posts a report on ask. What a metric alerting decides is the red mark and
+    the count in the report's header. The bands and floors are the constants below, and the
     report prints the live ones.
 
-    metric            alerts  measures
+    metric            marked  measures
     ----------------  ------  ----------------------------------------------
     peak memory       yes     the whole box, shared with other processes
     largest process   yes     one rustc process
@@ -45,8 +47,7 @@ Alerting:
     code holds still. Timing is wall time under whatever parallelism, runner and dependency cache
     the job drew, and moves by tens of percent between runs of an identical tree.
 
-    A comment counts one regression per crate or binary, however many jobs carry it, and is
-    deleted once the regression is gone. `/compile-metrics` posts every report regardless.
+    The header counts one regression per crate or binary, however many jobs carry it.
 
 Examples:
     # Wrap the build to record its peak memory.
@@ -70,8 +71,8 @@ Examples:
     scripts/compile-metrics local --rev main
     scripts/compile-metrics local --run 33374493992
 
-    # The same reports, posted to the pull request even when nothing crossed a threshold. This is
-    # what commenting `/compile-metrics` on a pull request runs.
+    # The same reports, posted to the pull request. This is what commenting `/compile-metrics`
+    # on a pull request runs.
     scripts/compile-metrics local --pr 4888 --comment
 """
 
@@ -1204,10 +1205,9 @@ def comparison_tables(changes: list[Change]) -> list[str]:
         else "No binary or memory metric over threshold.",
         "",
         (
-            "Section sizes and memory post a comment. Timing moves by tens of percent between "
+            "Only section sizes and memory are marked. Timing moves by tens of percent between "
             "runs of the same tree. A file size and a symbol count are mostly symbol table. A "
-            "crate or generic row breaks down a section, and speaks only when one regressed. "
-            "Comment `/compile-metrics` to have every report posted regardless."
+            "crate or generic row breaks down a section, and is marked only when one regressed."
         ),
         "",
         "| job | " + " | ".join(JOB_COLUMNS) + " |",
@@ -1343,10 +1343,9 @@ def newest_main_run(stats: dict[str, Any]) -> dict[str, Any] | None:
 
 def report_markdown(
     current: dict[str, Any], main: dict[str, Any] | None, title: str
-) -> tuple[str, bool]:
-    """The report, and whether an alerting metric crossed its threshold; see UNALERTED."""
+) -> str:
     changes = compare(main, current) if main else []
-    return render(main, current, changes, title), bool(alert_causes(changes))
+    return render(main, current, changes, title)
 
 
 def cmd_report(args: argparse.Namespace) -> int:
@@ -1356,13 +1355,7 @@ def cmd_report(args: argparse.Namespace) -> int:
         if args.main_stats
         else None
     )
-    summary, alerting = report_markdown(current, main, args.title)
-    print(summary)
-    # The step summary always carries the full table. A PR comment notifies everyone watching the
-    # PR, so it is written only when an alerting metric crossed its threshold. The workflow tests
-    # for the file with -f and deletes any stale comment when it is absent, so absent, not empty.
-    if args.pr_comment_out and alerting:
-        args.pr_comment_out.write_text(summary)
+    print(report_markdown(current, main, args.title))
     return 0
 
 
@@ -1403,7 +1396,7 @@ def cmd_local(args: argparse.Namespace) -> int:
                 raise RuntimeError(f"run {target.run_id}: metrics artifacts vanished")
             current = merged_metrics(artifacts, target.sha, target.url)
             main = fetch_baseline(target.workflow, target.baseline, work / "main.json")
-        summary, _ = report_markdown(current, main, target.title)
+        summary = report_markdown(current, main, target.title)
         reported += 1
         if pr:
             post_sticky(pr, target.baseline, summary)
@@ -1426,9 +1419,9 @@ def comment_target(args: argparse.Namespace) -> int:
 
 
 def sticky_marker(header: str) -> str:
-    """The marker `marocchino/sticky-pull-request-comment` writes, so the two paths share one
-    comment. Only in CI, where both are `github-actions[bot]`: that action matches on author too,
-    so a shell run posts as the developer and the next push opens a second comment beside it.
+    """The marker `marocchino/sticky-pull-request-comment` writes, which is what the workflows
+    posted through before they stopped commenting. Keeping it means an on-demand report replaces
+    a comment left over from then rather than sitting beside it.
     """
     return f"<!-- Sticky Pull Request Comment{header} -->"
 
@@ -1716,13 +1709,8 @@ def main(argv: list[str]) -> int:
     report.add_argument(
         "--title",
         default="Compile metrics",
-        help="heading for the summary and the comment; distinguishes one workflow's report "
-        "from another's when several post to the same pull request",
-    )
-    report.add_argument(
-        "--pr-comment-out",
-        type=Path,
-        help="write the comment body here, but only if an alerting metric crossed its threshold",
+        help="heading for the summary; distinguishes one workflow's report from another's when "
+        "several land on the same pull request",
     )
     report.set_defaults(func=cmd_report)
 
@@ -1745,9 +1733,8 @@ def main(argv: list[str]) -> int:
     local.add_argument(
         "--comment",
         action="store_true",
-        help="post each report to the pull request instead of stdout, whether or not anything "
-        "crossed a threshold; updates the comment the workflow posts, and so is deleted again "
-        "by the next push that finds nothing over threshold",
+        help="post each report to the pull request instead of stdout, one sticky comment per "
+        "workflow",
     )
     local.set_defaults(func=cmd_local)
 

--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -139,6 +139,7 @@ SECTION_FIELDS = tuple(f"{name.removeprefix('.')}_bytes" for name in SECTIONS)
 FAMILIES = ("cpu-s", "bytes", *SECTIONS, "symbols", "crate bytes", "instantiations")
 FAMILY_ROWS = 6
 FAMILY_IMPROVEMENTS = 3
+WORKFLOW_BOT = "github-actions[bot]"
 RED = " 🔴"
 GREEN = " 🟢"
 # A denylist rather than an allowlist, so a metric added later is loud by default instead of
@@ -1454,17 +1455,44 @@ def post_sticky(pr: int, header: str, body: str) -> None:
 
 
 def sticky_comment(pr: int, marker: str) -> str | None:
-    """The id of the comment carrying `marker`, or None. One id per page, so lines, not JSON."""
-    ids = capture(
+    """The id of the comment carrying `marker`, or None. One row per page, so lines, not JSON."""
+    rows = capture(
         "gh",
         "api",
         "--paginate",
         f"repos/{{owner}}/{{repo}}/issues/{pr}/comments",
         "--jq",
-        f".[] | select(.body | contains({json.dumps(marker)})) | .id",
-    ).split()
+        f".[] | select(.body | contains({json.dumps(marker)}))"
+        r' | "\(.id) \(.user.login)"',
+    )
+    return pick_sticky(rows, sticky_owners())
+
+
+def pick_sticky(rows: str, owners: set[str]) -> str | None:
+    """The newest comment carrying the marker that one of `owners` wrote.
+
+    Matching on the body alone is not enough to know a comment is ours to edit. GitHub's
+    quote-reply copies the raw markdown of whatever it quotes, and the marker is an HTML comment,
+    so a person quoting a report leaves a comment that carries it. Editing that would overwrite
+    what they wrote, and a maintainer's token is allowed to.
+    """
+    ours = [
+        row.split(" ", 1)[0]
+        for row in rows.splitlines()
+        if row and row.split(" ", 1)[-1] in owners
+    ]
     # The newest, for the duplicate the docstring anticipates: the stale one is the older.
-    return ids[-1] if ids else None
+    return ours[-1] if ours else None
+
+
+def sticky_owners() -> set[str]:
+    """Whoever is running this, plus the bot that posted these reports before it did."""
+    owners = {WORKFLOW_BOT}
+    try:
+        owners.add(capture("gh", "api", "user", "--jq", ".login"))
+    except RuntimeError as error:
+        log.debug("no viewer login, editing only %s comments: %s", WORKFLOW_BOT, error)
+    return owners
 
 
 def targets(pr: int | None, rev: str | None, run: int | None) -> list[Target]:
@@ -1477,14 +1505,13 @@ def targets(pr: int | None, rev: str | None, run: int | None) -> list[Target]:
     """
     if run:
         return [run_target(run)]
-    selector = (
-        ["--commit", capture("git", "rev-parse", rev)]
-        if rev
-        else ["--branch", pr_branch(pr)]
-    )
+    if rev:
+        selector, allowed = ["--commit", capture("git", "rev-parse", rev)], None
+    else:
+        selector, allowed = ["--branch", pr_branch(pr)], pr_commits(pr)
     found = []
     for workflow, baseline, title in WORKFLOWS:
-        newest = newest_with_metrics(workflow, selector)
+        newest = newest_with_metrics(workflow, selector, allowed)
         if newest is None:
             log.info("%s: no run with metrics artifacts", workflow)
             continue
@@ -1505,6 +1532,16 @@ def pr_branch(pr: int | None) -> str:
     return pr_field(pr, "headRefName")
 
 
+def pr_commits(pr: int | None) -> set[str]:
+    """The commits the branch selector is allowed to match.
+
+    A branch name is not unique across repositories. A pull request from a fork whose branch is
+    called `main` lists this repository's own main runs, and those would be reported as the pull
+    request's numbers: a main-versus-main comparison wearing the pull request's name.
+    """
+    return {commit["oid"] for commit in pr_field(pr, "commits")}
+
+
 def pr_number(pr: int | None) -> int:
     return int(pr_field(pr, "number"))
 
@@ -1514,7 +1551,9 @@ def pr_field(pr: int | None, field_name: str) -> Any:
     return json.loads(capture(*view, "--json", field_name))[field_name]
 
 
-def newest_with_metrics(workflow: str, selector: list[str]) -> dict[str, Any] | None:
+def newest_with_metrics(
+    workflow: str, selector: list[str], allowed: set[str] | None = None
+) -> dict[str, Any] | None:
     """The newest matching run whose artifacts are still there.
 
     The newest run is often not reportable: a push starts one whose build has not uploaded yet,
@@ -1535,7 +1574,15 @@ def newest_with_metrics(workflow: str, selector: list[str]) -> dict[str, Any] | 
             "databaseId,url,headSha",
         )
     )
-    return next((run for run in runs if has_metrics(run["databaseId"])), None)
+    return next(
+        (
+            run
+            for run in runs
+            if (allowed is None or run["headSha"] in allowed)
+            and has_metrics(run["databaseId"])
+        ),
+        None,
+    )
 
 
 def has_metrics(run_id: int) -> bool:

--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -16,35 +16,31 @@ build that reaches it; the diff against main is the only visible sign of it.
 
 Alerting:
     Every run writes a report to its step summary. It becomes a pull request comment only when a
-    metric that alerts crosses its band. Bands and floors are the constants below; the report
-    prints the live ones.
+    metric that alerts crosses its band. The bands and floors are the constants below, and the
+    report prints the live ones.
 
-    metric            alerts  band              measures
-    ----------------  ------  ----------------  --------------------------------------------
-    peak memory       yes     +15 %             the whole box, shared with other processes
-    largest process   yes     +10 %             one rustc process
-    .text, .rodata    yes     +2 %, 100 kB      the code, and the tables it reads
-    crate bytes       gated   +5 %, 64 kB       one crate's symbols, in every section
-    instantiations    gated   +5 %, 100         one generic's copies
-    file bytes        no      +5 %              debug info in test builds, `.symtab` in release
-    symbols           no      +5 %              `.symtab` entries, most of them not code
-    workspace cpu-s   no      +10 %             the job's summed unit time
-    critical path s   no      +10 %             the longest dependency chain
-    unit cpu-s        no      +15 %, over 20 s  one crate, under whatever parallelism it got
+    metric            alerts  measures
+    ----------------  ------  ----------------------------------------------
+    peak memory       yes     the whole box, shared with other processes
+    largest process   yes     one rustc process
+    .text, .rodata    yes     the code, and the tables it reads
+    crate bytes       gated   one crate's symbols, in every section
+    instantiations    gated   one generic's copies
+    file bytes        no      debug info in test builds, `.symtab` in release
+    symbols           no      `.symtab` entries, most of them not code
+    workspace cpu-s   no      the job's summed unit time
+    critical path s   no      the longest dependency chain
+    unit cpu-s        no      one crate, under whatever parallelism it got
 
     Gated rows break down a section that moved. They alert only when a section of the same
-    binary regressed.
+    binary regressed, since a crate's slice or a generic's count grows whenever code moves
+    between crates, including in a binary that shrank.
 
-    Measurements the table rests on:
-
-    - 4892 changed no Rust. Workspace cpu moved -10.5 % to +21.1 %, single units +65.0 % and
-      -59.7 %.
-    - Two main runs differing only in this script. Every size metric moved 0.00 %.
-    - 4896 shrank every binary it touched by 13 % to 17 %, and reported ten regressions: nine
-      slices of those binaries, one `keygen` symbol count against a byte-identical `.text`.
-    - 4890 release binaries held `.text` between +0.00 % and -1.00 % while symbol counts rose
-      32 % to 34 % and files 13 % to 15 %. There is no `[profile.release]` override, so release
-      carries no DWARF and a full `.symtab`, which is what `nm` counts.
+    Section sizes are the only size metric that is both reproducible and about code. An identical
+    tree gives identical bytes, so their band is narrow. A file size and a symbol count are
+    reproducible too but track the symbol table, which moves with the dependency graph while the
+    code holds still. Timing is wall time under whatever parallelism, runner and dependency cache
+    the job drew, and moves by tens of percent between runs of an identical tree.
 
     A comment counts one regression per crate or binary, however many jobs carry it, and is
     deleted once the regression is gone. `/compile-metrics` posts every report regardless.

--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -35,6 +35,10 @@ Examples:
     scripts/compile-metrics local --pr 4888
     scripts/compile-metrics local --rev main
     scripts/compile-metrics local --run 33374493992
+
+    # The same reports, posted to the pull request even when nothing crossed a threshold. This is
+    # what commenting `/compile-metrics` on a pull request runs.
+    scripts/compile-metrics local --pr 4888 --comment
 """
 
 import argparse
@@ -76,34 +80,50 @@ ARROW = "\x00"
 LEGACY_HASH_RE = re.compile(r"::h[0-9a-f]{16}$")
 EMPTY_PATH_RE = re.compile(r"::(::)+")
 
-# Thresholds, for deciding which rows are worth a table row. Only the binary metrics decide
-# whether anything is worth a pull request comment; see ALERTING.
+# Thresholds, for deciding which rows are worth a table row. Which of them post a pull request
+# comment is a separate question; see UNALERTED and `Change.alerts`.
 WORKSPACE_CPU_PCT = 10.0
 CRITICAL_PATH_PCT = 10.0
 UNIT_CPU_PCT = 15.0
 UNIT_MIN_S = 20.0
+# Peak memory of the whole box, against the largest single process. The box competes with
+# whatever else the runner is doing: on a tree with no Rust change at all it moved 7.3 % while
+# the largest rustc stayed within 2.8 %, so it gets the wider band.
+PEAK_USED_PCT = 15.0
 PEAK_RSS_PCT = 10.0
 BINARY_PCT = 5.0
+# `.text` is the only size metric that tracks code. It is bit-reproducible across runs of the
+# same tree, and a refactor that cut a crate's contribution by 47 % moved it 2.4 %, so its band
+# is narrow and backed by an absolute floor rather than left at BINARY_PCT.
+TEXT_PCT = 2.0
+TEXT_MIN_BYTES = 100 * 1024
 CRATE_BYTES_MIN = 256 * 1024
+CRATE_BYTES_DELTA = 64 * 1024
 INSTANTIATIONS_MIN = 50
+INSTANTIATIONS_DELTA = 100
 TOP_CRATES = 25
 TOP_BASES = 25
-# Metric families, in reading order. Compile cost first, then what the binary weighs. The
-# per-family caps bound the whole comment: a Cargo.lock bump moves hundreds of rows at once, and
-# a comment that long is unreadable and runs into GitHub's 65 kB limit on a comment body.
-FAMILIES = ("cpu-s", "bytes", "text_bytes", "symbols", "instantiations")
+# Metric families, in reading order. Compile cost first, then what the binary weighs, then the
+# breakdown that says why it weighs it. The per-family caps bound the whole comment: a Cargo.lock
+# bump moves hundreds of rows at once, and a comment that long is unreadable and runs into
+# GitHub's 65 kB limit on a comment body.
+FAMILIES = ("cpu-s", "bytes", "text_bytes", "symbols", "crate bytes", "instantiations")
 FAMILY_ROWS = 6
 FAMILY_IMPROVEMENTS = 3
 RED = " 🔴"
 GREEN = " 🟢"
+# What is reported and ranked but never posts a comment. The list names what stays quiet rather
+# than what speaks, so a metric added later is loud by default instead of silently unwatched.
+#
 # Timing is measured under whatever parallelism, runner and dependency cache the job happened to
 # draw, and the spread swamps the effect: pull request 4892 changed no Rust at all, yet its
 # per-job workspace cpu moved from -10.5 % to +21.1 % and single units moved +65.0 % and -59.7 %.
-# No band separates that from a real change, so timing is reported and ranked but never posts a
-# comment. Everything else does, which is also why this list names what stays quiet rather than
-# what speaks: a metric added later is loud by default instead of silently unwatched. Memory is
-# not in it because it holds still, within 3.2 % across the jobs of that same unchanged tree.
-UNALERTED = ("cpu-s", "workspace cpu-s", "critical path s")
+#
+# A binary's file size and symbol count are quiet for the opposite reason. Both are reproducible,
+# and both measure the debug information rather than the code: pull request 4896 cut
+# espresso-node's `.text` by 1.5 MB while the file shrank by 100 MB, and left `keygen` with a
+# byte-identical `.text` and 7,252 more symbols. `.text` alerts in their place.
+UNALERTED = ("cpu-s", "workspace cpu-s", "critical path s", "bytes", "symbols")
 TOP_BINARIES = 10
 TOP_UNITS = 20
 TOP_FEATURE_ROWS = 25
@@ -125,12 +145,19 @@ NO_FEATURE_RECORD = "no feature record in both runs"
 # Per-job metrics, as (field, column, regression threshold in %). The report compares these
 # against main and gives each its own column; everything else lands in the movers table.
 JOB_METRICS = (
-    ("peak_used_kb", "peak memory", PEAK_RSS_PCT),
+    ("peak_used_kb", "peak memory", PEAK_USED_PCT),
     ("peak_rss_kb", "largest process", PEAK_RSS_PCT),
     ("workspace_cpu_s", "workspace cpu-s", WORKSPACE_CPU_PCT),
     ("critical_path_s", "critical path s", CRITICAL_PATH_PCT),
 )
 JOB_COLUMNS = [column for _, column, _ in JOB_METRICS]
+# Whole-binary metrics, as (field, regression threshold in %, absolute floor).
+TEXT_METRIC = "text_bytes"
+BINARY_METRICS = (
+    ("bytes", BINARY_PCT, 0),
+    (TEXT_METRIC, TEXT_PCT, TEXT_MIN_BYTES),
+    ("symbols", BINARY_PCT, 0),
+)
 
 
 @dataclass(frozen=True)
@@ -141,6 +168,8 @@ class Change:
     main: float
     current: float
     threshold_pct: float
+    min_delta: float = 0.0
+    quiet: bool = False
 
     @property
     def delta_pct(self) -> float:
@@ -159,7 +188,19 @@ class Change:
 
     @property
     def alerts(self) -> bool:
-        return self.metric not in UNALERTED
+        """Whether crossing the band is worth a pull request comment.
+
+        `min_delta` keeps a percentage off a small number quiet: 148 -> 156 instantiations is
+        +5.4 %, and eight of anything in a binary of a third of a million symbols is nothing.
+        `quiet` is set by whoever built the row, for a metric whose band alone does not decide.
+        """
+        if self.quiet or self.metric in UNALERTED:
+            return False
+        return abs(self.current - self.main) >= self.min_delta
+
+    @property
+    def alerting_regression(self) -> bool:
+        return self.regressed and self.alerts
 
 
 @dataclass(frozen=True)
@@ -792,50 +833,67 @@ def compare(main: dict[str, Any], current: dict[str, Any]) -> list[Change]:
                 changes.append(Change(job, unit, "cpu-s", was, cpu, UNIT_CPU_PCT))
         for binary, sizes in now.get("binaries", {}).items():
             was_sizes = before.get("binaries", {}).get(binary)
-            if was_sizes is None:
-                continue
-            for metric in ("bytes", "text_bytes", "symbols"):
-                if metric not in was_sizes or metric not in sizes:
-                    continue
-                changes.append(
-                    Change(
-                        job,
-                        binary,
-                        metric,
-                        was_sizes[metric],
-                        sizes[metric],
-                        BINARY_PCT,
-                    )
+            if was_sizes is not None:
+                changes += binary_changes(job, binary, was_sizes, sizes)
+    return changes
+
+
+def binary_changes(
+    job: str, binary: str, was: dict[str, Any], now: dict[str, Any]
+) -> list[Change]:
+    """One binary's totals, then the breakdown that says where the total went.
+
+    A crate's slice of the binary and a generic's instantiation count exist to answer "why did
+    `.text` grow", so they are quiet unless it did. Pull request 4896 is what the gate is for: it
+    shrank every binary it touched by 13 % to 17 %, and still reported ten regressions, all of
+    them slices of those same binaries.
+    """
+    changes = []
+    text = None
+    for metric, threshold, floor in BINARY_METRICS:
+        if metric not in was or metric not in now:
+            continue
+        change = Change(job, binary, metric, was[metric], now[metric], threshold, floor)
+        changes.append(change)
+        if metric == TEXT_METRIC:
+            text = change
+    if text is None:
+        # Nothing alerts on this binary at all, so say so rather than let it go unwatched.
+        log.warning("%s/%s: no %s in both runs", job, binary, TEXT_METRIC)
+    quiet = text is None or not text.alerting_regression
+    for crate, crate_size in now.get("crate_bytes", {}).items():
+        was_crate = was.get("crate_bytes", {}).get(crate)
+        if was_crate is not None and was_crate >= CRATE_BYTES_MIN:
+            changes.append(
+                Change(
+                    job,
+                    f"{binary}: {crate}",
+                    "crate bytes",
+                    was_crate,
+                    crate_size,
+                    BINARY_PCT,
+                    CRATE_BYTES_DELTA,
+                    quiet,
                 )
-            for crate, crate_size in sizes.get("crate_bytes", {}).items():
-                was_crate = was_sizes.get("crate_bytes", {}).get(crate)
-                if was_crate is not None and was_crate >= CRATE_BYTES_MIN:
-                    changes.append(
-                        Change(
-                            job,
-                            f"{binary}: {crate}",
-                            "bytes",
-                            was_crate,
-                            crate_size,
-                            BINARY_PCT,
-                        )
-                    )
-            # Only the top TOP_BASES bases are recorded, so a base that was outside the baseline's
-            # top list has nothing to compare against and produces no row; the binary's symbol
-            # count still moves. The minimum count keeps a base going 2 -> 3 out of the table.
-            for base, count in sizes.get("instantiations", {}).items():
-                was_count = was_sizes.get("instantiations", {}).get(base)
-                if was_count is not None and was_count >= INSTANTIATIONS_MIN:
-                    changes.append(
-                        Change(
-                            job,
-                            f"{binary}: {base}",
-                            "instantiations",
-                            was_count,
-                            count,
-                            BINARY_PCT,
-                        )
-                    )
+            )
+    # Only the top TOP_BASES bases are recorded, so a base that was outside the baseline's top
+    # list has nothing to compare against and produces no row; the binary's symbol count still
+    # moves. The minimum count keeps a base going 2 -> 3 out of the table.
+    for base, count in now.get("instantiations", {}).items():
+        was_count = was.get("instantiations", {}).get(base)
+        if was_count is not None and was_count >= INSTANTIATIONS_MIN:
+            changes.append(
+                Change(
+                    job,
+                    f"{binary}: {base}",
+                    "instantiations",
+                    was_count,
+                    count,
+                    BINARY_PCT,
+                    INSTANTIATIONS_DELTA,
+                    quiet,
+                )
+            )
     return changes
 
 
@@ -846,7 +904,7 @@ def fmt_value(value: float) -> str:
 def fmt_metric(metric: str, value: float) -> str:
     if metric in ("peak memory", "largest process"):
         return fmt_bytes(value * 1024)
-    if metric in ("bytes", "text_bytes"):
+    if metric in ("bytes", "text_bytes", "crate bytes"):
         return fmt_bytes(value)
     return fmt_value(value)
 
@@ -952,16 +1010,21 @@ def family_tables(changes: list[Change]) -> list[str]:
         )
         # The count is only the rows past the band, so for a family that does not alert the
         # band has to be said: "3 up" reads as three units getting slower when three hundred
-        # may have moved by less.
+        # may have moved by less. A family is mixed when the gate opened for one binary and not
+        # another, and then only the rows that alert may be counted as alerts.
         band = f"{shown[0].change.threshold_pct:g} %"
-        alerting = metric not in UNALERTED
-        moved = "over threshold" if alerting else f"up by more than {band}"
-        down = "improved" if alerting else f"down by more than {band}"
-        summary = (
-            f"**{metric}**: {len(regressions)} {moved}, {len(improvements)} {down}."
+        alerts = sum(1 for row in regressions if row.change.alerting_regression)
+        counts = (
+            (alerts, "over threshold"),
+            (len(regressions) - alerts, f"up by more than {band}"),
+            (len(improvements), f"down by more than {band}"),
+        )
+        summary = f"**{metric}**: " + ", ".join(
+            f"{count} {label}" for count, label in counts if count
         )
         if dropped:
-            summary += f" {dropped} rows not shown."
+            summary += f". {dropped} rows not shown"
+        summary += "."
         lines += ["", summary, ""] + mover_table(shown)
     return lines
 
@@ -1085,21 +1148,37 @@ def fmt_cell(change: Change) -> str:
     )
 
 
+def alert_causes(changes: list[Change]) -> set[tuple[str, str]]:
+    """The distinct regressions worth a comment, counted once however many binaries carry them.
+
+    A crate that grew is one finding, but it grows in every binary that links it, in every job
+    that builds one: `hashbrown` alone accounted for three of pull request 4896's ten.
+    """
+    return {
+        (change.metric, change.name.partition(": ")[2] or change.name)
+        for change in changes
+        if change.regressed and change.alerts
+    }
+
+
 def comparison_tables(changes: list[Change]) -> list[str]:
     if not changes:
         return ["No job in this run has a counterpart in the baseline run."]
-    # Collapsed, because every table below counts merged groups; a header counting raw rows
-    # would read as though findings had been hidden.
-    alerts = collapse([c for c in changes if c.regressed and c.alerts])
+    alerts = alert_causes(changes)
     lines = [
-        f"**{len(alerts)} over threshold** "
-        f"(binary +{BINARY_PCT:g}%, memory +{PEAK_RSS_PCT:g}%)."
+        f"**{len(alerts)} over threshold** (`.text` +{TEXT_PCT:g}%, peak memory "
+        f"+{PEAK_USED_PCT:g}%, largest process +{PEAK_RSS_PCT:g}%, crate and generic "
+        f"+{BINARY_PCT:g}%). One count per regression, however many binaries and jobs "
+        "carry it."
         if alerts
         else "No binary or memory metric over threshold.",
         "",
         (
-            "Timing is reported below but never posts a pull request comment: it moves by tens "
-            "of percent between runs of the same tree."
+            "Only `.text` and memory post a pull request comment. Timing moves by tens of "
+            "percent between runs of the same tree; a binary's file size and symbol count "
+            "measure its debug information; and a crate or generic breaks down a `.text` that "
+            "moved, so it speaks only when one did. Comment `/compile-metrics` on a pull "
+            "request to have every report posted anyway."
         ),
         "",
         "| job | " + " | ".join(JOB_COLUMNS) + " |",
@@ -1196,24 +1275,33 @@ def fmt_features(names: list[str]) -> str:
     return ", ".join(fmt_name(name) for name in names)
 
 
+def run_label(run: dict[str, Any]) -> str:
+    sha = run.get("sha", "unknown")[:8]
+    return f"[{sha}]({run['run_url']})" if run.get("run_url") else sha
+
+
 def render(
     main: dict[str, Any] | None,
     current: dict[str, Any],
     changes: list[Change],
     title: str,
 ) -> str:
-    lines = [f"## {title}", "", "### This run", ""]
+    # Which run the numbers came from. `local` picks the newest run on the branch that still has
+    # artifacts, which is regularly not the newest push, so the commit has to be on the report.
+    lines = [
+        f"## {title}",
+        "",
+        f"Measured on {run_label(current)}.",
+        "",
+        "### This run",
+        "",
+    ]
     lines += state_tables(current)
     lines += ["", "### Against main", ""]
     if main is None:
         lines.append("No main-branch baseline available yet.")
     else:
-        baseline = (
-            f"[{main.get('sha', '')[:8]}]({main['run_url']})"
-            if main.get("run_url")
-            else main.get("sha", "unknown")[:8]
-        )
-        lines += [f"Baseline: main {baseline}.", ""]
+        lines += [f"Baseline: main {run_label(main)}.", ""]
         lines += comparison_tables(changes)
         lines += feature_tables(main, current)
     lines.append("")
@@ -1229,8 +1317,7 @@ def report_markdown(
 ) -> tuple[str, bool]:
     """The report, and whether an alerting metric crossed its threshold; see UNALERTED."""
     changes = compare(main, current) if main else []
-    alerting = any(c.regressed and c.alerts for c in changes)
-    return render(main, current, changes, title), alerting
+    return render(main, current, changes, title), bool(alert_causes(changes))
 
 
 def cmd_report(args: argparse.Namespace) -> int:
@@ -1269,8 +1356,11 @@ def cmd_local(args: argparse.Namespace) -> int:
     """Every workflow's report for one commit, rendered from the artifacts of its CI runs.
 
     The same reports CI posts, so a threshold can be tried out, or a number chased, without
-    pushing.
+    pushing. With --comment they are posted too, which is how `/compile-metrics` on a pull
+    request produces the report CI itself keeps quiet.
     """
+    pr = comment_target(args) if args.comment else None
+    reported = 0
     for target in targets(args.pr, args.rev, args.run):
         log.info("%s: run %d at %s", target.workflow, target.run_id, target.sha[:8])
         with tempfile.TemporaryDirectory() as tmp:
@@ -1282,8 +1372,80 @@ def cmd_local(args: argparse.Namespace) -> int:
             current = merged_metrics(artifacts, target.sha, target.url)
             main = fetch_baseline(target.workflow, target.baseline, work / "main.json")
         summary, _ = report_markdown(current, main, target.title)
-        print(align(summary))
+        reported += 1
+        if pr:
+            post_sticky(pr, target.baseline, summary)
+        else:
+            print(align(summary))
+    # Every workflow having nothing to report is how a wrong branch, an expired artifact and a
+    # missing token all look, and `/compile-metrics` runs where nobody sees the job succeed.
+    if not reported:
+        raise RuntimeError("no workflow run had compile metrics to report on")
     return 0
+
+
+def comment_target(args: argparse.Namespace) -> int:
+    """--comment posts to a pull request, so the target has to be one."""
+    if args.rev or args.run:
+        raise RuntimeError(
+            "--comment needs --pr or the current branch, not --rev or --run"
+        )
+    return args.pr or pr_number(None)
+
+
+def sticky_marker(header: str) -> str:
+    """The marker `marocchino/sticky-pull-request-comment` writes, matched exactly.
+
+    The workflows post through that action on every push. Writing the same marker makes an
+    on-demand report update that comment rather than sit beside it, so a pull request carries one
+    comment per workflow whichever path wrote it last. In CI both are `github-actions[bot]` and
+    they converge; run from a shell this posts as the developer, and the action, which matches on
+    author as well as marker, will open a second comment beside it on the next push.
+    """
+    return f"<!-- Sticky Pull Request Comment{header} -->"
+
+
+def post_sticky(pr: int, header: str, body: str) -> None:
+    """The body goes in as JSON on stdin, not as a `--field` in argv.
+
+    `gh api --field` expands `{owner}`, `{repo}` and `{branch}` inside a value and reads one
+    opening with `@` as a filename. A report is a literal that happens to be full of crate names,
+    and it is tens of kilobytes, which argv is no place for.
+    """
+    marker = sticky_marker(header)
+    existing = sticky_comment(pr, marker)
+    endpoint = (
+        f"repos/{{owner}}/{{repo}}/issues/comments/{existing}"
+        if existing
+        else f"repos/{{owner}}/{{repo}}/issues/{pr}/comments"
+    )
+    capture(
+        "gh",
+        "api",
+        "--method",
+        "PATCH" if existing else "POST",
+        endpoint,
+        "--input",
+        "-",
+        "--silent",
+        stdin=json.dumps({"body": f"{body}\n{marker}\n"}),
+    )
+    log.info(
+        "%s comment on #%d for %s", "updated" if existing else "posted", pr, header
+    )
+
+
+def sticky_comment(pr: int, marker: str) -> str | None:
+    """The id of the comment carrying `marker`, or None. One id per page, so lines, not JSON."""
+    ids = capture(
+        "gh",
+        "api",
+        "--paginate",
+        f"repos/{{owner}}/{{repo}}/issues/{pr}/comments",
+        "--jq",
+        f".[] | select(.body | contains({json.dumps(marker)})) | .id",
+    ).split()
+    return ids[0] if ids else None
 
 
 def targets(pr: int | None, rev: str | None, run: int | None) -> list[Target]:
@@ -1321,8 +1483,16 @@ def targets(pr: int | None, rev: str | None, run: int | None) -> list[Target]:
 
 
 def pr_branch(pr: int | None) -> str:
+    return pr_field(pr, "headRefName")
+
+
+def pr_number(pr: int | None) -> int:
+    return int(pr_field(pr, "number"))
+
+
+def pr_field(pr: int | None, field_name: str) -> Any:
     view = ["gh", "pr", "view", *([str(pr)] if pr else [])]
-    return json.loads(capture(*view, "--json", "headRefName"))["headRefName"]
+    return json.loads(capture(*view, "--json", field_name))[field_name]
 
 
 def newest_with_metrics(workflow: str, selector: list[str]) -> dict[str, Any] | None:
@@ -1436,10 +1606,16 @@ def align(markdown: str) -> str:
     return result.stdout if result.returncode == 0 else markdown
 
 
-def capture(*command: str) -> str:
-    return subprocess.run(
-        command, capture_output=True, text=True, check=True
-    ).stdout.strip()
+def capture(*command: str, stdin: str | None = None) -> str:
+    """`CalledProcessError` prints the command and drops stderr, which is where gh says why."""
+    done = subprocess.run(
+        command, capture_output=True, text=True, input=stdin, check=False
+    )
+    if done.returncode != 0:
+        raise RuntimeError(
+            f"{command[0]} exited {done.returncode}: {done.stderr.strip()}"
+        )
+    return done.stdout.strip()
 
 
 def run_quiet(*command: str) -> int:
@@ -1537,6 +1713,13 @@ def main(argv: list[str]) -> int:
         "--run",
         type=int,
         help="one workflow run id, to report on a run that is not the newest",
+    )
+    local.add_argument(
+        "--comment",
+        action="store_true",
+        help="post each report to the pull request instead of stdout, whether or not anything "
+        "crossed a threshold; updates the comment the workflow posts, and so is deleted again "
+        "by the next push that finds nothing over threshold",
     )
     local.set_defaults(func=cmd_local)
 

--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -103,11 +103,15 @@ INSTANTIATIONS_MIN = 50
 INSTANTIATIONS_DELTA = 100
 TOP_CRATES = 25
 TOP_BASES = 25
+# Sections measured per binary, recorded as `<name>_bytes`. `.text` is the code; `.rodata` is
+# what a `const` table or an `include_bytes!` lands in, and neither shows up in the other.
+SECTIONS = (".text", ".rodata")
+SIZE_METRICS = tuple(f"{name.lstrip('.')}_bytes" for name in SECTIONS)
 # Metric families, in reading order. Compile cost first, then what the binary weighs, then the
 # breakdown that says why it weighs it. The per-family caps bound the whole comment: a Cargo.lock
 # bump moves hundreds of rows at once, and a comment that long is unreadable and runs into
 # GitHub's 65 kB limit on a comment body.
-FAMILIES = ("cpu-s", "bytes", "text_bytes", "symbols", "crate bytes", "instantiations")
+FAMILIES = ("cpu-s", "bytes", *SIZE_METRICS, "symbols", "crate bytes", "instantiations")
 FAMILY_ROWS = 6
 FAMILY_IMPROVEMENTS = 3
 RED = " 🔴"
@@ -151,11 +155,11 @@ JOB_METRICS = (
     ("critical_path_s", "critical path s", CRITICAL_PATH_PCT),
 )
 JOB_COLUMNS = [column for _, column, _ in JOB_METRICS]
-# Whole-binary metrics, as (field, regression threshold in %, absolute floor).
-TEXT_METRIC = "text_bytes"
+# Whole-binary metrics, as (field, regression threshold in %, absolute floor). Only the section
+# sizes alert; see UNALERTED.
 BINARY_METRICS = (
     ("bytes", BINARY_PCT, 0),
-    (TEXT_METRIC, TEXT_PCT, TEXT_MIN_BYTES),
+    *((metric, TEXT_PCT, TEXT_MIN_BYTES) for metric in SIZE_METRICS),
     ("symbols", BINARY_PCT, 0),
 )
 
@@ -416,15 +420,19 @@ def resolved_features(metadata: dict[str, Any]) -> dict[str, str]:
     )
 
 
-def text_section_bytes(path: Path) -> int:
+def section_bytes(path: Path, sections: tuple[str, ...]) -> dict[str, int]:
+    """Sizes of the named sections. Absent means the linker emitted none, which is zero bytes."""
     out = subprocess.run(
         ["size", "-A", str(path)], check=True, capture_output=True, text=True
     )
+    sizes = {}
     for line in out.stdout.splitlines():
         fields = line.split()
-        if len(fields) >= 2 and fields[0] == ".text":
-            return int(fields[1])
-    raise RuntimeError(f"no .text section in {path}")
+        if len(fields) >= 2 and fields[0] in sections:
+            sizes[fields[0]] = int(fields[1])
+    if ".text" not in sizes:
+        raise RuntimeError(f"no .text section in {path}")
+    return sizes
 
 
 def measure_binary(path: Path) -> dict[str, Any]:
@@ -437,7 +445,11 @@ def measure_binary(path: Path) -> dict[str, Any]:
     `instantiations` is which base to go after: that is what turns "symbols +8 %" into "this
     function is instantiated 340 times".
     """
-    measured = {"bytes": path.stat().st_size, "text_bytes": text_section_bytes(path)}
+    sections = section_bytes(path, SECTIONS)
+    measured: dict[str, Any] = {"bytes": path.stat().st_size}
+    measured |= {
+        f"{name.lstrip('.')}_bytes": sections.get(name, 0) for name in SECTIONS
+    }
     symbols = 0
     instantiations = 0
     totals: dict[str, int] = {}
@@ -844,23 +856,27 @@ def binary_changes(
     """One binary's totals, then the breakdown that says where the total went.
 
     A crate's slice of the binary and a generic's instantiation count exist to answer "why did
-    `.text` grow", so they are quiet unless it did. Pull request 4896 is what the gate is for: it
-    shrank every binary it touched by 13 % to 17 %, and still reported ten regressions, all of
-    them slices of those same binaries.
+    this binary grow", so they are quiet unless a section did. Pull request 4896 is what the gate
+    is for: it shrank every binary it touched by 13 % to 17 %, and still reported ten
+    regressions, all of them slices of those same binaries.
+
+    The slices are sized by `nm`, which sizes symbols in every section, so the gate is over all
+    of SECTIONS rather than `.text` alone: a `const` table growing is a real regression, and
+    gating on the `.text` it does not touch would hide it.
     """
     changes = []
-    text = None
+    sizes = []
     for metric, threshold, floor in BINARY_METRICS:
         if metric not in was or metric not in now:
             continue
         change = Change(job, binary, metric, was[metric], now[metric], threshold, floor)
         changes.append(change)
-        if metric == TEXT_METRIC:
-            text = change
-    if text is None:
+        if metric in SIZE_METRICS:
+            sizes.append(change)
+    if not sizes:
         # Nothing alerts on this binary at all, so say so rather than let it go unwatched.
-        log.warning("%s/%s: no %s in both runs", job, binary, TEXT_METRIC)
-    quiet = text is None or not text.alerting_regression
+        log.warning("%s/%s: no section size in both runs", job, binary)
+    quiet = not any(change.alerting_regression for change in sizes)
     for crate, crate_size in now.get("crate_bytes", {}).items():
         was_crate = was.get("crate_bytes", {}).get(crate)
         if was_crate is not None and was_crate >= CRATE_BYTES_MIN:
@@ -904,7 +920,7 @@ def fmt_value(value: float) -> str:
 def fmt_metric(metric: str, value: float) -> str:
     if metric in ("peak memory", "largest process"):
         return fmt_bytes(value * 1024)
-    if metric in ("bytes", "text_bytes", "crate bytes"):
+    if metric in ("bytes", "crate bytes", *SIZE_METRICS):
         return fmt_bytes(value)
     return fmt_value(value)
 
@@ -955,9 +971,21 @@ class Merged:
 
 
 def collapse(changes: list[Change]) -> list[Merged]:
-    groups: dict[tuple[str, str, float, float], list[Change]] = {}
+    """`alerts` is in the key because the representative row decides the mark and the count.
+
+    Sibling binaries of one job share the std bases that dominate `instantiations`, at the same
+    counts, so a group can span a binary whose `.text` regressed and one whose did not. Without
+    it the red circle went to whichever the `binaries` dict happened to yield first.
+    """
+    groups: dict[tuple[str, str, float, float, bool], list[Change]] = {}
     for change in changes:
-        key = (change.scope, change.metric, change.main, change.current)
+        key = (
+            change.scope,
+            change.metric,
+            change.main,
+            change.current,
+            change.alerts,
+        )
         groups.setdefault(key, []).append(change)
     return [Merged(rows[0], len(rows)) for rows in groups.values()]
 
@@ -1166,10 +1194,12 @@ def comparison_tables(changes: list[Change]) -> list[str]:
         return ["No job in this run has a counterpart in the baseline run."]
     alerts = alert_causes(changes)
     lines = [
-        f"**{len(alerts)} over threshold** (`.text` +{TEXT_PCT:g}%, peak memory "
-        f"+{PEAK_USED_PCT:g}%, largest process +{PEAK_RSS_PCT:g}%, crate and generic "
-        f"+{BINARY_PCT:g}%). One count per regression, however many binaries and jobs "
-        "carry it."
+        f"**{len(alerts)} over threshold** (section +{TEXT_PCT:g}% and "
+        f"{fmt_bytes(TEXT_MIN_BYTES)}, crate +{BINARY_PCT:g}% and "
+        f"{fmt_bytes(CRATE_BYTES_DELTA)}, generic +{BINARY_PCT:g}% and "
+        f"{INSTANTIATIONS_DELTA}, peak memory +{PEAK_USED_PCT:g}%, largest process "
+        f"+{PEAK_RSS_PCT:g}%). One count per regression, however many binaries and "
+        "jobs carry it."
         if alerts
         else "No binary or memory metric over threshold.",
         "",
@@ -1357,7 +1387,9 @@ def cmd_local(args: argparse.Namespace) -> int:
 
     The same reports CI posts, so a threshold can be tried out, or a number chased, without
     pushing. With --comment they are posted too, which is how `/compile-metrics` on a pull
-    request produces the report CI itself keeps quiet.
+    request produces the report CI itself keeps quiet. That path runs the default branch's
+    checkout, so it renders with main's thresholds; trying a threshold out means running this
+    from a shell.
     """
     pr = comment_target(args) if args.comment else None
     reported = 0
@@ -1367,8 +1399,9 @@ def cmd_local(args: argparse.Namespace) -> int:
             work = Path(tmp)
             artifacts = work / "artifacts"
             if not download_metrics(target.run_id, artifacts):
-                log.warning("run %d: metrics artifacts vanished", target.run_id)
-                continue
+                # `newest_with_metrics` picked this run because the API listed its artifacts,
+                # so a failed download is not the ordinary "not built yet" case.
+                raise RuntimeError(f"run {target.run_id}: metrics artifacts vanished")
             current = merged_metrics(artifacts, target.sha, target.url)
             main = fetch_baseline(target.workflow, target.baseline, work / "main.json")
         summary, _ = report_markdown(current, main, target.title)
@@ -1445,7 +1478,8 @@ def sticky_comment(pr: int, marker: str) -> str | None:
         "--jq",
         f".[] | select(.body | contains({json.dumps(marker)})) | .id",
     ).split()
-    return ids[0] if ids else None
+    # The newest, for the duplicate the docstring anticipates: the stale one is the older.
+    return ids[-1] if ids else None
 
 
 def targets(pr: int | None, rev: str | None, run: int | None) -> list[Target]:

--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -14,6 +14,43 @@ per-unit table is a pointer.
 per package across the whole build, so a feature enabled on one leaf crate is compiled into every
 build that reaches it; the diff against main is the only visible sign of it.
 
+Alerting:
+    Every run writes a report to its step summary. It becomes a pull request comment, which
+    notifies everyone watching, only when a metric that alerts crosses its band. Bands and floors
+    are the constants below, and the report prints the live ones.
+
+    metric            alerts  band              measures
+    ----------------  ------  ----------------  --------------------------------------------
+    peak memory       yes     +15 %             the whole box, shared with the runner
+    largest process   yes     +10 %             one rustc, and it holds still
+    .text, .rodata    yes     +2 %, 100 kB      the code, and the tables it reads
+    crate bytes       gated   +5 %, 64 kB       one crate's symbols, in every section
+    instantiations    gated   +5 %, 100         one generic's copies
+    file bytes        no      +5 %              debug info in test builds, `.symtab` in release
+    symbols           no      +5 %              `.symtab` entries, most of them not code
+    workspace cpu-s   no      +10 %             the job's summed unit time
+    critical path s   no      +10 %             the longest dependency chain
+    unit cpu-s        no      +15 %, over 20 s  one crate, under whatever parallelism it got
+
+    Gated rows alert only when a section of the same binary regressed. A crate's slice and a
+    generic's instantiation count say why a binary grew; they do not get to claim it did.
+
+    Timing never alerts: 4892 changed no Rust and its workspace cpu moved -10.5 % to +21.1 %,
+    with single units at +65.0 % and -59.7 %. The size metrics are the opposite, exactly
+    reproducible: across two main runs differing only in this script, every one moved 0.00 %.
+    They fired because they measured the wrong thing. 4896 shrank every binary it touched by
+    13 % to 17 % and reported ten regressions: nine were slices of those same binaries, and the
+    tenth was `keygen`'s symbol count against a byte-identical `.text`.
+
+    Release builds are the worst case for the two quiet size metrics, not the best. There is no
+    `[profile.release]` override, so they carry no DWARF but a full `.symtab`, which is what `nm`
+    counts and which moves with the dependency graph: across 4890 the release binaries held
+    `.text` between +0.00 % and -1.00 % while their symbol counts rose 32 % to 34 % and their
+    files 13 % to 15 %.
+
+    A comment counts one regression per crate or binary, however many jobs carry it, and is
+    deleted once the regression is gone. Commenting `/compile-metrics` posts every report anyway.
+
 Examples:
     # Wrap the build to record its peak memory.
     scripts/compile-metrics sample-rss --out peak-rss.json -- scripts/ci-build-binary espresso-node
@@ -80,21 +117,14 @@ ARROW = "\x00"
 LEGACY_HASH_RE = re.compile(r"::h[0-9a-f]{16}$")
 EMPTY_PATH_RE = re.compile(r"::(::)+")
 
-# Thresholds, for deciding which rows are worth a table row. Which of them post a pull request
-# comment is a separate question; see UNALERTED and `Change.alerts`.
+# The numbers in the `Alerting` table of the module docstring, which is where they are explained.
 WORKSPACE_CPU_PCT = 10.0
 CRITICAL_PATH_PCT = 10.0
 UNIT_CPU_PCT = 15.0
 UNIT_MIN_S = 20.0
-# Peak memory of the whole box, against the largest single process. The box competes with
-# whatever else the runner is doing: on a tree with no Rust change at all it moved 7.3 % while
-# the largest rustc stayed within 2.8 %, so it gets the wider band.
 PEAK_USED_PCT = 15.0
 PEAK_RSS_PCT = 10.0
 BINARY_PCT = 5.0
-# `.text` is the only size metric that tracks code. It is bit-reproducible across runs of the
-# same tree, and a refactor that cut a crate's contribution by 47 % moved it 2.4 %, so its band
-# is narrow and backed by an absolute floor rather than left at BINARY_PCT.
 TEXT_PCT = 2.0
 TEXT_MIN_BYTES = 100 * 1024
 CRATE_BYTES_MIN = 256 * 1024
@@ -103,30 +133,18 @@ INSTANTIATIONS_MIN = 50
 INSTANTIATIONS_DELTA = 100
 TOP_CRATES = 25
 TOP_BASES = 25
-# Sections measured per binary, recorded as `<name>_bytes`. `.text` is the code; `.rodata` is
-# what a `const` table or an `include_bytes!` lands in, and neither shows up in the other.
+# Recorded as `<name>_bytes`.
 SECTIONS = (".text", ".rodata")
 SIZE_METRICS = tuple(f"{name.lstrip('.')}_bytes" for name in SECTIONS)
-# Metric families, in reading order. Compile cost first, then what the binary weighs, then the
-# breakdown that says why it weighs it. The per-family caps bound the whole comment: a Cargo.lock
-# bump moves hundreds of rows at once, and a comment that long is unreadable and runs into
-# GitHub's 65 kB limit on a comment body.
+# Metric families, in reading order. The per-family caps bound the whole comment: a Cargo.lock
+# bump moves hundreds of rows at once, against GitHub's 65 kB limit on a comment body.
 FAMILIES = ("cpu-s", "bytes", *SIZE_METRICS, "symbols", "crate bytes", "instantiations")
 FAMILY_ROWS = 6
 FAMILY_IMPROVEMENTS = 3
 RED = " 🔴"
 GREEN = " 🟢"
-# What is reported and ranked but never posts a comment. The list names what stays quiet rather
-# than what speaks, so a metric added later is loud by default instead of silently unwatched.
-#
-# Timing is measured under whatever parallelism, runner and dependency cache the job happened to
-# draw, and the spread swamps the effect: pull request 4892 changed no Rust at all, yet its
-# per-job workspace cpu moved from -10.5 % to +21.1 % and single units moved +65.0 % and -59.7 %.
-#
-# A binary's file size and symbol count are quiet for the opposite reason. Both are reproducible,
-# and both measure the debug information rather than the code: pull request 4896 cut
-# espresso-node's `.text` by 1.5 MB while the file shrank by 100 MB, and left `keygen` with a
-# byte-identical `.text` and 7,252 more symbols. `.text` alerts in their place.
+# A denylist rather than an allowlist, so a metric added later is loud by default instead of
+# silently unwatched.
 UNALERTED = ("cpu-s", "workspace cpu-s", "critical path s", "bytes", "symbols")
 TOP_BINARIES = 10
 TOP_UNITS = 20
@@ -155,8 +173,7 @@ JOB_METRICS = (
     ("critical_path_s", "critical path s", CRITICAL_PATH_PCT),
 )
 JOB_COLUMNS = [column for _, column, _ in JOB_METRICS]
-# Whole-binary metrics, as (field, regression threshold in %, absolute floor). Only the section
-# sizes alert; see UNALERTED.
+# Whole-binary metrics, as (field, regression threshold in %, absolute floor).
 BINARY_METRICS = (
     ("bytes", BINARY_PCT, 0),
     *((metric, TEXT_PCT, TEXT_MIN_BYTES) for metric in SIZE_METRICS),
@@ -192,12 +209,7 @@ class Change:
 
     @property
     def alerts(self) -> bool:
-        """Whether crossing the band is worth a pull request comment.
-
-        `min_delta` keeps a percentage off a small number quiet: 148 -> 156 instantiations is
-        +5.4 %, and eight of anything in a binary of a third of a million symbols is nothing.
-        `quiet` is set by whoever built the row, for a metric whose band alone does not decide.
-        """
+        """`min_delta` keeps a percentage off a small number quiet; `quiet` is the gate."""
         if self.quiet or self.metric in UNALERTED:
             return False
         return abs(self.current - self.main) >= self.min_delta
@@ -853,16 +865,11 @@ def compare(main: dict[str, Any], current: dict[str, Any]) -> list[Change]:
 def binary_changes(
     job: str, binary: str, was: dict[str, Any], now: dict[str, Any]
 ) -> list[Change]:
-    """One binary's totals, then the breakdown that says where the total went.
+    """One binary's totals, then the breakdown of where they went.
 
-    A crate's slice of the binary and a generic's instantiation count exist to answer "why did
-    this binary grow", so they are quiet unless a section did. Pull request 4896 is what the gate
-    is for: it shrank every binary it touched by 13 % to 17 %, and still reported ten
-    regressions, all of them slices of those same binaries.
-
-    The slices are sized by `nm`, which sizes symbols in every section, so the gate is over all
-    of SECTIONS rather than `.text` alone: a `const` table growing is a real regression, and
-    gating on the `.text` it does not touch would hide it.
+    The breakdown is gated on a section regressing; see `Alerting`. The gate is over all of
+    SECTIONS because `nm` sizes symbols in every one of them, so gating on `.text` alone would
+    hide a `const` table it does not touch.
     """
     changes = []
     sizes = []
@@ -971,11 +978,8 @@ class Merged:
 
 
 def collapse(changes: list[Change]) -> list[Merged]:
-    """`alerts` is in the key because the representative row decides the mark and the count.
-
-    Sibling binaries of one job share the std bases that dominate `instantiations`, at the same
-    counts, so a group can span a binary whose `.text` regressed and one whose did not. Without
-    it the red circle went to whichever the `binaries` dict happened to yield first.
+    """`alerts` is in the key: the representative row decides the mark and the count, and
+    sibling binaries share std bases at equal counts across an open gate and a shut one.
     """
     groups: dict[tuple[str, str, float, float, bool], list[Change]] = {}
     for change in changes:
@@ -1177,11 +1181,7 @@ def fmt_cell(change: Change) -> str:
 
 
 def alert_causes(changes: list[Change]) -> set[tuple[str, str]]:
-    """The distinct regressions worth a comment, counted once however many binaries carry them.
-
-    A crate that grew is one finding, but it grows in every binary that links it, in every job
-    that builds one: `hashbrown` alone accounted for three of pull request 4896's ten.
-    """
+    """One entry per regression, however many binaries link it and jobs build them."""
     return {
         (change.metric, change.name.partition(": ")[2] or change.name)
         for change in changes
@@ -1427,23 +1427,16 @@ def comment_target(args: argparse.Namespace) -> int:
 
 
 def sticky_marker(header: str) -> str:
-    """The marker `marocchino/sticky-pull-request-comment` writes, matched exactly.
-
-    The workflows post through that action on every push. Writing the same marker makes an
-    on-demand report update that comment rather than sit beside it, so a pull request carries one
-    comment per workflow whichever path wrote it last. In CI both are `github-actions[bot]` and
-    they converge; run from a shell this posts as the developer, and the action, which matches on
-    author as well as marker, will open a second comment beside it on the next push.
+    """The marker `marocchino/sticky-pull-request-comment` writes, so the two paths share one
+    comment. Only in CI, where both are `github-actions[bot]`: that action matches on author too,
+    so a shell run posts as the developer and the next push opens a second comment beside it.
     """
     return f"<!-- Sticky Pull Request Comment{header} -->"
 
 
 def post_sticky(pr: int, header: str, body: str) -> None:
-    """The body goes in as JSON on stdin, not as a `--field` in argv.
-
-    `gh api --field` expands `{owner}`, `{repo}` and `{branch}` inside a value and reads one
-    opening with `@` as a filename. A report is a literal that happens to be full of crate names,
-    and it is tens of kilobytes, which argv is no place for.
+    """JSON on stdin, because `gh api --field` expands `{owner}`, `{repo}` and `{branch}` inside
+    a value and reads one opening with `@` as a filename, and a report is a literal.
     """
     marker = sticky_marker(header)
     existing = sticky_comment(pr, marker)
@@ -1673,7 +1666,9 @@ def split_command(argv: list[str]) -> tuple[list[str], list[str]]:
 
 def main(argv: list[str]) -> int:
     argv, build_command = split_command(argv)
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     sub = parser.add_subparsers(dest="subcommand", required=True)
 
     collect = sub.add_parser("collect", help="metrics for one build job")

--- a/scripts/compile-metrics
+++ b/scripts/compile-metrics
@@ -15,14 +15,14 @@ per package across the whole build, so a feature enabled on one leaf crate is co
 build that reaches it; the diff against main is the only visible sign of it.
 
 Alerting:
-    Every run writes a report to its step summary. It becomes a pull request comment, which
-    notifies everyone watching, only when a metric that alerts crosses its band. Bands and floors
-    are the constants below, and the report prints the live ones.
+    Every run writes a report to its step summary. It becomes a pull request comment only when a
+    metric that alerts crosses its band. Bands and floors are the constants below; the report
+    prints the live ones.
 
     metric            alerts  band              measures
     ----------------  ------  ----------------  --------------------------------------------
-    peak memory       yes     +15 %             the whole box, shared with the runner
-    largest process   yes     +10 %             one rustc, and it holds still
+    peak memory       yes     +15 %             the whole box, shared with other processes
+    largest process   yes     +10 %             one rustc process
     .text, .rodata    yes     +2 %, 100 kB      the code, and the tables it reads
     crate bytes       gated   +5 %, 64 kB       one crate's symbols, in every section
     instantiations    gated   +5 %, 100         one generic's copies
@@ -32,24 +32,22 @@ Alerting:
     critical path s   no      +10 %             the longest dependency chain
     unit cpu-s        no      +15 %, over 20 s  one crate, under whatever parallelism it got
 
-    Gated rows alert only when a section of the same binary regressed. A crate's slice and a
-    generic's instantiation count say why a binary grew; they do not get to claim it did.
+    Gated rows break down a section that moved. They alert only when a section of the same
+    binary regressed.
 
-    Timing never alerts: 4892 changed no Rust and its workspace cpu moved -10.5 % to +21.1 %,
-    with single units at +65.0 % and -59.7 %. The size metrics are the opposite, exactly
-    reproducible: across two main runs differing only in this script, every one moved 0.00 %.
-    They fired because they measured the wrong thing. 4896 shrank every binary it touched by
-    13 % to 17 % and reported ten regressions: nine were slices of those same binaries, and the
-    tenth was `keygen`'s symbol count against a byte-identical `.text`.
+    Measurements the table rests on:
 
-    Release builds are the worst case for the two quiet size metrics, not the best. There is no
-    `[profile.release]` override, so they carry no DWARF but a full `.symtab`, which is what `nm`
-    counts and which moves with the dependency graph: across 4890 the release binaries held
-    `.text` between +0.00 % and -1.00 % while their symbol counts rose 32 % to 34 % and their
-    files 13 % to 15 %.
+    - 4892 changed no Rust. Workspace cpu moved -10.5 % to +21.1 %, single units +65.0 % and
+      -59.7 %.
+    - Two main runs differing only in this script. Every size metric moved 0.00 %.
+    - 4896 shrank every binary it touched by 13 % to 17 %, and reported ten regressions: nine
+      slices of those binaries, one `keygen` symbol count against a byte-identical `.text`.
+    - 4890 release binaries held `.text` between +0.00 % and -1.00 % while symbol counts rose
+      32 % to 34 % and files 13 % to 15 %. There is no `[profile.release]` override, so release
+      carries no DWARF and a full `.symtab`, which is what `nm` counts.
 
     A comment counts one regression per crate or binary, however many jobs carry it, and is
-    deleted once the regression is gone. Commenting `/compile-metrics` posts every report anyway.
+    deleted once the regression is gone. `/compile-metrics` posts every report regardless.
 
 Examples:
     # Wrap the build to record its peak memory.
@@ -1204,11 +1202,10 @@ def comparison_tables(changes: list[Change]) -> list[str]:
         else "No binary or memory metric over threshold.",
         "",
         (
-            "Only `.text` and memory post a pull request comment. Timing moves by tens of "
-            "percent between runs of the same tree; a binary's file size and symbol count "
-            "measure its debug information; and a crate or generic breaks down a `.text` that "
-            "moved, so it speaks only when one did. Comment `/compile-metrics` on a pull "
-            "request to have every report posted anyway."
+            "Section sizes and memory post a comment. Timing moves by tens of percent between "
+            "runs of the same tree. A file size and a symbol count are mostly symbol table. A "
+            "crate or generic row breaks down a section, and speaks only when one regressed. "
+            "Comment `/compile-metrics` to have every report posted regardless."
         ),
         "",
         "| job | " + " | ".join(JOB_COLUMNS) + " |",

--- a/scripts/test_compile_metrics.py
+++ b/scripts/test_compile_metrics.py
@@ -235,13 +235,12 @@ def sized(text, rodata=0, bytes_=None, symbols=None, crates=None, bases=None):
     }
 
 
-def posts_comment(main_binaries, current_binaries):
-    _, alerting = cm.report_markdown(
-        {"jobs": {"j": job(binaries=current_binaries)}},
+def alerts(main_binaries, current_binaries):
+    changes = cm.compare(
         {"jobs": {"j": job(binaries=main_binaries)}},
-        "t",
+        {"jobs": {"j": job(binaries=current_binaries)}},
     )
-    return alerting
+    return bool(cm.alert_causes(changes))
 
 
 class Alerts(unittest.TestCase):
@@ -273,20 +272,21 @@ class Alerts(unittest.TestCase):
     def test_an_unknown_metric_alerts_rather_than_going_unwatched(self):
         self.assertTrue(cm.Change("j", "n", "rodata_bytes", 100, 200, 5.0).alerts)
 
-    def test_a_timing_regression_alone_posts_no_comment(self):
-        current = {"jobs": {"j": job({"slow lib": 200.0})}}
-        main = {"jobs": {"j": job({"slow lib": 100.0})}}
-        _, regressed = cm.report_markdown(current, main, "t")
-        self.assertFalse(regressed)
+    def test_a_timing_regression_alone_is_not_a_cause(self):
+        changes = cm.compare(
+            {"jobs": {"j": job({"slow lib": 100.0})}},
+            {"jobs": {"j": job({"slow lib": 200.0})}},
+        )
+        self.assertEqual(cm.alert_causes(changes), set())
 
-    def test_a_text_regression_posts_one(self):
-        self.assertTrue(posts_comment({"b": sized(10**7)}, {"b": sized(2 * 10**7)}))
+    def test_a_section_regression_is_one(self):
+        self.assertTrue(alerts({"b": sized(10**7)}, {"b": sized(2 * 10**7)}))
 
-    def test_a_text_move_under_the_floor_does_not(self):
+    def test_a_section_move_under_the_floor_is_not(self):
         """A binary small enough that its whole band fits inside the floor cannot alert."""
         small = cm.SECTION_MIN_BYTES * 2
         over_band = round(small * (1 + cm.SECTION_PCT / 100)) + 1
-        self.assertFalse(posts_comment({"b": sized(small)}, {"b": sized(over_band)}))
+        self.assertFalse(alerts({"b": sized(small)}, {"b": sized(over_band)}))
 
 
 CRATES = {"hashbrown": 1_179_110}

--- a/scripts/test_compile_metrics.py
+++ b/scripts/test_compile_metrics.py
@@ -306,7 +306,7 @@ class Gate(unittest.TestCase):
         return next(c for c in changes if c.metric == "crate bytes")
 
     def test_quiet_inside_a_shrinking_binary(self):
-        """Pull request 4896: every binary shrank, and ten slices of them alerted."""
+        """Code moving between crates grows a slice of a binary that got smaller."""
         crate = self.crate(66_389_344, 64_884_720)
         self.assertTrue(crate.regressed)
         self.assertTrue(crate.quiet)
@@ -405,26 +405,6 @@ class FamilyTables(unittest.TestCase):
 
 class Docstring(unittest.TestCase):
     """The module docstring is the only place the rules are written out, so it has to keep up."""
-
-    def test_every_band_is_stated(self):
-        doc = cm.__doc__ or ""
-        bands = (
-            cm.PEAK_USED_PCT,
-            cm.PEAK_RSS_PCT,
-            cm.TEXT_PCT,
-            cm.BINARY_PCT,
-            cm.WORKSPACE_CPU_PCT,
-            cm.UNIT_CPU_PCT,
-        )
-        for band in bands:
-            self.assertIn(f"+{band:g} %", doc)
-
-    def test_every_floor_is_stated(self):
-        doc = cm.__doc__ or ""
-        self.assertIn(f"{cm.TEXT_MIN_BYTES // 1024} kB", doc)
-        self.assertIn(f"{cm.CRATE_BYTES_DELTA // 1024} kB", doc)
-        self.assertIn(f"{cm.INSTANTIATIONS_DELTA}", doc)
-        self.assertIn(f"{cm.UNIT_MIN_S:g} s", doc)
 
     def test_every_silenced_metric_is_named(self):
         doc = cm.__doc__ or ""

--- a/scripts/test_compile_metrics.py
+++ b/scripts/test_compile_metrics.py
@@ -8,6 +8,7 @@ Everything here is a pure function over literals, so no build, no artifact and n
 import importlib.util
 import math
 import unittest
+from dataclasses import replace
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -214,21 +215,50 @@ class Collapse(unittest.TestCase):
         self.assertEqual(len(cm.collapse(rows)), 2)
 
 
-class Alerts(unittest.TestCase):
-    """Timing is a measurement; binary size is a property of the artifact."""
+def sized(text, bytes_=None, symbols=None, crates=None, bases=None):
+    return {
+        "bytes": bytes_ if bytes_ is not None else text,
+        "text_bytes": text,
+        "symbols": symbols if symbols is not None else text,
+        "crate_bytes": crates or {},
+        "instantiations": bases or {},
+    }
 
-    def test_binary_metrics_alert(self):
-        for metric in ("bytes", "text_bytes", "symbols", "instantiations"):
-            self.assertTrue(cm.Change("j", "n", metric, 100, 200, 5.0).alerts, metric)
+
+def posts_comment(main_binaries, current_binaries):
+    _, alerting = cm.report_markdown(
+        {"jobs": {"j": job(binaries=current_binaries)}},
+        {"jobs": {"j": job(binaries=main_binaries)}},
+        "t",
+    )
+    return alerting
+
+
+class Alerts(unittest.TestCase):
+    """`.text` and memory speak. Everything else is a diagnostic for one of them."""
+
+    def test_text_alerts(self):
+        change = cm.Change("j", "n", "text_bytes", 10**7, 2 * 10**7, cm.TEXT_PCT)
+        self.assertTrue(change.alerts)
 
     def test_memory_alerts(self):
-        """On an unchanged tree memory stayed within 3.2 %, well inside its band."""
+        """On an unchanged tree the largest process stayed within 2.8 %, inside its band."""
         for metric in ("peak memory", "largest process"):
             self.assertTrue(cm.Change("j", "n", metric, 100, 200, 10.0).alerts, metric)
+
+    def test_file_size_and_symbol_count_do_not(self):
+        """`keygen` kept a byte-identical `.text` and gained 7,252 symbols and 6.6 MB."""
+        for metric in ("bytes", "symbols"):
+            self.assertFalse(cm.Change("j", "n", metric, 100, 200, 5.0).alerts, metric)
 
     def test_timing_does_not(self):
         for metric in ("cpu-s", "workspace cpu-s", "critical path s"):
             self.assertFalse(cm.Change("j", "n", metric, 100, 200, 5.0).alerts, metric)
+
+    def test_a_percentage_off_a_small_number_does_not(self):
+        change = cm.Change("j", "b: base", "instantiations", 148, 156, 5.0, 100)
+        self.assertTrue(change.regressed)
+        self.assertFalse(change.alerts)
 
     def test_an_unknown_metric_alerts_rather_than_going_unwatched(self):
         self.assertTrue(cm.Change("j", "n", "rodata_bytes", 100, 200, 5.0).alerts)
@@ -239,27 +269,150 @@ class Alerts(unittest.TestCase):
         _, regressed = cm.report_markdown(current, main, "t")
         self.assertFalse(regressed)
 
-    def test_a_binary_regression_posts_one(self):
-        def binary(size):
-            return {"b": {"bytes": size, "text_bytes": size, "symbols": size}}
+    def test_a_text_regression_posts_one(self):
+        self.assertTrue(posts_comment({"b": sized(10**7)}, {"b": sized(2 * 10**7)}))
 
-        current = {"jobs": {"j": job(binaries=binary(200))}}
-        main = {"jobs": {"j": job(binaries=binary(100))}}
-        _, regressed = cm.report_markdown(current, main, "t")
-        self.assertTrue(regressed)
+    def test_a_text_move_under_the_floor_does_not(self):
+        """A binary small enough that its whole band fits inside the floor cannot alert."""
+        small = cm.TEXT_MIN_BYTES * 2
+        over_band = round(small * (1 + cm.TEXT_PCT / 100)) + 1
+        self.assertFalse(posts_comment({"b": sized(small)}, {"b": sized(over_band)}))
+
+
+CRATES = {"hashbrown": 1_179_110}
+GROWN_CRATES = {"hashbrown": 1_320_174}
+
+
+class Gate(unittest.TestCase):
+    """A crate or a generic is the breakdown of a `.text` that moved, not a finding of its own."""
+
+    def crate(self, was_text, now_text):
+        changes = cm.binary_changes(
+            "j",
+            "b",
+            sized(was_text, crates=CRATES),
+            sized(now_text, crates=GROWN_CRATES),
+        )
+        return next(c for c in changes if c.metric == "crate bytes")
+
+    def test_quiet_inside_a_shrinking_binary(self):
+        """Pull request 4896: every binary shrank, and ten slices of them alerted."""
+        crate = self.crate(66_389_344, 64_884_720)
+        self.assertTrue(crate.regressed)
+        self.assertTrue(crate.quiet)
+        self.assertFalse(crate.alerts)
+
+    def test_loud_inside_a_growing_binary(self):
+        crate = self.crate(10**7, 2 * 10**7)
+        self.assertFalse(crate.quiet)
+        self.assertTrue(crate.alerts)
+
+    def test_quiet_when_the_binary_has_no_comparable_text(self):
+        """An artifact without `.text` leaves nothing on the binary that alerts."""
+        was = sized(10**7, crates=CRATES)
+        now = sized(2 * 10**7, crates=GROWN_CRATES)
+        del was["text_bytes"]
+        with self.assertLogs(cm.log, "WARNING"):
+            changes = cm.binary_changes("j", "b", was, now)
+        self.assertFalse(any(c.alerts for c in changes))
+
+    def test_a_binary_missing_from_the_baseline_is_not_compared(self):
+        """The largest possible size regression, and it produces no row at all."""
+        current = {"jobs": {"j": job(binaries={"new": sized(10**7)})}}
+        main = {"jobs": {"j": job(binaries={})}}
+        self.assertEqual(cm.compare(main, current), [])
+
+
+class AlertCauses(unittest.TestCase):
+    """A crate grows in every binary that links it, in every job that builds one."""
+
+    def test_one_crate_across_binaries_and_jobs_is_one_cause(self):
+        rows = [
+            cm.Change(job, f"{binary}: hashbrown", "crate bytes", 10**6, 2 * 10**6, 5.0)
+            for job, binary in (("j1", "node"), ("j1", "dev-node"), ("j2", "node"))
+        ]
+        self.assertEqual(len(cm.alert_causes(rows)), 1)
+
+    def test_distinct_crates_stay_apart(self):
+        rows = [
+            cm.Change("j", f"node: {crate}", "crate bytes", 10**6, 2 * 10**6, 5.0)
+            for crate in ("hashbrown", "serde_json")
+        ]
+        self.assertEqual(len(cm.alert_causes(rows)), 2)
+
+    def test_a_quiet_row_is_not_a_cause(self):
+        row = cm.Change("j", "node: hashbrown", "crate bytes", 10**6, 2 * 10**6, 5.0)
+        self.assertEqual(len(cm.alert_causes([row])), 1)
+        self.assertEqual(len(cm.alert_causes([replace(row, quiet=True)])), 0)
+
+    def test_a_whole_binary_is_named_by_itself(self):
+        """Binary names carry no `": "`, which is what separates the two shapes."""
+        rows = [
+            cm.Change("j", binary, "text_bytes", 10**7, 2 * 10**7, 2.0)
+            for binary in ("espresso-node", "espresso-node-sqlite")
+        ]
+        self.assertEqual(
+            cm.alert_causes(rows),
+            {("text_bytes", "espresso-node"), ("text_bytes", "espresso-node-sqlite")},
+        )
+
+
+class FamilyTables(unittest.TestCase):
+    def test_a_mixed_family_counts_only_the_rows_that_alert(self):
+        """The gate opens per binary, so one crate table can hold both kinds of row."""
+        rows = [
+            cm.Change("j", "a: hashbrown", "crate bytes", 10**6, 2 * 10**6, 5.0),
+            cm.Change(
+                "j", "b: hashbrown", "crate bytes", 10**6, 3 * 10**6, 5.0, quiet=True
+            ),
+        ]
+        (summary,) = [
+            line for line in cm.family_tables(rows) if line.startswith("**crate bytes")
+        ]
+        self.assertIn("1 over threshold", summary)
+        self.assertIn("1 up by more than 5 %", summary)
+
+    def test_a_family_with_no_alerting_row_says_only_the_band(self):
+        rows = [cm.Change("j", "u", "cpu-s", 100.0, 200.0, 15.0)]
+        (summary,) = [
+            line for line in cm.family_tables(rows) if line.startswith("**cpu-s")
+        ]
+        self.assertNotIn("over threshold", summary)
+        self.assertIn("1 up by more than 15 %", summary)
+
+
+class StickyMarker(unittest.TestCase):
+    """Pins the contract with `marocchino/sticky-pull-request-comment`, which CI posts through."""
+
+    def test_matches_the_action(self):
+        self.assertEqual(
+            cm.sticky_marker("compile-metrics-build"),
+            "<!-- Sticky Pull Request Commentcompile-metrics-build -->",
+        )
+
+    def test_headers_do_not_match_each_other(self):
+        """`sticky_comment` matches with `contains`, and `-test` is a prefix of `-slowtest`."""
+        markers = [cm.sticky_marker(header) for _, header, _ in cm.WORKFLOWS]
+        for marker in markers:
+            self.assertEqual([m for m in markers if marker in m], [marker])
 
 
 class Mark(unittest.TestCase):
     def test_regression_is_red(self):
-        self.assertEqual(cm.mark(cm.Change("j", "n", "bytes", 10.0, 20.0, 5.0)), cm.RED)
+        change = cm.Change("j", "n", "text_bytes", 10**7, 2 * 10**7, 5.0)
+        self.assertEqual(cm.mark(change), cm.RED)
 
     def test_improvement_is_green(self):
-        self.assertEqual(
-            cm.mark(cm.Change("j", "n", "bytes", 20.0, 10.0, 5.0)), cm.GREEN
-        )
+        change = cm.Change("j", "n", "text_bytes", 2 * 10**7, 10**7, 5.0)
+        self.assertEqual(cm.mark(change), cm.GREEN)
 
     def test_within_the_band_is_unmarked(self):
-        self.assertEqual(cm.mark(cm.Change("j", "n", "bytes", 10.0, 10.1, 5.0)), "")
+        change = cm.Change("j", "n", "text_bytes", 10**7, 10**7 + 1, 5.0)
+        self.assertEqual(cm.mark(change), "")
+
+    def test_a_quiet_row_is_never_marked(self):
+        row = cm.Change("j", "b: hashbrown", "crate bytes", 10**6, 2 * 10**6, 5.0)
+        self.assertEqual(cm.mark(replace(row, quiet=True)), "")
 
     def test_timing_is_never_marked(self):
         self.assertEqual(cm.mark(cm.Change("j", "n", "cpu-s", 10.0, 20.0, 15.0)), "")

--- a/scripts/test_compile_metrics.py
+++ b/scripts/test_compile_metrics.py
@@ -403,6 +403,35 @@ class FamilyTables(unittest.TestCase):
         self.assertIn("1 up by more than 15 %", summary)
 
 
+class Docstring(unittest.TestCase):
+    """The module docstring is the only place the rules are written out, so it has to keep up."""
+
+    def test_every_band_is_stated(self):
+        doc = cm.__doc__ or ""
+        bands = (
+            cm.PEAK_USED_PCT,
+            cm.PEAK_RSS_PCT,
+            cm.TEXT_PCT,
+            cm.BINARY_PCT,
+            cm.WORKSPACE_CPU_PCT,
+            cm.UNIT_CPU_PCT,
+        )
+        for band in bands:
+            self.assertIn(f"+{band:g} %", doc)
+
+    def test_every_floor_is_stated(self):
+        doc = cm.__doc__ or ""
+        self.assertIn(f"{cm.TEXT_MIN_BYTES // 1024} kB", doc)
+        self.assertIn(f"{cm.CRATE_BYTES_DELTA // 1024} kB", doc)
+        self.assertIn(f"{cm.INSTANTIATIONS_DELTA}", doc)
+        self.assertIn(f"{cm.UNIT_MIN_S:g} s", doc)
+
+    def test_every_silenced_metric_is_named(self):
+        doc = cm.__doc__ or ""
+        for metric in cm.UNALERTED:
+            self.assertIn(metric, doc, metric)
+
+
 class StickyMarker(unittest.TestCase):
     """Pins the contract with `marocchino/sticky-pull-request-comment`, which CI posts through."""
 

--- a/scripts/test_compile_metrics.py
+++ b/scripts/test_compile_metrics.py
@@ -1,16 +1,19 @@
-"""Tests for the parsing in `compile-metrics` that is not obvious from reading it.
+"""Tests for the parts of `compile-metrics` that are not obvious from reading it.
 
-Everything here is a pure function over literals, so no build, no artifact and no network.
+Pure functions over literals, plus a few that stub `gh` out, so no build, no artifact and no
+network.
 
     just py::test
 """
 
 import importlib.util
+import json
 import math
 import unittest
 from dataclasses import replace
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from unittest import mock
 
 SCRIPT = Path(__file__).with_name("compile-metrics")
 _spec = importlib.util.spec_from_loader(
@@ -448,6 +451,54 @@ class Mark(unittest.TestCase):
     def test_timing_is_never_marked(self):
         self.assertEqual(cm.mark(cm.Change("j", "n", "cpu-s", 10.0, 20.0, 15.0)), "")
         self.assertEqual(cm.mark(cm.Change("j", "n", "cpu-s", 20.0, 10.0, 15.0)), "")
+
+
+OWNERS = frozenset({"sveitser", "github-actions[bot]"})
+
+
+class PickSticky(unittest.TestCase):
+    """Quote-reply copies a report's raw markdown, invisible marker included."""
+
+    def test_a_third_party_quote_is_not_ours_to_edit(self):
+        rows = "1 github-actions[bot]\n2 someone-else"
+        self.assertEqual(cm.pick_sticky(rows, OWNERS), "1")
+
+    def test_newest_of_ours_wins(self):
+        rows = "1 github-actions[bot]\n2 someone-else\n3 sveitser"
+        self.assertEqual(cm.pick_sticky(rows, OWNERS), "3")
+
+    def test_only_third_parties_means_post_a_new_one(self):
+        self.assertIsNone(cm.pick_sticky("2 someone-else", OWNERS))
+
+    def test_no_matches(self):
+        self.assertIsNone(cm.pick_sticky("", OWNERS))
+
+
+class RunSelection(unittest.TestCase):
+    """A branch name is not unique across repositories."""
+
+    RUNS = json.dumps(
+        [
+            {"databaseId": 2, "url": "u2", "headSha": "beef"},
+            {"databaseId": 1, "url": "u1", "headSha": "cafe"},
+        ]
+    )
+
+    def newest(self, allowed):
+        with (
+            mock.patch.object(cm, "capture", return_value=self.RUNS),
+            mock.patch.object(cm, "has_metrics", return_value=True),
+        ):
+            return cm.newest_with_metrics("build.yml", ["--branch", "main"], allowed)
+
+    def test_a_run_outside_the_pull_request_is_skipped(self):
+        self.assertEqual(self.newest({"cafe"})["databaseId"], 1)
+
+    def test_no_run_belongs_to_the_pull_request(self):
+        self.assertIsNone(self.newest(set()))
+
+    def test_a_revision_selector_constrains_nothing(self):
+        self.assertEqual(self.newest(None)["databaseId"], 2)
 
 
 class FmtName(unittest.TestCase):

--- a/scripts/test_compile_metrics.py
+++ b/scripts/test_compile_metrics.py
@@ -245,10 +245,10 @@ def posts_comment(main_binaries, current_binaries):
 
 
 class Alerts(unittest.TestCase):
-    """`.text` and memory speak. Everything else is a diagnostic for one of them."""
+    """Section sizes and memory speak. Everything else is a diagnostic for one of them."""
 
     def test_text_alerts(self):
-        change = cm.Change("j", "n", "text_bytes", 10**7, 2 * 10**7, cm.TEXT_PCT)
+        change = cm.Change("j", "n", ".text", 10**7, 2 * 10**7, cm.SECTION_PCT)
         self.assertTrue(change.alerts)
 
     def test_memory_alerts(self):
@@ -284,8 +284,8 @@ class Alerts(unittest.TestCase):
 
     def test_a_text_move_under_the_floor_does_not(self):
         """A binary small enough that its whole band fits inside the floor cannot alert."""
-        small = cm.TEXT_MIN_BYTES * 2
-        over_band = round(small * (1 + cm.TEXT_PCT / 100)) + 1
+        small = cm.SECTION_MIN_BYTES * 2
+        over_band = round(small * (1 + cm.SECTION_PCT / 100)) + 1
         self.assertFalse(posts_comment({"b": sized(small)}, {"b": sized(over_band)}))
 
 
@@ -321,8 +321,8 @@ class Gate(unittest.TestCase):
         """An artifact without section sizes leaves nothing on the binary that alerts."""
         was = sized(10**7, crates=CRATES)
         now = sized(2 * 10**7, crates=GROWN_CRATES)
-        for metric in cm.SIZE_METRICS:
-            del was[metric]
+        for field in cm.SECTION_FIELDS:
+            del was[field]
         with self.assertLogs(cm.log, "WARNING"):
             changes = cm.binary_changes("j", "b", was, now)
         self.assertFalse(any(c.alerts for c in changes))
@@ -333,7 +333,7 @@ class Gate(unittest.TestCase):
         was = sized(text, rodata=10**7, crates=CRATES)
         now = sized(text, rodata=2 * 10**7, crates=GROWN_CRATES)
         changes = cm.binary_changes("j", "b", was, now)
-        rodata = next(c for c in changes if c.metric == "rodata_bytes")
+        rodata = next(c for c in changes if c.metric == ".rodata")
         crate = next(c for c in changes if c.metric == "crate bytes")
         self.assertTrue(rodata.alerting_regression)
         self.assertFalse(crate.quiet)
@@ -370,12 +370,12 @@ class AlertCauses(unittest.TestCase):
     def test_a_whole_binary_is_named_by_itself(self):
         """Binary names carry no `": "`, which is what separates the two shapes."""
         rows = [
-            cm.Change("j", binary, "text_bytes", 10**7, 2 * 10**7, 2.0)
+            cm.Change("j", binary, ".text", 10**7, 2 * 10**7, 2.0)
             for binary in ("espresso-node", "espresso-node-sqlite")
         ]
         self.assertEqual(
             cm.alert_causes(rows),
-            {("text_bytes", "espresso-node"), ("text_bytes", "espresso-node-sqlite")},
+            {(".text", "espresso-node"), (".text", "espresso-node-sqlite")},
         )
 
 
@@ -391,7 +391,7 @@ class FamilyTables(unittest.TestCase):
         (summary,) = [
             line for line in cm.family_tables(rows) if line.startswith("**crate bytes")
         ]
-        self.assertIn("1 over threshold", summary)
+        self.assertIn("1 row over threshold", summary)
         self.assertIn("1 up by more than 5 %", summary)
 
     def test_a_family_with_no_alerting_row_says_only_the_band(self):
@@ -430,15 +430,15 @@ class StickyMarker(unittest.TestCase):
 
 class Mark(unittest.TestCase):
     def test_regression_is_red(self):
-        change = cm.Change("j", "n", "text_bytes", 10**7, 2 * 10**7, 5.0)
+        change = cm.Change("j", "n", ".text", 10**7, 2 * 10**7, 5.0)
         self.assertEqual(cm.mark(change), cm.RED)
 
     def test_improvement_is_green(self):
-        change = cm.Change("j", "n", "text_bytes", 2 * 10**7, 10**7, 5.0)
+        change = cm.Change("j", "n", ".text", 2 * 10**7, 10**7, 5.0)
         self.assertEqual(cm.mark(change), cm.GREEN)
 
     def test_within_the_band_is_unmarked(self):
-        change = cm.Change("j", "n", "text_bytes", 10**7, 10**7 + 1, 5.0)
+        change = cm.Change("j", "n", ".text", 10**7, 10**7 + 1, 5.0)
         self.assertEqual(cm.mark(change), "")
 
     def test_a_quiet_row_is_never_marked(self):

--- a/scripts/test_compile_metrics.py
+++ b/scripts/test_compile_metrics.py
@@ -207,6 +207,15 @@ class Collapse(unittest.TestCase):
         ]
         self.assertEqual(len(cm.collapse(rows)), 2)
 
+    def test_a_quiet_row_does_not_merge_into_a_loud_one(self):
+        """Sibling binaries share the std bases that dominate `instantiations`, at equal counts."""
+        rows = [
+            cm.Change("j", "a: base", "instantiations", 148, 356, 5.0, 100),
+            cm.Change("j", "b: base", "instantiations", 148, 356, 5.0, 100, quiet=True),
+        ]
+        self.assertEqual(len(cm.collapse(rows)), 2)
+        self.assertEqual(len(cm.collapse(rows[::-1])), 2)
+
     def test_different_jobs_stay_apart(self):
         rows = [
             cm.Change("j1", "bin: a", "instantiations", 50, 93, 5.0),
@@ -215,10 +224,11 @@ class Collapse(unittest.TestCase):
         self.assertEqual(len(cm.collapse(rows)), 2)
 
 
-def sized(text, bytes_=None, symbols=None, crates=None, bases=None):
+def sized(text, rodata=0, bytes_=None, symbols=None, crates=None, bases=None):
     return {
         "bytes": bytes_ if bytes_ is not None else text,
         "text_bytes": text,
+        "rodata_bytes": rodata,
         "symbols": symbols if symbols is not None else text,
         "crate_bytes": crates or {},
         "instantiations": bases or {},
@@ -307,14 +317,26 @@ class Gate(unittest.TestCase):
         self.assertFalse(crate.quiet)
         self.assertTrue(crate.alerts)
 
-    def test_quiet_when_the_binary_has_no_comparable_text(self):
-        """An artifact without `.text` leaves nothing on the binary that alerts."""
+    def test_quiet_when_the_binary_has_no_comparable_section(self):
+        """An artifact without section sizes leaves nothing on the binary that alerts."""
         was = sized(10**7, crates=CRATES)
         now = sized(2 * 10**7, crates=GROWN_CRATES)
-        del was["text_bytes"]
+        for metric in cm.SIZE_METRICS:
+            del was[metric]
         with self.assertLogs(cm.log, "WARNING"):
             changes = cm.binary_changes("j", "b", was, now)
         self.assertFalse(any(c.alerts for c in changes))
+
+    def test_rodata_opens_the_gate_on_its_own(self):
+        """An `include_bytes!` grows `.rodata` and leaves `.text` where it was."""
+        text = 10**7
+        was = sized(text, rodata=10**7, crates=CRATES)
+        now = sized(text, rodata=2 * 10**7, crates=GROWN_CRATES)
+        changes = cm.binary_changes("j", "b", was, now)
+        rodata = next(c for c in changes if c.metric == "rodata_bytes")
+        crate = next(c for c in changes if c.metric == "crate bytes")
+        self.assertTrue(rodata.alerting_regression)
+        self.assertFalse(crate.quiet)
 
     def test_a_binary_missing_from_the_baseline_is_not_compared(self):
         """The largest possible size regression, and it produces no row at all."""


### PR DESCRIPTION
- metrics are rather noisy probably need historical tracking to me useful
- add a github bot `/compile-metrics` should run on the PR and post a sticky comment on the PR (this needs merge to main to test, I believe)