### PR TITLE
fix(slow-tests): box rotate_validator to bound test stack use

### DIFF
--- a/justfile
+++ b/justfile
@@ -169,9 +169,12 @@ test *args:
     just nextest --features embedded-db  {{args}}
     just nextest {{args}}
 
+# These tests stand up whole multi-node networks inline on a single libtest
+# thread, which leaves the largest of them a few KB under the 2 MiB default
+# stack. 4 MiB gives them roughly 2x headroom instead.
 test-slow *args:
     @echo 'Only slow tests are included. Use `test` for those deemed not slow. Or `test-all` for all tests.'
-    cargo nextest run --profile slow --locked -p slow-tests --verbose {{args}}
+    RUST_MIN_STACK=4194304 cargo nextest run --profile slow --locked -p slow-tests --verbose {{args}}
 
 build-dev-node *args:
     cargo build -p espresso-dev-node {{args}}

--- a/slow-tests/tests/stake_table_changes.rs
+++ b/slow-tests/tests/stake_table_changes.rs
@@ -1589,10 +1589,10 @@ async fn rotate_validator(rotation: Rotation) -> anyhow::Result<()> {
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_stake_table_rotate_p2p_address_v6() -> anyhow::Result<()> {
-    rotate_validator(Rotation::P2pAddr).await
+    Box::pin(rotate_validator(Rotation::P2pAddr)).await
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_stake_table_rotate_consensus_keys_v6() -> anyhow::Result<()> {
-    rotate_validator(Rotation::ConsensusKeys).await
+    Box::pin(rotate_validator(Rotation::ConsensusKeys)).await
 }

--- a/slow-tests/tests/stake_table_changes.rs
+++ b/slow-tests/tests/stake_table_changes.rs
@@ -1428,7 +1428,7 @@ async fn fresh_node_joins(version: Upgrade, epoch_height: u64) -> anyhow::Result
 /// Fresh join at 0.5: see [`fresh_node_joins`].
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_stake_table_fresh_node_joins_v5() -> anyhow::Result<()> {
-    fresh_node_joins(V5, 15).await
+    Box::pin(fresh_node_joins(V5, 15)).await
 }
 
 /// Fresh join at 0.6: the node is outside every cliquenet peer window until
@@ -1436,7 +1436,7 @@ async fn test_stake_table_fresh_node_joins_v5() -> anyhow::Result<()> {
 /// happens in the epoch before its duties begin; see [`fresh_node_joins`].
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_stake_table_fresh_node_joins_v6() -> anyhow::Result<()> {
-    fresh_node_joins(V6, 20).await
+    Box::pin(fresh_node_joins(V6, 20)).await
 }
 
 /// How [`rotate_validator`] rotates the validator's on-chain identity.


### PR DESCRIPTION
### This PR:
* Raises the slow-test thread stack to 4 MiB in the `test-slow` recipe, giving every test in `stake_table_changes` roughly 2x headroom instead of the few KB it had.
* Boxes the outermost future of the four largest tests there, so their ~72-75 KB state machines are heap-allocated rather than sitting on the libtest thread's stack.
* Background: `test_stake_table_rotate_{p2p_address,consensus_keys}_v6` had under 8 KB of headroom on `main`, and #4866's epoch-membership rewrite tipped them into `fatal runtime error: stack overflow` on the postgres shards. `test_stake_table_fresh_node_joins_{v5,v6}` had 12-24 KB and were next in line.

### This PR does not:
* Touch production code — the `rotate_validator` and `fresh_node_joins` helpers, and the node init path, are unchanged.
* Use nextest's `[env]` table for the stack value: 0.9.140 silently ignores it (a test forced to 1 MiB that way ran normally on the 2 MiB default), so the setting lives in the recipe, which covers CI and local runs alike.

### Key places to review:
* `justfile`, `test-slow` — the 4 MiB value. This alone fixes CI; the boxing commits are belt-and-braces for anyone running the test binary directly rather than through `just`.
* `slow-tests/tests/stake_table_changes.rs` — the four boxed call sites. `rotate_validator` and `fresh_node_joins` are the outermost futures of their tests, so every other future nests inside them; boxing anything further in recovers strictly less.

### How to test this PR:
* `just test-slow test_stake_table_fresh_node_joins_v6` — note that `{{args}}` is interpolated unquoted, so a nextest `-E 'test(...)'` filter expression needs quoting of its own; a bare substring filter works.

### Things tested
* Via `just test-slow` in a worktree on these commits: with the recipe temporarily set to 1 MiB the test aborts (`has overflowed its stack`, SIGABRT at 20.9 s, exit 100); restored to 4 MiB it passes — `PASS [242.749s] ... 1 test run: 1 passed`. The 1 MiB control is what proves the variable actually reaches libtest.
* `RUST_MIN_STACK` bisection of the boxing, on a warm tree carrying these changes: the rotate tests move from a threshold just over 2 MiB to ~1.81 MiB, and `fresh_node_joins_v6` from `(2072576, 2084864]` to `(1835008, 1900544]`.
* Not run: clippy, and the full slow-test suite against these commits — left to CI.
