### PR TITLE
fix(state-cert): bind fetched certs to their block height's epoch

### DIFF
--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -734,7 +734,13 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence> StateCertFetchingData
             ))),
             Ok(Ok(cert)) => {
                 // Validation errors should be mapped to ValidationError
-                validate_state_cert(&cert, &stake_table).map_err(|e| {
+                validate_state_cert(
+                    &cert,
+                    &stake_table,
+                    EpochNumber::new(epoch),
+                    *coordinator.epoch_height(),
+                )
+                .map_err(|e| {
                     StateCertFetchError::ValidationError(e.context(format!(
                         "state certificate validation failed for epoch={epoch}"
                     )))

--- a/crates/espresso/node/src/state_cert.rs
+++ b/crates/espresso/node/src/state_cert.rs
@@ -9,10 +9,12 @@ use espresso_types::SeqTypes;
 use hotshot_contract_adapter::light_client::derive_signed_state_digest;
 use hotshot_query_service::availability::Error;
 use hotshot_types::{
+    data::EpochNumber,
     light_client::StateVerKey,
     simple_certificate::LightClientStateUpdateCertificateV2,
     stake_table::HSStakeTable,
     traits::signature_key::{LCV2StateSignatureKey, LCV3StateSignatureKey, StakeTableEntryType},
+    utils::epoch_from_block_number,
 };
 
 /// Error type for state certificate fetching
@@ -47,11 +49,37 @@ impl From<StateCertFetchError> for hotshot_query_service::availability::Error {
     }
 }
 
-/// Validates a state certificate by verifying signatures and checking threshold
+/// Validates a state certificate: that it belongs to `expected_epoch`, and that its
+/// signatures reach the threshold under `stake_table`.
 pub fn validate_state_cert(
     cert: &LightClientStateUpdateCertificateV2<SeqTypes>,
     stake_table: &HSStakeTable<SeqTypes>,
+    expected_epoch: EpochNumber,
+    epoch_height: u64,
 ) -> anyhow::Result<()> {
+    // `cert.epoch` is outside the signed digest, so a peer can set it to whatever was
+    // requested. `block_height` is inside it, so derive the epoch from that instead.
+    let derived_epoch = EpochNumber::new(epoch_from_block_number(
+        cert.light_client_state.block_height,
+        epoch_height,
+    ));
+    if derived_epoch != expected_epoch {
+        bail!(
+            "state certificate is for block {} in epoch {derived_epoch}, but epoch \
+             {expected_epoch} was requested",
+            cert.light_client_state.block_height
+        );
+    }
+
+    if cert.epoch != derived_epoch {
+        bail!(
+            "state certificate is labelled epoch {}, but its block {} belongs to epoch \
+             {derived_epoch}",
+            cert.epoch,
+            cert.light_client_state.block_height
+        );
+    }
+
     let signed_state_digest = derive_signed_state_digest(
         &cert.light_client_state,
         &cert.next_stake_table_state,
@@ -114,4 +142,125 @@ pub fn validate_state_cert(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{FixedBytes, U256};
+    use espresso_types::PubKey;
+    use hotshot_contract_adapter::light_client::derive_signed_state_digest;
+    use hotshot_types::{
+        light_client::{CircuitField, LightClientState, StakeTableState, StateKeyPair, StateVerKey},
+        simple_certificate::LightClientStateUpdateCertificateV2,
+        stake_table::HSStakeTable,
+        traits::signature_key::{LCV2StateSignatureKey, LCV3StateSignatureKey, SignatureKey},
+        PeerConfig,
+    };
+
+    use super::*;
+
+    /// Non-zero, so the LCV3 signatures are checked. The exact bytes don't matter.
+    const AUTH_ROOT: [u8; 32] = [9u8; 32];
+
+    const NUM_SIGNERS: u64 = 4;
+    const STAKE_PER_SIGNER: u64 = 100;
+
+    /// Makes the fixture's block 100 the epoch root of epoch 1: (100 + 5) % 105 == 0.
+    const EPOCH_HEIGHT: u64 = 105;
+
+    /// A certificate with valid LCV2 and LCV3 signatures from every signer, and the stake
+    /// table those signers belong to.
+    fn valid_cert_and_stake_table() -> (
+        LightClientStateUpdateCertificateV2<SeqTypes>,
+        HSStakeTable<SeqTypes>,
+    ) {
+        let light_client_state = LightClientState {
+            view_number: 42,
+            block_height: 100,
+            block_comm_root: CircuitField::from(7u64),
+        };
+        let next_stake_table_state = StakeTableState {
+            bls_key_comm: CircuitField::from(1u64),
+            schnorr_key_comm: CircuitField::from(2u64),
+            amount_comm: CircuitField::from(3u64),
+            threshold: CircuitField::from(1u64),
+        };
+        let auth_root = FixedBytes::<32>::from(AUTH_ROOT);
+        let digest =
+            derive_signed_state_digest(&light_client_state, &next_stake_table_state, &auth_root);
+
+        let mut signatures = Vec::new();
+        let mut peers = Vec::new();
+        for i in 0..NUM_SIGNERS {
+            let state_key_pair = StateKeyPair::generate_from_seed_indexed([0u8; 32], i);
+            let sign_key = state_key_pair.sign_key_ref();
+
+            let lcv2_sig = <StateVerKey as LCV2StateSignatureKey>::sign_state(
+                sign_key,
+                &light_client_state,
+                &next_stake_table_state,
+            )
+            .expect("LCV2 sign");
+            let lcv3_sig = <StateVerKey as LCV3StateSignatureKey>::sign_state(sign_key, digest)
+                .expect("LCV3 sign");
+
+            signatures.push((state_key_pair.ver_key(), lcv3_sig, lcv2_sig));
+
+            let bls_key = PubKey::generated_from_seed_indexed([0u8; 32], i).0;
+            peers.push(PeerConfig::<SeqTypes> {
+                stake_table_entry: bls_key.stake_table_entry(U256::from(STAKE_PER_SIGNER)),
+                state_ver_key: state_key_pair.ver_key(),
+                connect_info: None,
+            });
+        }
+
+        let cert = LightClientStateUpdateCertificateV2::<SeqTypes> {
+            epoch: hotshot_types::data::EpochNumber::new(1),
+            light_client_state,
+            next_stake_table_state,
+            signatures,
+            auth_root,
+        };
+        (cert, HSStakeTable::from(peers))
+    }
+
+    #[test]
+    fn test_valid_cert_is_accepted() {
+        let (cert, stake_table) = valid_cert_and_stake_table();
+        validate_state_cert(&cert, &stake_table, EpochNumber::new(1), EPOCH_HEIGHT)
+            .expect("well-formed certificate must validate");
+    }
+
+    /// `epoch` is a bare label: `derive_signed_state_digest` covers only the light client
+    /// state, the next stake table state, and the auth root. A peer can relabel a certificate
+    /// it holds for one epoch to match a request for another, and enough of the two epochs'
+    /// signers normally overlap to clear the one-honest threshold against the wrong stake
+    /// table. So the binding must be to `block_height`, which is signed.
+    #[test]
+    fn test_cert_from_another_epoch_is_rejected() {
+        let (mut cert, stake_table) = valid_cert_and_stake_table();
+
+        let digest_before = derive_signed_state_digest(
+            &cert.light_client_state,
+            &cert.next_stake_table_state,
+            &cert.auth_root,
+        );
+        cert.epoch = EpochNumber::new(2);
+        let digest_after = derive_signed_state_digest(
+            &cert.light_client_state,
+            &cert.next_stake_table_state,
+            &cert.auth_root,
+        );
+        assert_eq!(
+            digest_before, digest_after,
+            "relabelling changed the signed digest; if this ever fails the epoch became \
+             authenticated and the label check is redundant"
+        );
+
+        // Relabelling does not help: the signed block height still says epoch 1.
+        validate_state_cert(&cert, &stake_table, EpochNumber::new(2), EPOCH_HEIGHT).expect_err(
+            "a cert whose signed block height belongs to epoch 1 must not satisfy a request \
+             for epoch 2, however it is labelled",
+        );
+    }
 }

--- a/crates/espresso/node/src/state_cert.rs
+++ b/crates/espresso/node/src/state_cert.rs
@@ -286,6 +286,23 @@ mod tests {
         );
     }
 
+    /// The label is what downstream consumers key on after validation, so it has to agree
+    /// with the block height even when the height itself satisfies the request.
+    #[test]
+    fn test_cert_with_mislabelled_epoch_is_rejected() {
+        // Block 100 is an epoch root and derives to the requested epoch, so only the label
+        // check can reject this.
+        assert!(is_epoch_root(100, EPOCH_HEIGHT));
+        assert_eq!(epoch_from_block_number(100, EPOCH_HEIGHT), 1);
+
+        let (mut cert, stake_table) = valid_cert_and_stake_table();
+        cert.epoch = EpochNumber::new(2);
+
+        validate_state_cert(&cert, &stake_table, EpochNumber::new(1), EPOCH_HEIGHT).expect_err(
+            "a cert whose label disagrees with its signed block height must be rejected",
+        );
+    }
+
     /// Validators sign the light client state of ordinary blocks too, and publish those
     /// signatures to a public relay over the same digest verified here. Only epoch roots
     /// carry a genuine certificate, so a bundle assembled at any other height is a forgery.

--- a/crates/espresso/node/src/state_cert.rs
+++ b/crates/espresso/node/src/state_cert.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use alloy::primitives::{FixedBytes, U256};
-use anyhow::bail;
+use anyhow::{bail, ensure};
 use disco_types::status::StatusCode;
 use espresso_types::SeqTypes;
 use hotshot_contract_adapter::light_client::derive_signed_state_digest;
@@ -14,7 +14,7 @@ use hotshot_types::{
     simple_certificate::LightClientStateUpdateCertificateV2,
     stake_table::HSStakeTable,
     traits::signature_key::{LCV2StateSignatureKey, LCV3StateSignatureKey, StakeTableEntryType},
-    utils::epoch_from_block_number,
+    utils::{epoch_from_block_number, is_epoch_root},
 };
 
 /// Error type for state certificate fetching
@@ -57,6 +57,15 @@ pub fn validate_state_cert(
     expected_epoch: EpochNumber,
     epoch_height: u64,
 ) -> anyhow::Result<()> {
+    // Validators publish state signatures for ordinary blocks to a public relay, over the
+    // same digest verified below. Only epoch roots ever carry a genuine certificate, so
+    // without this a peer could assemble one from harvested relay signatures.
+    ensure!(
+        is_epoch_root(cert.light_client_state.block_height, epoch_height),
+        "state certificate is for block {}, which is not an epoch root",
+        cert.light_client_state.block_height
+    );
+
     // `cert.epoch` is outside the signed digest, so a peer can set it to whatever was
     // requested. `block_height` is inside it, so derive the epoch from that instead.
     let derived_epoch = EpochNumber::new(epoch_from_block_number(
@@ -174,9 +183,20 @@ mod tests {
         LightClientStateUpdateCertificateV2<SeqTypes>,
         HSStakeTable<SeqTypes>,
     ) {
+        cert_and_stake_table_at(100)
+    }
+
+    /// As above, but for an arbitrary block height, so a caller can build a correctly signed
+    /// certificate for a block that is not an epoch root.
+    fn cert_and_stake_table_at(
+        block_height: u64,
+    ) -> (
+        LightClientStateUpdateCertificateV2<SeqTypes>,
+        HSStakeTable<SeqTypes>,
+    ) {
         let light_client_state = LightClientState {
             view_number: 42,
-            block_height: 100,
+            block_height,
             block_comm_root: CircuitField::from(7u64),
         };
         let next_stake_table_state = StakeTableState {
@@ -262,5 +282,20 @@ mod tests {
             "a cert whose signed block height belongs to epoch 1 must not satisfy a request \
              for epoch 2, however it is labelled",
         );
+    }
+
+    /// Validators sign the light client state of ordinary blocks too, and publish those
+    /// signatures to a public relay over the same digest verified here. Only epoch roots
+    /// carry a genuine certificate, so a bundle assembled at any other height is a forgery.
+    #[test]
+    fn test_cert_for_a_non_epoch_root_block_is_rejected() {
+        // Block 99 is inside epoch 1 but is not its root, so only the epoch-root check
+        // can reject it: the signatures are valid and the derived epoch matches.
+        assert!(!is_epoch_root(99, EPOCH_HEIGHT));
+        assert_eq!(epoch_from_block_number(99, EPOCH_HEIGHT), 1);
+
+        let (cert, stake_table) = cert_and_stake_table_at(99);
+        validate_state_cert(&cert, &stake_table, EpochNumber::new(1), EPOCH_HEIGHT)
+            .expect_err("a cert for a block that is not an epoch root must be rejected");
     }
 }

--- a/crates/espresso/node/src/state_cert.rs
+++ b/crates/espresso/node/src/state_cert.rs
@@ -159,11 +159,13 @@ mod tests {
     use espresso_types::PubKey;
     use hotshot_contract_adapter::light_client::derive_signed_state_digest;
     use hotshot_types::{
-        light_client::{CircuitField, LightClientState, StakeTableState, StateKeyPair, StateVerKey},
+        PeerConfig,
+        light_client::{
+            CircuitField, LightClientState, StakeTableState, StateKeyPair, StateVerKey,
+        },
         simple_certificate::LightClientStateUpdateCertificateV2,
         stake_table::HSStakeTable,
         traits::signature_key::{LCV2StateSignatureKey, LCV3StateSignatureKey, SignatureKey},
-        PeerConfig,
     };
 
     use super::*;
@@ -279,8 +281,8 @@ mod tests {
 
         // Relabelling does not help: the signed block height still says epoch 1.
         validate_state_cert(&cert, &stake_table, EpochNumber::new(2), EPOCH_HEIGHT).expect_err(
-            "a cert whose signed block height belongs to epoch 1 must not satisfy a request \
-             for epoch 2, however it is labelled",
+            "a cert whose signed block height belongs to epoch 1 must not satisfy a request for \
+             epoch 2, however it is labelled",
         );
     }
 


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
This is for an issue in node-side validation, used when the node fetches/serves a state cert via StateCertFetchingData in the API layer. This prevents a real cert from being misapplied outside its intended epoch context.  It also ensures that the fetched certs are at an epoch root

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

### How to test this PR:
cargo test -p espresso-node --lib state_cert::

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216719045684458