### PR TITLE
Validate the epoch of share fragments and shares.

### DIFF
--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -190,12 +190,21 @@ pub enum ConsensusOutput<T: NodeType> {
     BroadcastVidShare(VidDisperseShare2<T>),
 }
 
-type UnpairedProposals<T> = BTreeMap<
-    (ViewNumber, VidCommitment2),
-    (<T as NodeType>::SignatureKey, ProposalMessage<T, Validated>),
->;
+/// What a proposal and this node's VID share for it must agree on to pair.
+///
+/// A share's epoch is supplied by its disperser and covered by no signature,
+/// so keying on it means a share naming an epoch other than its proposal's
+/// never pairs: it cannot be the one this node votes on, stores, or
+/// broadcasts, and the honest share for the view can still arrive and pair.
+///
+/// That makes the share's epoch exactly as trustworthy as the proposal's, and
+/// no more.
+type PairingKey = (ViewNumber, Option<EpochNumber>, VidCommitment2);
 
-type UnpairedVidShares<T> = BTreeMap<(ViewNumber, VidCommitment2), VidDisperseShare2<T>>;
+type UnpairedProposals<T> =
+    BTreeMap<PairingKey, (<T as NodeType>::SignatureKey, ProposalMessage<T, Validated>)>;
+
+type UnpairedVidShares<T> = BTreeMap<PairingKey, VidDisperseShare2<T>>;
 
 /// Views to retain decide inputs (`proposals`, `certs`, `certs2`) behind the
 /// decided view, letting a late-broadcast Cert2 decide an older gap view.
@@ -977,8 +986,9 @@ impl<T: NodeType> Consensus<T> {
                 self.certs2 = self.certs2.split_off(&keep_from);
                 self.decided_views = self.decided_views.split_off(&keep_from);
                 self.proposals = self.proposals.split_off(&keep_from);
-                self.unpaired_proposals = self.unpaired_proposals.split_off(&(keep_from, vc));
-                self.unpaired_vid_shares = self.unpaired_vid_shares.split_off(&(keep_from, vc));
+                self.unpaired_proposals = self.unpaired_proposals.split_off(&(keep_from, None, vc));
+                self.unpaired_vid_shares =
+                    self.unpaired_vid_shares.split_off(&(keep_from, None, vc));
                 self.vote1_parent = self.vote1_parent.split_off(&keep_from);
                 self.leaves = self.leaves.split_off(&view);
                 self.signed_proposals = self.signed_proposals.split_off(&view);
@@ -1045,7 +1055,7 @@ impl<T: NodeType> Consensus<T> {
 
     /// Pair a validated proposal with this node's VID share for the same payload.
     ///
-    /// The half arriving first is parked, keyed by (view, payload commitment).
+    /// The half arriving first is parked under its [`PairingKey`].
     fn pair_proposal(
         &mut self,
         sender: T::SignatureKey,
@@ -1058,9 +1068,9 @@ impl<T: NodeType> Consensus<T> {
             warn!(%view, "proposal payload commitment is not V2, discarding");
             return Protocol::Abort;
         };
-        let Some(vid_share) = self.unpaired_vid_shares.remove(&(view, commit)) else {
-            self.unpaired_proposals
-                .insert((view, commit), (sender, proposal));
+        let key = (view, Some(proposal.proposal.data.epoch), commit);
+        let Some(vid_share) = self.unpaired_vid_shares.remove(&key) else {
+            self.unpaired_proposals.insert(key, (sender, proposal));
             return Protocol::Abort;
         };
         self.on_proposal_paired(sender, proposal, vid_share, outbox)
@@ -1068,13 +1078,17 @@ impl<T: NodeType> Consensus<T> {
 
     /// Pair this node's VID share with a validated proposal for the same payload.
     ///
-    /// The half arriving first is parked, keyed by (view, payload commitment).
+    /// The half arriving first is parked under its [`PairingKey`].
     fn pair_vid_share(
         &mut self,
         vid_share: VidDisperseShare2<T>,
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) -> Protocol {
-        let key = (vid_share.view_number(), vid_share.payload_commitment);
+        let key = (
+            vid_share.view_number(),
+            vid_share.epoch,
+            vid_share.payload_commitment,
+        );
         let Some((sender, proposal)) = self.unpaired_proposals.remove(&key) else {
             self.unpaired_vid_shares.insert(key, vid_share);
             return Protocol::Abort;
@@ -1318,7 +1332,8 @@ impl<T: NodeType> Consensus<T> {
         view: ViewNumber,
         leaf_commit: Commitment<Leaf2<T>>,
     ) -> Option<ProposalMessage<T, Validated>> {
-        let range = (view, VidCommitment2::default())..(view + 1, VidCommitment2::default());
+        let vc = VidCommitment2::default();
+        let range = (view, None, vc)..(view + 1, None, vc);
         self.unpaired_proposals
             .range(range)
             .map(|(_, (_, message))| message)
@@ -1355,7 +1370,7 @@ impl<T: NodeType> Consensus<T> {
             return None;
         };
         self.unpaired_vid_shares
-            .get(&(view, commitment))
+            .get(&(view, Some(proposal.epoch), commitment))
             .map(|share| share.payload_byte_len())
     }
 

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -1740,11 +1740,6 @@ impl<T: NodeType> Consensus<T> {
             view,
             epoch,
         ));
-        if !self.is_leader(view, epoch) {
-            debug!(%epoch, "not leader");
-            return Protocol::Abort;
-        }
-
         // If we are the leader of the next view, try to get a block to propose
         // after forming the TC
         let Some(locked_view) = self.locked_cert.as_ref().map(|cert| cert.view_number()) else {
@@ -1755,12 +1750,25 @@ impl<T: NodeType> Consensus<T> {
             debug!(%locked_view, "proposal not available");
             return Protocol::Abort;
         };
-        // Note: We don't handle epoch change on timeout certificate, because
-        // we can't change epoch after a timeout
+        // Not an epoch change: `current_epoch` stays where the certificate put
+        // it. A block's epoch follows its own height, so one built on the last
+        // parent of an epoch belongs to the next, timeout or not. This is the
+        // rule `maybe_propose` uses to pick the proposal's epoch, and matching
+        // it keeps the dispersal in the same epoch as the proposal.
+        let request_epoch =
+            if is_last_block(proposal.block_header.block_number(), *self.epoch_height) {
+                proposal.epoch + 1
+            } else {
+                proposal.epoch
+            };
+        if !self.is_leader(view, request_epoch) {
+            debug!(epoch = %request_epoch, "not leader");
+            return Protocol::Abort;
+        }
         outbox.push_back(ConsensusOutput::RequestBlockAndHeader(
             BlockAndHeaderRequest {
                 view,
-                epoch,
+                epoch: request_epoch,
                 parent_proposal: proposal.clone(),
             },
         ));

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -2102,7 +2102,7 @@ pub enum GcScope {
 /// The window around `current` that a VID share fragment's epoch may name.
 pub(crate) fn fragment_epoch_admissible(epoch: EpochNumber, current: EpochNumber) -> bool {
     current.saturating_sub(EPOCH_CHANGE_LOOKBEHIND) <= *epoch
-        && *epoch <= *current + EPOCH_CHANGE_LOOKAHEAD
+        && *epoch <= current.saturating_add(EPOCH_CHANGE_LOOKAHEAD)
 }
 
 /// A payload built locally and awaiting DA persistence.

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -88,6 +88,18 @@ const STORAGE_GC_MARGIN: u64 = 5;
 /// advances ([`CertVerifiers::retry_pending`] runs on every DRB arrival).
 const EPOCH_CHANGE_LOOKAHEAD: u64 = 3;
 
+/// Epochs *below* the node's current one that a VID share fragment may name.
+///
+/// [`EPOCH_CHANGE_LOOKAHEAD`] alone is one-sided, which for a fragment would
+/// leave every cached epoch's leader schedule admissible -- around
+/// `RECENT_STAKE_TABLES_LIMIT` of them. A fragment's epoch authorises nobody on
+/// its own, so this is not what stops a forged one; it bounds how many distinct
+/// dispersers can open a fragment buffer for a single view.
+///
+/// One epoch of slack, because a fragment for the tail of the outgoing epoch
+/// can arrive just after the node has entered the next one.
+const EPOCH_CHANGE_LOOKBEHIND: u64 = 1;
+
 pub(crate) const MAX_VIEWS_AHEAD: ViewNumber = ViewNumber::new(30);
 
 #[derive(Builder)]
@@ -829,7 +841,7 @@ where
                     );
                 }
                 let expected_param =
-                    expected_vid_param(&self.membership_coordinator, vid_share.target_epoch);
+                    expected_vid_param(&self.membership_coordinator, proposal.data.epoch);
                 self.vid_reconstructor.handle_proposal(
                     view,
                     vid_share.payload_commitment,
@@ -1115,6 +1127,10 @@ where
                 ConsensusMessage::VidShareFragment(fragment) => {
                     let view = fragment.data.view_number();
                     debug!(%node, %sender, %view, "received vid share fragment");
+                    if self.is_view_too_far_ahead(view) {
+                        warn!(%node, %sender, %view, "vid share fragment is too far ahead");
+                        return None;
+                    }
                     if fragment.data.recipient_key != self.public_key {
                         warn!(
                             %node,
@@ -1124,22 +1140,36 @@ where
                         );
                         return None;
                     }
-                    let leader = fragment
-                        .data
-                        .epoch
-                        .and_then(|epoch| self.leader(view, epoch));
-                    if leader.as_ref() != Some(&message.sender) {
+                    let Some(epoch) = fragment.data.epoch else {
+                        warn!(%node, %sender, %view, "ignoring vid share fragment without an epoch");
+                        return None;
+                    };
+                    if !self.is_fragment_epoch_admissible(epoch) {
                         warn!(
                             %node,
                             %sender,
                             %view,
+                            %epoch,
+                            "vid share fragment epoch is outside the admissible window"
+                        );
+                        return None;
+                    }
+                    if self.leader(view, epoch).as_ref() != Some(&message.sender) {
+                        warn!(
+                            %node,
+                            %sender,
+                            %view,
+                            %epoch,
                             "ignoring vid share fragment not from the view leader"
                         );
                         return None;
                     }
                     if self.consensus.wants_proposal_for_view(&view) {
                         let signature = fragment.signature.clone();
-                        match self.vid_fragment_accumulator.accept(fragment.data) {
+                        match self
+                            .vid_fragment_accumulator
+                            .accept(&message.sender, fragment.data)
+                        {
                             Ok(Some(share)) => self
                                 .share_validator
                                 .validate(SignedProposal::new(share, signature)),
@@ -2021,6 +2051,15 @@ where
         epoch.is_some_and(|e| e > current + EPOCH_CHANGE_LOOKAHEAD)
     }
 
+    /// Is `epoch` close enough to the node's own to buffer a fragment naming it?
+    fn is_fragment_epoch_admissible(&self, epoch: EpochNumber) -> bool {
+        let current = self
+            .consensus
+            .current_epoch()
+            .unwrap_or(EpochNumber::genesis());
+        fragment_epoch_admissible(epoch, current)
+    }
+
     pub(crate) fn catchup_evidence(&self) -> Option<ConsensusMessage<T, Validated>> {
         Some(match self.consensus.catchup_evidence()? {
             CatchupEvidence::Qc(qc) => ConsensusMessage::HighQc(qc),
@@ -2058,6 +2097,12 @@ pub enum GcScope {
     Decided(ViewNumber),
     /// GC is invoked on a view that advanced via timeout certificate.
     Timeout(ViewNumber),
+}
+
+/// The window around `current` that a VID share fragment's epoch may name.
+pub(crate) fn fragment_epoch_admissible(epoch: EpochNumber, current: EpochNumber) -> bool {
+    current.saturating_sub(EPOCH_CHANGE_LOOKBEHIND) <= *epoch
+        && *epoch <= *current + EPOCH_CHANGE_LOOKAHEAD
 }
 
 /// A payload built locally and awaiting DA persistence.

--- a/crates/hotshot/new-protocol/src/fetch.rs
+++ b/crates/hotshot/new-protocol/src/fetch.rs
@@ -168,7 +168,7 @@ impl<T: NodeType> Fetcher<T> {
                     fetch.pending.remove(sender);
                 }
 
-                let Some(param) = expected_vid_param(membership, Some(proposal.epoch)) else {
+                let Some(param) = expected_vid_param(membership, proposal.epoch) else {
                     warn!(%view, "no VID param for fetched payload; dropping");
                     return false;
                 };
@@ -292,11 +292,8 @@ mod tests {
         };
         let bytes = payload.encode().to_vec();
 
-        let param = expected_vid_param(
-            &harness.membership_coordinator,
-            Some(EpochNumber::genesis()),
-        )
-        .expect("committee resolves");
+        let param = expected_vid_param(&harness.membership_coordinator, EpochNumber::genesis())
+            .expect("committee resolves");
         let ns_table = ns_table::parse_ns_table(bytes.len(), &metadata.encode());
         let (commitment, _) = AvidmGf2Scheme::commit(&param, &bytes, ns_table).expect("commit");
 

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -392,7 +392,7 @@ impl TestData {
                 .get(&leader_public_key)
                 .expect("Leader key not found in key map");
 
-            let (vid_disperse, vid_shares) = extract_vid_disperse(gen_view);
+            let (mut vid_disperse, mut vid_shares) = extract_vid_disperse(gen_view);
             let block_number = BlockHeader::<TestTypes>::block_number(&proposal.block_header);
 
             // Compute epoch from block number (generator doesn't know about
@@ -431,6 +431,16 @@ impl TestData {
             let gen_epoch = gen_view.epoch_number.unwrap_or(EpochNumber::genesis());
             let epoch_patched = epoch != gen_epoch;
             proposal.epoch = epoch;
+            // The dispersal carries the proposal's epoch, as `VidDisperser`
+            // gives it: the two must agree for the share to pair with the
+            // proposal. The epoch is not an input to the commitment, so
+            // patching it does not invalidate the shares.
+            vid_disperse.epoch = Some(epoch);
+            vid_disperse.target_epoch = Some(epoch);
+            for share in &mut vid_shares {
+                share.epoch = Some(epoch);
+                share.target_epoch = Some(epoch);
+            }
 
             let needs_new_epoch = is_last_block(block_number.saturating_sub(1), epoch_height);
             if needs_new_epoch {

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -2146,3 +2146,45 @@ async fn test_no_fork_votes_from_one_node_reversed() {
          branch parented at view 1"
     );
 }
+
+/// A VID share pairs with a proposal only when the two name the same epoch.
+///
+/// The share's epoch is supplied by its disperser and covered by no signature,
+/// so a share naming another epoch must not become the one this node votes on,
+/// stores or broadcasts — and, just as importantly, must not consume the
+/// view: the honest share has to remain free to arrive and pair.
+#[tokio::test]
+async fn vid_share_pairs_only_within_the_proposals_epoch() {
+    let test_data = TestData::new(1).await;
+    let view = &test_data.views[0];
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+    let mut harness = ConsensusHarness::new(0).await;
+
+    let is_paired = |output: &ConsensusOutput<TestTypes>| {
+        matches!(output, ConsensusOutput::ProposalPaired { .. })
+    };
+
+    let (proposal, honest_share) = view.proposal_input_consensus(&node_key);
+    let mut relabelled = view.vid_share_for(&node_key);
+    relabelled.epoch = relabelled.epoch.map(|epoch| epoch + 1);
+    relabelled.target_epoch = relabelled.epoch;
+
+    harness.apply(proposal).await;
+    harness.apply(ConsensusInput::VidShare(relabelled)).await;
+    assert!(
+        !any(harness.outputs(), is_paired),
+        "a share naming another epoch must not pair with the proposal"
+    );
+    assert!(
+        !any(harness.outputs(), is_vote1),
+        "and must not produce a vote"
+    );
+
+    // The proposal is still waiting, so its own share pairs when it arrives.
+    harness.apply(honest_share).await;
+    assert!(
+        any(harness.outputs(), is_paired),
+        "the honest share must still pair after the relabelled one was refused"
+    );
+    assert!(any(harness.outputs(), is_vote1), "and must produce a vote");
+}

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -2188,3 +2188,76 @@ async fn vid_share_pairs_only_within_the_proposals_epoch() {
     );
     assert!(any(harness.outputs(), is_vote1), "and must produce a vote");
 }
+
+/// A block's epoch follows its own height, so one built on the last parent of
+/// an epoch belongs to the next — timeout or not. The request epoch decides
+/// which committee the block is dispersed to and which total weight its
+/// payload commitment is built under, so it has to be the epoch the proposal
+/// will name, not the certificate's.
+#[tokio::test]
+async fn timeout_at_an_epoch_boundary_requests_the_next_epoch() {
+    const EPOCH_HEIGHT: u64 = 10;
+
+    // `parent_idx` is the view whose block the proposal chains from; the
+    // request is for the view after it.
+    async fn request_epoch_after_timeout(parent_idx: usize, epoch: EpochNumber) -> EpochNumber {
+        let test_data = TestData::new_with_epoch_height(parent_idx + 2, EPOCH_HEIGHT).await;
+        let parent = &test_data.views[parent_idx];
+        let next_view = ViewNumber::new(parent_idx as u64 + 2);
+
+        // The node that leads the next view in the epoch its block falls in.
+        let probe = ConsensusHarness::new_with_epoch_height(0, EPOCH_HEIGHT).await;
+        let leader = probe
+            .consensus
+            .leader_of(next_view, epoch)
+            .expect("a leader for the next view");
+        let mut harness =
+            ConsensusHarness::new_with_epoch_height(node_index_for_key(&leader), EPOCH_HEIGHT)
+                .await;
+
+        harness
+            .apply_pair(parent.proposal_input_consensus(&leader))
+            .await;
+        harness.apply(parent.block_reconstructed_input()).await;
+        harness.apply(parent.cert1_input()).await;
+        harness.apply(parent.timeout_cert_input()).await;
+
+        // Scope to the view under test: the setup steps and `maybe_propose`'s
+        // re-request path emit their own requests, and taking the first would
+        // assert on one of those instead.
+        let epochs: Vec<EpochNumber> = harness
+            .outputs()
+            .iter()
+            .filter_map(|output| match output {
+                ConsensusOutput::RequestBlockAndHeader(request) if request.view == next_view => {
+                    Some(request.epoch)
+                },
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !epochs.is_empty(),
+            "the leader requests a block for view {next_view} after the timeout"
+        );
+        assert!(
+            epochs.iter().all(|e| *e == epochs[0]),
+            "every request for view {next_view} must name one epoch, got {epochs:?}"
+        );
+        epochs[0]
+    }
+
+    // View 10 carries block 10, the last of epoch 1, so the block built on it
+    // is the first of epoch 2.
+    assert_eq!(
+        request_epoch_after_timeout(9, EpochNumber::new(2)).await,
+        EpochNumber::new(2),
+        "a boundary parent must roll the request epoch over",
+    );
+
+    // A mid-epoch parent must not: the rollover is not unconditional.
+    assert_eq!(
+        request_epoch_after_timeout(4, EpochNumber::new(1)).await,
+        EpochNumber::new(1),
+        "a mid-epoch parent must keep the parent's epoch",
+    );
+}

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -807,12 +807,17 @@ async fn test_epoch3_transition_requests_drb_for_future_epoch() {
         signature: v17.proposal.signature.clone(),
         _pd: std::marker::PhantomData,
     };
-    let vid_share = v17
+    let mut vid_share = v17
         .vid_shares
         .iter()
         .find(|s| s.recipient_key == node_key)
         .expect("VID share not found")
         .clone();
+    // The proposal is relabelled into epoch 3 to reach the transition window,
+    // so its dispersal is too: a share pairs with a proposal only in the epoch
+    // the proposal names.
+    vid_share.epoch = Some(EpochNumber::new(3));
+    vid_share.target_epoch = Some(EpochNumber::new(3));
     harness
         .apply_pair((
             ConsensusInput::Proposal(v17.leader_public_key, ProposalMessage::validated(signed)),

--- a/crates/hotshot/new-protocol/src/tests/integration.rs
+++ b/crates/hotshot/new-protocol/src/tests/integration.rs
@@ -2,12 +2,19 @@ use std::time::Duration;
 
 use hotshot::types::BLSPubKey;
 use hotshot_example_types::node_types::TestTypes;
-use hotshot_types::{traits::signature_key::SignatureKey, vote::HasViewNumber};
+use hotshot_types::{
+    data::{EpochNumber, VidCommitment2},
+    traits::signature_key::SignatureKey,
+    vote::HasViewNumber,
+};
 
 use super::common::{harness::TestHarness, utils::TestData};
 use crate::{
-    consensus::ConsensusInput,
-    message::{CatchupEvidence, ConsensusMessage, EpochChangeMessage, Proposal, Validated},
+    consensus::{ConsensusInput, ConsensusOutput},
+    message::{
+        CatchupEvidence, ConsensusMessage, EpochChangeMessage, Message, MessageType, Proposal,
+        Validated,
+    },
     tests::common::assertions::{
         any, count_matching, is_block_built, is_block_reconstructed, is_cert1, is_cert2,
         is_drb_result, is_header_created, is_header_created_for_view, is_leaf_decided, is_proposal,
@@ -763,4 +770,83 @@ async fn test_stale_timeout_vote_answered_with_catchup_evidence() {
     // tallied: it must not regress or otherwise disturb consensus state.
     harness.message(test_data.views[0].timeout_vote_input(1, None));
     assert_eq!(*harness.current_view(), 3);
+}
+
+/// A VID share fragment authorises its sender through an epoch the sender
+/// chose, over a signature covering only the payload commitment. Neither a
+/// stream from a node that does not lead the view nor one naming an epoch
+/// outside the admissible window may displace the honest leader's: the node
+/// must still assemble its own share, vote, and broadcast the real share.
+///
+/// The forged streams are shaped as squats -- a single namespace, so they
+/// would complete on their first fragment -- which under a view-keyed
+/// accumulator would retire the view and strand the honest fragments.
+#[tokio::test]
+async fn test_forged_vid_fragments_do_not_block_the_vote() {
+    let test_data = TestData::new(1).await;
+    let mut harness = TestHarness::new(0).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+    let view = &test_data.views[0];
+
+    // Shape a squat: claim a single namespace so the stream completes at once,
+    // and a commitment of its own so an admitted forgery is distinguishable
+    // from the honest share.
+    let squat = |fragment: &mut Message<TestTypes, Validated>| {
+        if let MessageType::Consensus(ConsensusMessage::VidShareFragment(f)) =
+            &mut fragment.message_type
+        {
+            f.data.num_namespaces = 1;
+            f.data.namespaces.truncate(1);
+            f.data.payload_commitment = VidCommitment2::default();
+        }
+    };
+
+    // A node that does not lead this view, relaying the leader's signature
+    // (it covers only the payload commitment, so it is public).
+    let impostor = (1..10u64)
+        .map(|i| BLSPubKey::generated_from_seed_indexed([0; 32], i).0)
+        .find(|key| *key != view.leader_public_key)
+        .expect("a non-leader among the committee");
+    for mut fragment in view.vid_share_inputs(&node_key) {
+        fragment.sender = impostor;
+        squat(&mut fragment);
+        harness.message(fragment);
+    }
+
+    // The view's real leader, but naming an epoch outside the window.
+    for mut fragment in view.vid_share_inputs(&node_key) {
+        squat(&mut fragment);
+        if let MessageType::Consensus(ConsensusMessage::VidShareFragment(f)) =
+            &mut fragment.message_type
+        {
+            f.data.epoch = Some(EpochNumber::new(999));
+            f.data.target_epoch = Some(EpochNumber::new(999));
+        }
+        harness.message(fragment);
+    }
+
+    harness.message(view.proposal_input());
+    for fragment in view.vid_share_inputs(&node_key) {
+        harness.message(fragment);
+    }
+
+    // If either forged stream had taken the view, the honest share would never
+    // assemble and no vote1 would ever be produced.
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        harness.process_until_output(|outputs| any(outputs, is_vote1)),
+    )
+    .await
+    .expect("forged fragments must not stop the honest share assembling");
+
+    // And the share it broadcasts is its own, not a forgery.
+    let broadcast = harness
+        .outputs()
+        .iter()
+        .find_map(|output| match output {
+            ConsensusOutput::BroadcastVidShare(share) => Some(share.clone()),
+            _ => None,
+        })
+        .expect("the node broadcasts its share alongside vote1");
+    assert_eq!(broadcast, view.vid_share_for(&node_key));
 }

--- a/crates/hotshot/new-protocol/src/tests/vid.rs
+++ b/crates/hotshot/new-protocol/src/tests/vid.rs
@@ -32,6 +32,13 @@ fn attacker_key() -> BLSPubKey {
     BLSPubKey::generated_from_seed_indexed([0u8; 32], 9).0
 }
 
+/// The disperser a fragment arrived from: the authenticated message sender,
+/// which the accumulator keys its per-view buffers by. Stands in for the view's
+/// honest leader.
+fn disperser_key() -> BLSPubKey {
+    BLSPubKey::generated_from_seed_indexed([0u8; 32], 1).0
+}
+
 /// A share claiming the view's commitment and common but carrying a different
 /// payload's content, so it fails merkle verification. Occupies voter `slot`'s
 /// shard range, addressed to `recipient_key` (forge it to model squatting).
@@ -614,7 +621,9 @@ async fn fragment_accumulator_reassembles_share() {
     let mut accumulator = VidFragmentAccumulator::<TestTypes>::new();
     let mut reassembled = None;
     for (i, fragment) in fragments.into_iter().enumerate() {
-        let out = accumulator.accept(fragment).expect("fragment accepted");
+        let out = accumulator
+            .accept(&disperser_key(), fragment)
+            .expect("fragment accepted");
         if i == last {
             reassembled = out;
         } else {
@@ -644,7 +653,7 @@ async fn fragment_accumulator_rejects_malformed_fragments() {
     out_of_range.num_namespaces = 2;
     out_of_range.namespaces[0].ns_index = 2;
     assert!(matches!(
-        accumulator.accept(out_of_range),
+        accumulator.accept(&disperser_key(), out_of_range),
         Err(VidFragmentError::IndexOutOfRange {
             index: 2,
             num_namespaces: 2
@@ -657,14 +666,14 @@ async fn fragment_accumulator_rejects_malformed_fragments() {
     first.namespaces[0].ns_index = 0;
     assert!(
         accumulator
-            .accept(first.clone())
+            .accept(&disperser_key(), first.clone())
             .expect("accepted")
             .is_none()
     );
 
     // A second fragment for the same index is a duplicate.
     assert!(matches!(
-        accumulator.accept(first),
+        accumulator.accept(&disperser_key(), first),
         Err(VidFragmentError::DuplicateIndex(0))
     ));
 
@@ -674,7 +683,7 @@ async fn fragment_accumulator_rejects_malformed_fragments() {
     wrong_commitment.namespaces[0].ns_index = 1;
     wrong_commitment.payload_commitment = VidCommitment2::default();
     assert!(matches!(
-        accumulator.accept(wrong_commitment),
+        accumulator.accept(&disperser_key(), wrong_commitment),
         Err(VidFragmentError::Inconsistent)
     ));
 }
@@ -728,7 +737,9 @@ async fn fragment_accumulator_reassembles_multi_piece_fragments() {
         .collect();
     let mut accumulator = VidFragmentAccumulator::<TestTypes>::new();
     assert_eq!(
-        accumulator.accept(whole).expect("accepted"),
+        accumulator
+            .accept(&disperser_key(), whole)
+            .expect("accepted"),
         Some(original.clone())
     );
 
@@ -744,8 +755,18 @@ async fn fragment_accumulator_reassembles_multi_piece_fragments() {
     second.namespaces = pieces[2..].to_vec();
 
     let mut accumulator = VidFragmentAccumulator::<TestTypes>::new();
-    assert!(accumulator.accept(second).expect("accepted").is_none());
-    assert_eq!(accumulator.accept(first).expect("accepted"), Some(original));
+    assert!(
+        accumulator
+            .accept(&disperser_key(), second)
+            .expect("accepted")
+            .is_none()
+    );
+    assert_eq!(
+        accumulator
+            .accept(&disperser_key(), first)
+            .expect("accepted"),
+        Some(original)
+    );
 }
 
 /// Two pieces for the same namespace index within a single fragment are
@@ -765,7 +786,115 @@ async fn fragment_accumulator_rejects_intra_fragment_duplicate() {
 
     let mut accumulator = VidFragmentAccumulator::<TestTypes>::new();
     assert!(matches!(
-        accumulator.accept(fragment),
+        accumulator.accept(&disperser_key(), fragment),
         Err(VidFragmentError::DuplicateIndex(0))
+    ));
+}
+
+/// A fragment's `epoch` and `target_epoch` are both chosen by its sender and
+/// covered by no signature, yet they select committees on different paths: the
+/// leader lookup and share verification for `epoch`, the erasure parameters the
+/// reconstructor holds every peer's share to for `target_epoch`. An honest
+/// disperser sends them equal, so a fragment that lets them diverge is
+/// malformed — as is one that names no epoch at all.
+#[tokio::test]
+async fn fragment_accumulator_rejects_diverging_epochs() {
+    let test_data = TestData::new(1).await;
+    let view = &test_data.views[0];
+    let template = vid_fragments(&honest_share(view, 0))
+        .next()
+        .expect("at least one piece");
+
+    let mut accumulator = VidFragmentAccumulator::<TestTypes>::new();
+
+    let mut diverging = template.clone();
+    diverging.target_epoch = diverging.epoch.map(|e| e + 1);
+    assert!(matches!(
+        accumulator.accept(&disperser_key(), diverging),
+        Err(VidFragmentError::TargetEpochMismatch { .. })
+    ));
+
+    let mut no_epoch = template;
+    no_epoch.epoch = None;
+    no_epoch.target_epoch = None;
+    assert!(matches!(
+        accumulator.accept(&disperser_key(), no_epoch),
+        Err(VidFragmentError::MissingEpoch)
+    ));
+}
+
+/// A fragment stream is buffered per disperser, so one sender cannot lock a
+/// view. Here an attacker completes the view first with a one-namespace
+/// fragment carrying the real commitment — under a single per-view buffer this
+/// would pin the metadata and mark the view done, dropping everything the
+/// honest leader sent afterwards. The honest share must still reassemble.
+#[tokio::test]
+async fn fragment_accumulator_isolates_dispersers() {
+    let test_data = TestData::new(1).await;
+    let view = &test_data.views[0];
+    let original = multi_namespace_share(view, 0, 4);
+
+    // The attacker replays the view's commitment but claims a single namespace,
+    // so its "share" completes on the first fragment.
+    let mut squat = vid_fragments(&original).next().expect("at least one piece");
+    squat.num_namespaces = 1;
+    let mut accumulator = VidFragmentAccumulator::<TestTypes>::new();
+    assert!(
+        accumulator
+            .accept(&attacker_key(), squat)
+            .expect("accepted")
+            .is_some(),
+        "the squatting stream should complete on its own buffer",
+    );
+
+    // The honest leader's four fragments still reassemble the real share.
+    let fragments = vid_fragments(&original).collect::<Vec<_>>();
+    let last = fragments.len() - 1;
+    let mut reassembled = None;
+    for (i, fragment) in fragments.into_iter().enumerate() {
+        let out = accumulator
+            .accept(&disperser_key(), fragment)
+            .expect("fragment accepted");
+        if i == last {
+            reassembled = out;
+        } else {
+            assert!(out.is_none(), "share completed before its last fragment");
+        }
+    }
+    assert_eq!(reassembled, Some(original));
+}
+
+/// The fragment epoch window is inclusive on both sides and must not overflow
+/// on an epoch chosen by whoever sent the fragment.
+#[test]
+fn fragment_epoch_window_bounds() {
+    use hotshot_types::data::EpochNumber;
+
+    use crate::coordinator::fragment_epoch_admissible;
+
+    let current = EpochNumber::new(10);
+    for (epoch, admissible) in [
+        (8, false),
+        (9, true),
+        (10, true),
+        (13, true),
+        (14, false),
+        (u64::MAX, false),
+    ] {
+        assert_eq!(
+            fragment_epoch_admissible(EpochNumber::new(epoch), current),
+            admissible,
+            "epoch {epoch} against current {current}",
+        );
+    }
+
+    // Genesis: the lower bound saturates rather than wrapping to the top.
+    assert!(fragment_epoch_admissible(
+        EpochNumber::genesis(),
+        EpochNumber::genesis()
+    ));
+    assert!(!fragment_epoch_admissible(
+        EpochNumber::new(u64::MAX),
+        EpochNumber::genesis()
     ));
 }

--- a/crates/hotshot/new-protocol/src/vid.rs
+++ b/crates/hotshot/new-protocol/src/vid.rs
@@ -42,16 +42,15 @@ pub use reconstruct::{
     ObtainedPayload, VidReconstructError, VidReconstructErrorKind, VidReconstructor,
 };
 
-/// The VID erasure parameters the committee fixes for `target_epoch`,
-/// matching what an honest disperser derives. Used to reject shares whose
-/// `common.param` is forged (the commitment binds `ns_commits`, not `param`)
-/// and to verify payloads fetched whole. `None` if the committee cannot be
-/// resolved.
+/// The VID erasure parameters the committee for `epoch` fixes, matching what
+/// an honest disperser derives. Used to reject shares whose `common.param` is
+/// forged (the commitment binds `ns_commits`, not `param`) and to verify
+/// payloads fetched whole. `None` if the committee cannot be resolved.
 pub fn expected_vid_param<T: NodeType>(
     membership: &EpochMembershipCoordinator<T>,
-    target_epoch: Option<EpochNumber>,
+    epoch: EpochNumber,
 ) -> Option<AvidmGf2Param> {
-    let membership = membership.stake_table_for_epoch(target_epoch).ok()?;
-    let total_weight = vid_total_weight::<T, _>(membership.stake_table(), target_epoch);
+    let membership = membership.stake_table_for_epoch(Some(epoch)).ok()?;
+    let total_weight = vid_total_weight::<T, _>(membership.stake_table(), Some(epoch));
     init_avidm_gf2_param(total_weight).ok()
 }

--- a/crates/hotshot/new-protocol/src/vid/fragments.rs
+++ b/crates/hotshot/new-protocol/src/vid/fragments.rs
@@ -197,7 +197,8 @@ impl<T: NodeType> PendingShare<T> {
         &mut self,
         pieces: Vec<AvidmGf2NamespacePiece>,
     ) -> Result<(), VidFragmentError> {
-        for piece in pieces {
+        let mut incoming = BTreeSet::new();
+        for piece in &pieces {
             let ns_index = piece.ns_index;
             if ns_index >= self.num_namespaces {
                 return Err(VidFragmentError::IndexOutOfRange {
@@ -205,10 +206,12 @@ impl<T: NodeType> PendingShare<T> {
                     num_namespaces: self.num_namespaces,
                 });
             }
-            if self.pieces.contains_key(&ns_index) {
+            if self.pieces.contains_key(&ns_index) || !incoming.insert(ns_index) {
                 return Err(VidFragmentError::DuplicateIndex(ns_index));
             }
-            self.pieces.insert(ns_index, piece);
+        }
+        for piece in pieces {
+            self.pieces.insert(piece.ns_index, piece);
         }
         Ok(())
     }

--- a/crates/hotshot/new-protocol/src/vid/fragments.rs
+++ b/crates/hotshot/new-protocol/src/vid/fragments.rs
@@ -10,8 +10,11 @@ use hotshot_types::{
 };
 
 pub struct VidFragmentAccumulator<T: NodeType> {
-    pending: BTreeMap<ViewNumber, PendingShare<T>>,
-    completed: BTreeSet<ViewNumber>,
+    /// Partial shares per view, keyed within a view by the disperser that sent
+    /// the fragments. Keying by disperser is what keeps one sender's stream
+    /// from displacing another's; see [`Self::accept`].
+    pending: BTreeMap<ViewNumber, BTreeMap<T::SignatureKey, PendingShare<T>>>,
+    completed: BTreeMap<ViewNumber, BTreeSet<T::SignatureKey>>,
     lower_bound: ViewNumber,
 }
 
@@ -28,17 +31,15 @@ pub enum VidFragmentError {
 
     #[error("fragment contains no namespaces")]
     Empty,
-}
 
-/// A view's partially-collected namespace pieces, keyed by namespace index.
-struct PendingShare<T: NodeType> {
-    epoch: Option<EpochNumber>,
-    target_epoch: Option<EpochNumber>,
-    payload_commitment: VidCommitment2,
-    recipient_key: T::SignatureKey,
-    param: AvidmGf2Param,
-    num_namespaces: usize,
-    pieces: BTreeMap<usize, AvidmGf2NamespacePiece>,
+    #[error("fragment names no epoch")]
+    MissingEpoch,
+
+    #[error("fragment target epoch {target_epoch:?} does not match its epoch {epoch:?}")]
+    TargetEpochMismatch {
+        epoch: Option<EpochNumber>,
+        target_epoch: Option<EpochNumber>,
+    },
 }
 
 impl<T: NodeType> Default for VidFragmentAccumulator<T> {
@@ -51,93 +52,199 @@ impl<T: NodeType> VidFragmentAccumulator<T> {
     pub fn new() -> Self {
         Self {
             pending: BTreeMap::new(),
-            completed: BTreeSet::new(),
+            completed: BTreeMap::new(),
             lower_bound: ViewNumber::genesis(),
         }
     }
 
-    /// Buffer a `fragment` addressed to this node.
+    /// Buffer a `fragment` addressed to this node, sent by `disperser`.
     ///
     /// Returns `Ok(None)` while namespaces are still outstanding,
     /// `Ok(Some(share))` once the final namespace completes the view, and
-    /// `Err` if the fragment is malformed or inconsistent with the view's
-    /// already-pinned metadata.
+    /// `Err` if the fragment is malformed or inconsistent with what
+    /// `disperser` already pinned for the view.
+    ///
+    /// `disperser` is the authenticated message sender, not a field of the
+    /// fragment. Each disperser gets its own buffer: a fragment stream commits to
+    /// nothing beyond its payload commitment, so a stream that pinned or
+    /// completed a view for one sender must not lock out the view's honest
+    /// leader.
     pub fn accept(
         &mut self,
+        disperser: &T::SignatureKey,
         fragment: AvidmGf2DisperseShareFragment<T>,
     ) -> Result<Option<VidDisperseShare2<T>>, VidFragmentError> {
         let view = fragment.view_number;
-        if view < self.lower_bound || self.completed.contains(&view) {
+        if self.is_retired(view, disperser) {
             return Ok(None);
         }
-        if fragment.num_namespaces == 0 {
-            return Err(VidFragmentError::Empty);
-        }
-        let pending = self.pending.entry(view).or_insert_with(|| PendingShare {
-            epoch: fragment.epoch,
-            target_epoch: fragment.target_epoch,
-            payload_commitment: fragment.payload_commitment,
-            recipient_key: fragment.recipient_key.clone(),
-            param: fragment.param.clone(),
-            num_namespaces: fragment.num_namespaces,
-            pieces: BTreeMap::new(),
-        });
-        if pending.num_namespaces != fragment.num_namespaces
-            || pending.epoch != fragment.epoch
-            || pending.target_epoch != fragment.target_epoch
-            || pending.payload_commitment != fragment.payload_commitment
-            || pending.recipient_key != fragment.recipient_key
-            || pending.param != fragment.param
-        {
-            return Err(VidFragmentError::Inconsistent);
-        }
-        for piece in fragment.namespaces {
-            let ns_index = piece.ns_index;
-            if ns_index >= pending.num_namespaces {
-                return Err(VidFragmentError::IndexOutOfRange {
-                    index: ns_index,
-                    num_namespaces: pending.num_namespaces,
-                });
-            }
-            if pending.pieces.contains_key(&ns_index) {
-                return Err(VidFragmentError::DuplicateIndex(ns_index));
-            }
-            pending.pieces.insert(ns_index, piece);
-        }
-        if pending.pieces.len() != pending.num_namespaces {
+        let epoch = well_formed(&fragment)?;
+        let complete = {
+            let pending = self.pending_for(view, disperser, epoch, &fragment)?;
+            pending.insert_pieces(fragment.namespaces)?;
+            pending.is_complete()
+        };
+        if !complete {
             return Ok(None);
         }
-        // Every namespace is present and indices are distinct and in range, so
-        // they cover `0..num_namespaces` exactly; the `BTreeMap` yields them in
-        // that order.
-        let pending = self.pending.remove(&view).expect("just inserted above");
-        self.completed.insert(view);
-        let mut ns_commits = Vec::with_capacity(pending.num_namespaces);
-        let mut ns_lens = Vec::with_capacity(pending.num_namespaces);
-        let mut ns_shares = Vec::with_capacity(pending.num_namespaces);
-        for piece in pending.pieces.into_values() {
-            ns_commits.push(piece.ns_commit);
-            ns_lens.push(piece.ns_payload_byte_len);
-            ns_shares.push(piece.ns_share);
-        }
-        Ok(Some(VidDisperseShare2 {
-            view_number: view,
-            epoch: pending.epoch,
-            target_epoch: pending.target_epoch,
-            payload_commitment: pending.payload_commitment,
-            share: ns_shares.into(),
-            recipient_key: pending.recipient_key,
-            common: AvidmGf2Common {
-                param: pending.param,
-                ns_commits,
-                ns_lens,
-            },
-        }))
+        let pending = self.take_pending(view, disperser);
+        self.completed
+            .entry(view)
+            .or_default()
+            .insert(disperser.clone());
+        Ok(Some(pending.into_share(view)))
     }
 
     pub fn gc(&mut self, view_number: ViewNumber) {
         self.pending = self.pending.split_off(&view_number);
         self.completed = self.completed.split_off(&view_number);
         self.lower_bound = view_number;
+    }
+
+    /// Has `view` been GCed, or `disperser` already completed a share for it?
+    fn is_retired(&self, view: ViewNumber, disperser: &T::SignatureKey) -> bool {
+        view < self.lower_bound
+            || self
+                .completed
+                .get(&view)
+                .is_some_and(|keys| keys.contains(disperser))
+    }
+
+    /// `disperser`'s buffer for `view`, opening it on the first fragment and
+    /// pinning the metadata every later fragment of the stream must repeat.
+    fn pending_for<'a>(
+        &'a mut self,
+        view: ViewNumber,
+        disperser: &T::SignatureKey,
+        epoch: EpochNumber,
+        fragment: &AvidmGf2DisperseShareFragment<T>,
+    ) -> Result<&'a mut PendingShare<T>, VidFragmentError> {
+        let pending = self
+            .pending
+            .entry(view)
+            .or_default()
+            .entry(disperser.clone())
+            .or_insert_with(|| PendingShare {
+                epoch,
+                payload_commitment: fragment.payload_commitment,
+                recipient_key: fragment.recipient_key.clone(),
+                param: fragment.param.clone(),
+                num_namespaces: fragment.num_namespaces,
+                pieces: BTreeMap::new(),
+            });
+        if pending.num_namespaces != fragment.num_namespaces
+            || pending.epoch != epoch
+            || pending.payload_commitment != fragment.payload_commitment
+            || pending.recipient_key != fragment.recipient_key
+            || pending.param != fragment.param
+        {
+            return Err(VidFragmentError::Inconsistent);
+        }
+        Ok(pending)
+    }
+
+    /// Remove `disperser`'s buffer for `view`, dropping the view's map once it
+    /// holds no other disperser.
+    fn take_pending(&mut self, view: ViewNumber, disperser: &T::SignatureKey) -> PendingShare<T> {
+        let by_disperser = self
+            .pending
+            .get_mut(&view)
+            .expect("buffer just opened above");
+        let pending = by_disperser
+            .remove(disperser)
+            .expect("buffer just opened above");
+        if by_disperser.is_empty() {
+            self.pending.remove(&view);
+        }
+        pending
+    }
+}
+
+/// The fragment's epoch, if the fragment is structurally sound.
+///
+/// An honest disperser sends `epoch` and `target_epoch` equal. They are
+/// separately chosen by whoever sent the fragment and select committees on
+/// different paths downstream -- `epoch` the leader and share verification,
+/// `target_epoch` the erasure parameters the reconstructor holds every peer's
+/// share to -- so a fragment that lets them diverge is malformed.
+fn well_formed<T: NodeType>(
+    fragment: &AvidmGf2DisperseShareFragment<T>,
+) -> Result<EpochNumber, VidFragmentError> {
+    if fragment.num_namespaces == 0 {
+        return Err(VidFragmentError::Empty);
+    }
+    if fragment.target_epoch != fragment.epoch {
+        return Err(VidFragmentError::TargetEpochMismatch {
+            epoch: fragment.epoch,
+            target_epoch: fragment.target_epoch,
+        });
+    }
+    fragment.epoch.ok_or(VidFragmentError::MissingEpoch)
+}
+
+/// A view's partially-collected namespace pieces, keyed by namespace index.
+struct PendingShare<T: NodeType> {
+    epoch: EpochNumber,
+    payload_commitment: VidCommitment2,
+    recipient_key: T::SignatureKey,
+    param: AvidmGf2Param,
+    num_namespaces: usize,
+    pieces: BTreeMap<usize, AvidmGf2NamespacePiece>,
+}
+
+impl<T: NodeType> PendingShare<T> {
+    fn insert_pieces(
+        &mut self,
+        pieces: Vec<AvidmGf2NamespacePiece>,
+    ) -> Result<(), VidFragmentError> {
+        for piece in pieces {
+            let ns_index = piece.ns_index;
+            if ns_index >= self.num_namespaces {
+                return Err(VidFragmentError::IndexOutOfRange {
+                    index: ns_index,
+                    num_namespaces: self.num_namespaces,
+                });
+            }
+            if self.pieces.contains_key(&ns_index) {
+                return Err(VidFragmentError::DuplicateIndex(ns_index));
+            }
+            self.pieces.insert(ns_index, piece);
+        }
+        Ok(())
+    }
+
+    fn is_complete(&self) -> bool {
+        self.pieces.len() == self.num_namespaces
+    }
+
+    /// Assemble the completed share.
+    ///
+    /// Every namespace is present and indices are distinct and in range, so
+    /// they cover `0..num_namespaces` exactly; the `BTreeMap` yields them in
+    /// that order.
+    fn into_share(self, view: ViewNumber) -> VidDisperseShare2<T> {
+        let mut ns_commits = Vec::with_capacity(self.num_namespaces);
+        let mut ns_lens = Vec::with_capacity(self.num_namespaces);
+        let mut ns_shares = Vec::with_capacity(self.num_namespaces);
+        for piece in self.pieces.into_values() {
+            ns_commits.push(piece.ns_commit);
+            ns_lens.push(piece.ns_payload_byte_len);
+            ns_shares.push(piece.ns_share);
+        }
+        VidDisperseShare2 {
+            view_number: view,
+            epoch: Some(self.epoch),
+            // Equal to `epoch` by `well_formed`; reusing it is what keeps the
+            // two from diverging in the assembled share.
+            target_epoch: Some(self.epoch),
+            payload_commitment: self.payload_commitment,
+            share: ns_shares.into(),
+            recipient_key: self.recipient_key,
+            common: AvidmGf2Common {
+                param: self.param,
+                ns_commits,
+                ns_lens,
+            },
+        }
     }
 }


### PR DESCRIPTION
A VID share fragment's epoch is chosen by its sender, over a signature covering only the payload commitment and with no block number or certificate to check it against. It nonetheless selected the committee for the leader lookup authorising that sender, and the assembled share's epoch selected the committee for share verification. Nothing compared either against the proposal. Fragment-side counterpart to https://github.com/EspressoSystems/espresso-network/pull/4897.

Put the epoch in the proposal/share pairing key, so a share naming another epoch never pairs and cannot be voted on, stored or broadcast.

Pairing is downstream of assembly, so it cannot help if the real share never assembles — and the accumulator keyed its state by view alone, so any node leading the view in some other epoch could complete or pin it first and lock the honest leader out, denying the replica its vote. Key `pending` and `completed` by the authenticated sender as well as the view, so each disperser fills its own buffer.

Bound the epoch a fragment may name to a two-sided window around the node's own, checked before the leader lookup so a message cannot drive stake-table catchup. Also require target_epoch == epoch, and add the `is_view_too_far_ahead` guard the neighbouring message arms already have.

The fixture patched a proposal's epoch by block height but left its VID shares at genesis; production disperses with the epoch it proposes with, so patch the shares too.