### PR TITLE
Epoch handling at a timed-out epoch boundary

### DIFF
--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -220,6 +220,11 @@ where
             .await
             .context("loading persisted locked QC")?;
 
+        let anchor_cert2 = persistence
+            .load_cert2(initializer_for_coordinator.anchor_leaf().view_number())
+            .await
+            .context("loading persisted anchor cert2")?;
+
         let coordinator = Coordinator::maker()
             .membership_coordinator(membership_coordinator.clone())
             .network(coordinator_network)
@@ -234,6 +239,7 @@ where
             .metrics(metrics)
             .consensus_metrics(consensus_metrics)
             .maybe_locked_qc(locked_qc)
+            .maybe_anchor_cert2(anchor_cert2)
             .make();
 
         let legacy_event_rx = handle.event_stream_known_impl().deactivate();

--- a/crates/espresso/node/src/persistence.rs
+++ b/crates/espresso/node/src/persistence.rs
@@ -2881,6 +2881,134 @@ mod tests {
         Ok(())
     }
 
+    /// The anchor's Cert2 survives a consumed decide, as its leaf does.
+    ///
+    /// A node restarted on the last block of an epoch proposes the first block
+    /// of the next one, and needs that block's Cert2 to do it. Nothing rebuilds
+    /// the certificate once the view is decided, so the cleanup that follows a
+    /// decide has to spare the newest leaf's row.
+    ///
+    /// Only that row. Rows behind the anchor go on each backend's own schedule,
+    /// eagerly under SQL and with retention on the file backend, which
+    /// `test_pruning` covers.
+    #[rstest_reuse::apply(persistence_types)]
+    pub async fn test_decide_keeps_the_anchor_cert2<P: TestablePersistence>(_p: PhantomData<P>) {
+        // With this height, block 10 is the last block of epoch 1 and block 11
+        // the first of epoch 2.
+        const EPOCH_HEIGHT: u64 = 10;
+
+        let tmp = P::tmp_storage().await;
+        let storage = P::connect(&tmp).await;
+
+        let genesis_leaf: Leaf2 = Leaf2::genesis(
+            &ValidatedState::default(),
+            &NodeState::mock(),
+            TEST_VERSIONS.test.base,
+        )
+        .await;
+        let mut quorum_proposal = QuorumProposalWrapper::<SeqTypes> {
+            proposal: QuorumProposal2::<SeqTypes> {
+                epoch: Some(EpochNumber::new(1)),
+                block_header: genesis_leaf.block_header().clone(),
+                view_number: ViewNumber::new(EPOCH_HEIGHT - 1),
+                justify_qc: QuorumCertificate2::genesis(
+                    &ValidatedState::default(),
+                    &NodeState::mock(),
+                    TEST_VERSIONS.test,
+                )
+                .await,
+                upgrade_certificate: None,
+                view_change_evidence: None,
+                next_drb_result: None,
+                next_epoch_justify_qc: None,
+                state_cert: None,
+            },
+        };
+
+        // The block before the boundary, then the boundary block itself.
+        *quorum_proposal.proposal.block_header.height_mut() = EPOCH_HEIGHT - 1;
+        let penultimate = Leaf2::from_quorum_proposal(&quorum_proposal);
+
+        quorum_proposal.proposal.view_number = ViewNumber::new(EPOCH_HEIGHT);
+        *quorum_proposal.proposal.block_header.height_mut() = EPOCH_HEIGHT;
+        quorum_proposal.proposal.justify_qc.view_number = ViewNumber::new(EPOCH_HEIGHT - 1);
+        let boundary = Leaf2::from_quorum_proposal(&quorum_proposal);
+
+        let qc_for = |leaf: &Leaf2| {
+            let mut qc = leaf.justify_qc();
+            qc.view_number = leaf.view_number();
+            qc.data.leaf_commit = Committable::commit(leaf);
+            qc
+        };
+        let cert2_for = |leaf: &Leaf2| {
+            let data = Vote2Data {
+                leaf_commit: Committable::commit(leaf),
+                epoch: EpochNumber::new(1),
+                block_number: leaf.height(),
+            };
+            Certificate2::new(
+                data.clone(),
+                data.commit(),
+                leaf.view_number(),
+                None,
+                PhantomData,
+            )
+        };
+
+        let penultimate_cert2 = cert2_for(&penultimate);
+        let boundary_cert2 = cert2_for(&boundary);
+        storage
+            .append_cert2(penultimate.view_number(), penultimate_cert2)
+            .await
+            .unwrap();
+        storage
+            .append_cert2(boundary.view_number(), boundary_cert2.clone())
+            .await
+            .unwrap();
+
+        let consumer = EventCollector::default();
+        storage
+            .append_decided_leaves(
+                boundary.view_number(),
+                [
+                    (
+                        &leaf_info(penultimate.clone()),
+                        CertificatePair::non_epoch_change(qc_for(&penultimate)),
+                    ),
+                    (
+                        &leaf_info(boundary.clone()),
+                        CertificatePair::non_epoch_change(qc_for(&boundary)),
+                    ),
+                ],
+                None,
+                &consumer,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !consumer.events.read().await.is_empty(),
+            "the decide consumer must have run, or the cleanup under test never happened"
+        );
+
+        // The boundary block is the anchor a restart resumes from, so its Cert2
+        // has to still be there.
+        let (anchor, _) = storage
+            .load_anchor_leaf()
+            .await
+            .unwrap()
+            .expect("an anchor leaf survives the decide");
+        assert_eq!(anchor.view_number(), boundary.view_number());
+        assert_eq!(
+            storage
+                .load_cert2(boundary.view_number())
+                .await
+                .unwrap()
+                .as_ref(),
+            Some(&boundary_cert2),
+            "the anchor's Cert2 must survive the decide, as its leaf does"
+        );
+    }
+
     #[rstest_reuse::apply(persistence_types)]
     pub async fn test_non_consecutive_decide<P: TestablePersistence>(_p: PhantomData<P>) {
         let tmp = P::tmp_storage().await;

--- a/crates/espresso/node/src/persistence/fs.rs
+++ b/crates/espresso/node/src/persistence/fs.rs
@@ -374,16 +374,19 @@ impl Inner {
             None,
             prune_intervals,
         )?;
-        self.prune_files(
-            self.decided_cert2_dir_path(),
-            prune_view,
-            None,
-            prune_intervals,
-        )?;
-
         // Save the most recent leaf as it will be our anchor point if the node restarts.
         self.prune_files(
             self.decided_leaf2_path(),
+            prune_view,
+            Some(decided_view),
+            prune_intervals,
+        )?;
+
+        // Keep the anchor's Cert2 for the same reason, so it survives with the leaf it certifies.
+        // A node restarted on the last block of an epoch proposes the first block of the next one,
+        // and needs that certificate to do it; nothing rebuilds it once the view is decided.
+        self.prune_files(
+            self.decided_cert2_dir_path(),
             prune_view,
             Some(decided_view),
             prune_intervals,

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -1341,18 +1341,23 @@ impl Persistence {
                         .bind(to_view_i64),
                 )
                 .await?;
-                tx.execute(
-                    query("DELETE FROM decided_cert2 where view >= $1 AND view <= $2")
-                        .bind(from_view_i64)
-                        .bind(to_view_i64),
-                )
-                .await?;
-
                 // Clean up leaves, but do not delete the most recent one (all leaves with a view
                 // number less than the given value). This is necessary to ensure that, in case of
                 // a restart, we can resume from the last decided leaf.
                 tx.execute(
                     query("DELETE FROM anchor_leaf2 WHERE view >= $1 AND view < $2")
+                        .bind(from_view_i64)
+                        .bind(to_view_i64),
+                )
+                .await?;
+
+                // The anchor's Cert2 is bounded the same way, so it survives with the leaf it
+                // certifies. A node restarted on the last block of an epoch proposes the first
+                // block of the next one, and needs that certificate to do it; nothing rebuilds it
+                // once the view is decided. Both rows are in `PRUNE_TABLES`, so retention
+                // collects whichever anchor the next decide leaves behind.
+                tx.execute(
+                    query("DELETE FROM decided_cert2 where view >= $1 AND view < $2")
                         .bind(from_view_i64)
                         .bind(to_view_i64),
                 )

--- a/crates/hotshot/example-types/src/storage_types.rs
+++ b/crates/hotshot/example-types/src/storage_types.rs
@@ -24,8 +24,8 @@ use hotshot_types::{
     event::HotShotAction,
     message::Proposal,
     simple_certificate::{
-        LightClientStateUpdateCertificateV2, NextEpochQuorumCertificate2, QuorumCertificate2,
-        UpgradeCertificate,
+        Certificate2, LightClientStateUpdateCertificateV2, NextEpochQuorumCertificate2,
+        QuorumCertificate2, UpgradeCertificate,
     },
     traits::{node_implementation::NodeType, storage::Storage},
     vote::HasViewNumber,
@@ -57,6 +57,7 @@ pub struct TestStorageState<TYPES: NodeType> {
     action_log: Vec<(ViewNumber, HotShotAction)>,
     epoch: Option<EpochNumber>,
     state_certs: BTreeMap<EpochNumber, LightClientStateUpdateCertificateV2<TYPES>>,
+    cert2s: BTreeMap<ViewNumber, Certificate2<TYPES>>,
     drb_results: BTreeMap<EpochNumber, DrbResult>,
     drb_inputs: BTreeMap<u64, DrbInput>,
     epoch_roots: BTreeMap<EpochNumber, TYPES::BlockHeader>,
@@ -81,6 +82,7 @@ impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
             action_log: Vec::new(),
             epoch: None,
             state_certs: BTreeMap::new(),
+            cert2s: BTreeMap::new(),
             drb_results: BTreeMap::new(),
             drb_inputs: BTreeMap::new(),
             epoch_roots: BTreeMap::new(),
@@ -186,6 +188,15 @@ impl<TYPES: NodeType> TestStorage<TYPES> {
             .iter()
             .next_back()
             .map(|(_, cert)| cert.clone())
+    }
+
+    /// Persist the Cert2 of a directly decided view.
+    pub async fn store_cert2(&self, view: ViewNumber, cert2: Certificate2<TYPES>) {
+        self.inner.write().await.cert2s.insert(view, cert2);
+    }
+
+    pub async fn cert2_cloned(&self, view: ViewNumber) -> Option<Certificate2<TYPES>> {
+        self.inner.read().await.cert2s.get(&view).cloned()
     }
 }
 

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -266,8 +266,6 @@ pub struct Consensus<T: NodeType> {
     /// re-casting the phase-2 vote itself (see [`Self::vote2_persisted`]).
     restart_barred_view: ViewNumber,
     current_view: ViewNumber,
-    /// The epoch this node acts in. It never moves back: every write outside
-    /// the test-only [`Self::set_view`] goes through [`Self::enter_epoch`].
     current_epoch: Option<EpochNumber>,
 
     // TODO: We need a next epoch stake table to handle the transition
@@ -935,10 +933,10 @@ impl<T: NodeType> Consensus<T> {
     /// `current_view`, if it leads that view.
     ///
     /// The proposal builds on the parent at `current_view`, so its epoch
-    /// follows the parent's height, not the epoch cursor: a parent that is
-    /// the last block of an epoch puts the proposal in the next one.
-    /// Without a parent proposal, which happens when the node resumes past
-    /// its anchor, the timeout path takes over instead.
+    /// follows the parent's height: a parent that is the last block of an
+    /// epoch puts the proposal in the next one. Without a parent proposal,
+    /// which happens when the node resumes past its anchor, the timeout
+    /// path takes over instead.
     pub fn restart_block_request(&self) -> Option<BlockAndHeaderRequest<T>> {
         let view = self.current_view + 1;
         let parent = self.proposals.get(&self.current_view)?;
@@ -1736,13 +1734,17 @@ impl<T: NodeType> Consensus<T> {
         outbox.push_back(ConsensusOutput::ViewChanged(view, effective_epoch));
         outbox.push_back(ConsensusOutput::ViewTimedOut(certificate.view_number()));
 
-        // Whoever proposes for `view` builds on our lock, so their epoch
-        // follows the lock's height and not the certificate's. The two differ
-        // when the lock is the last block of an epoch: the quorum that timed
-        // out still signed with the outgoing epoch, but the block they wait
-        // for opens the next one. Each node derives the leader from its own
-        // lock, so nodes whose locks straddle the boundary can name different
-        // leaders for one view; that costs a further timeout, not progress.
+        // The leader of `view` proposes on their lock, so the proposal's epoch
+        // is fixed by the lock's height, not by the certificate. The two
+        // differ when the lock is the last block of an epoch: the timeout
+        // votes carry the outgoing epoch, the next block opens the new one,
+        // and its leader comes from the new stake table. Taking the epoch
+        // from the certificate would address a leader whose proposal the
+        // receivers reject, since they judge it by the epoch its height
+        // demands. We derive that epoch from our own lock, as does every
+        // other node, so nodes whose locks straddle the boundary may address
+        // different leaders for `view`. That may cost more timeouts but
+        // nothing else.
         let locked_view = self.locked_cert.as_ref().map(|cert| cert.view_number());
         let parent = locked_view.and_then(|locked_view| self.proposals.get(&locked_view));
         let next_epoch = parent.map_or(effective_epoch, |parent| self.next_proposal_epoch(parent));

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -446,6 +446,18 @@ impl<T: NodeType> Consensus<T> {
         }
     }
 
+    /// Restore the Cert2 of the decided anchor, where storage kept one.
+    ///
+    /// Only a node holding a view's Cert2 decides that view directly, and only
+    /// a direct decide persists the certificate, so a node that took the anchor
+    /// as an ancestor of a later decide has none to restore. A leader proposing
+    /// the first block of an epoch needs the boundary block's Cert2 as the
+    /// proposal's `next_epoch_justify_qc`, so once too few nodes can re-form it,
+    /// losing it across a restart stalls the network for good.
+    pub fn seed_cert2(&mut self, cert2: Certificate2<T>) {
+        self.certs2.insert(cert2.view_number(), cert2);
+    }
+
     /// Advance the locked-QC persistence watermark to `view` if it is newer.
     fn bump_stored_high_qc(&mut self, view: ViewNumber) {
         if self.stored_high_qc.is_none_or(|cur| cur < view) {

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -931,6 +931,25 @@ impl<T: NodeType> Consensus<T> {
         }
     }
 
+    /// The block request a restarted node makes for the view after
+    /// `current_view`, if it leads that view.
+    ///
+    /// The proposal builds on the parent at `current_view`, so its epoch
+    /// follows the parent's height, not the epoch cursor: a parent that is
+    /// the last block of an epoch puts the proposal in the next one.
+    /// Without a parent proposal, which happens when the node resumes past
+    /// its anchor, the timeout path takes over instead.
+    pub fn restart_block_request(&self) -> Option<BlockAndHeaderRequest<T>> {
+        let view = self.current_view + 1;
+        let parent = self.proposals.get(&self.current_view)?;
+        let epoch = self.next_proposal_epoch(parent);
+        self.is_leader(view, epoch).then(|| BlockAndHeaderRequest {
+            view,
+            epoch,
+            parent_proposal: parent.clone(),
+        })
+    }
+
     pub fn wants_proposal_for_view(&self, view: &ViewNumber) -> bool {
         let locked_too_new = self
             .locked_cert

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -1744,10 +1744,15 @@ impl<T: NodeType> Consensus<T> {
         // demands. We derive that epoch from our own lock, as does every
         // other node, so nodes whose locks straddle the boundary may address
         // different leaders for `view`. That may cost more timeouts but
-        // nothing else.
+        // nothing else. A lock behind the epoch we are in says nothing about
+        // the leader of `view`, since the cursor only advances on certificates
+        // from the new epoch and those prove the chain has passed our lock. The
+        // cursor therefore bounds the derivation from below, and a node whose
+        // lock is behind relays the certificate without requesting a block.
         let locked_view = self.locked_cert.as_ref().map(|cert| cert.view_number());
         let parent = locked_view.and_then(|locked_view| self.proposals.get(&locked_view));
-        let next_epoch = parent.map_or(effective_epoch, |parent| self.next_proposal_epoch(parent));
+        let lock_epoch = parent.map(|parent| self.next_proposal_epoch(parent));
+        let next_epoch = lock_epoch.map_or(effective_epoch, |e| e.max(effective_epoch));
 
         outbox.push_back(ConsensusOutput::SendTimeoutCertificate(
             certificate.into_cert(),
@@ -1769,6 +1774,10 @@ impl<T: NodeType> Consensus<T> {
             debug!(%locked_view, "proposal not available");
             return Protocol::Abort;
         };
+        if lock_epoch != Some(next_epoch) {
+            debug!(%locked_view, epoch = %next_epoch, "lock behind the current epoch");
+            return Protocol::Abort;
+        }
         outbox.push_back(ConsensusOutput::RequestBlockAndHeader(
             BlockAndHeaderRequest {
                 view,

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -266,6 +266,8 @@ pub struct Consensus<T: NodeType> {
     /// re-casting the phase-2 vote itself (see [`Self::vote2_persisted`]).
     restart_barred_view: ViewNumber,
     current_view: ViewNumber,
+    /// The epoch this node acts in. It never moves back: every write outside
+    /// the test-only [`Self::set_view`] goes through [`Self::enter_epoch`].
     current_epoch: Option<EpochNumber>,
 
     // TODO: We need a next epoch stake table to handle the transition
@@ -405,7 +407,7 @@ impl<T: NodeType> Consensus<T> {
         proposal: Proposal<T>,
         reconstructed: impl IntoIterator<Item = (ViewNumber, VidCommitment2)>,
     ) {
-        self.current_epoch = Some(proposal.epoch);
+        self.enter_epoch(proposal.epoch);
         // The seed cert comes from persistent storage, so its lock is already persisted.
         self.bump_stored_high_qc(cert1.view_number());
         self.certs.insert(cert1.view_number(), cert1.clone());
@@ -562,9 +564,7 @@ impl<T: NodeType> Consensus<T> {
             highest_seeded_block,
             *self.epoch_height,
         ));
-        if self.current_epoch.is_none_or(|cur| cur < seeded_epoch) {
-            self.current_epoch = Some(seeded_epoch);
-        }
+        self.enter_epoch(seeded_epoch);
     }
 
     /// Register `justify_qc` as Cert1 for its parent view (idempotent)
@@ -1365,11 +1365,7 @@ impl<T: NodeType> Consensus<T> {
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) {
         let view = proposal.view_number();
-        let epoch = if is_last_block(proposal.block_header.block_number(), *self.epoch_height) {
-            proposal.epoch + 1
-        } else {
-            proposal.epoch
-        };
+        let epoch = self.next_proposal_epoch(proposal);
         if self.is_leader(view + 1, epoch) {
             outbox.push_back(ConsensusOutput::RequestBlockAndHeader(
                 BlockAndHeaderRequest {
@@ -1576,8 +1572,8 @@ impl<T: NodeType> Consensus<T> {
 
         if next_view > self.current_view {
             self.current_view = next_view;
-            self.current_epoch = Some(epoch);
-            outbox.push_back(ConsensusOutput::ViewChanged(next_view, epoch));
+            let effective_epoch = self.enter_epoch(epoch);
+            outbox.push_back(ConsensusOutput::ViewChanged(next_view, effective_epoch));
         }
 
         Protocol::Continue
@@ -1716,37 +1712,47 @@ impl<T: NodeType> Consensus<T> {
         let epoch = certificate.epoch();
         self.timeout_certs.insert(view, certificate.cert().clone());
         self.current_view = self.current_view.max(view);
-        self.current_epoch = Some(epoch);
+        let effective_epoch = self.enter_epoch(epoch);
         self.request_missing_payloads(outbox);
-        outbox.push_back(ConsensusOutput::ViewChanged(view, epoch));
+        outbox.push_back(ConsensusOutput::ViewChanged(view, effective_epoch));
         outbox.push_back(ConsensusOutput::ViewTimedOut(certificate.view_number()));
+
+        // Whoever proposes for `view` builds on our lock, so their epoch
+        // follows the lock's height and not the certificate's. The two differ
+        // when the lock is the last block of an epoch: the quorum that timed
+        // out still signed with the outgoing epoch, but the block they wait
+        // for opens the next one. Each node derives the leader from its own
+        // lock, so nodes whose locks straddle the boundary can name different
+        // leaders for one view; that costs a further timeout, not progress.
+        let locked_view = self.locked_cert.as_ref().map(|cert| cert.view_number());
+        let parent = locked_view.and_then(|locked_view| self.proposals.get(&locked_view));
+        let next_epoch = parent.map_or(effective_epoch, |parent| self.next_proposal_epoch(parent));
+
         outbox.push_back(ConsensusOutput::SendTimeoutCertificate(
             certificate.into_cert(),
             view,
-            epoch,
+            next_epoch,
         ));
-        if !self.is_leader(view, epoch) {
-            debug!(%epoch, "not leader");
+        if !self.is_leader(view, next_epoch) {
+            debug!(epoch = %next_epoch, "not leader");
             return Protocol::Abort;
         }
 
         // If we are the leader of the next view, try to get a block to propose
         // after forming the TC
-        let Some(locked_view) = self.locked_cert.as_ref().map(|cert| cert.view_number()) else {
+        let Some(locked_view) = locked_view else {
             debug!("locked certificate not available");
             return Protocol::Abort;
         };
-        let Some(proposal) = self.proposals.get(&locked_view) else {
+        let Some(parent) = parent else {
             debug!(%locked_view, "proposal not available");
             return Protocol::Abort;
         };
-        // Note: We don't handle epoch change on timeout certificate, because
-        // we can't change epoch after a timeout
         outbox.push_back(ConsensusOutput::RequestBlockAndHeader(
             BlockAndHeaderRequest {
                 view,
-                epoch,
-                parent_proposal: proposal.clone(),
+                epoch: next_epoch,
+                parent_proposal: parent.clone(),
             },
         ));
         Protocol::Continue
@@ -1791,7 +1797,7 @@ impl<T: NodeType> Consensus<T> {
         let next_epoch = cert2.data.epoch + 1;
         // Change view to the first view of the next epoch
         self.current_view = self.current_view.max(next_view);
-        self.current_epoch = Some(next_epoch);
+        self.enter_epoch(next_epoch);
         outbox.push_back(ConsensusOutput::ViewChanged(next_view, next_epoch));
 
         // Request block and header if we're the first leader of the next epoch
@@ -1872,12 +1878,7 @@ impl<T: NodeType> Consensus<T> {
             // that moment; if the lock moved since (bridged legacy QC at
             // cutover), re-request. The block builder dedups by (view, parent).
             if view_change_evidence.is_some() {
-                let request_epoch =
-                    if is_last_block(proposal.block_header.block_number(), *self.epoch_height) {
-                        proposal.epoch + 1
-                    } else {
-                        proposal.epoch
-                    };
+                let request_epoch = self.next_proposal_epoch(proposal);
                 if self.is_leader(view, request_epoch) {
                     outbox.push_back(ConsensusOutput::RequestBlockAndHeader(
                         BlockAndHeaderRequest {
@@ -2519,17 +2520,18 @@ impl<T: NodeType> Consensus<T> {
         // We can now update the lock, change view and vote
         if self
             .locked_cert
-            .as_mut()
+            .as_ref()
             .is_none_or(|locked_cert| locked_cert.view_number() < cert1.view_number())
         {
+            let cert1 = cert1.clone();
             self.locked_cert = Some(cert1.clone());
             self.current_view = self.current_view.max(view + 1);
-            self.current_epoch = Some(proposal_epoch);
+            let effective_epoch = self.enter_epoch(proposal_epoch);
             outbox.push_back(ConsensusOutput::LockUpdated(cert1.view_number()));
-            outbox.push_back(ConsensusOutput::ViewChanged(view + 1, proposal_epoch));
+            outbox.push_back(ConsensusOutput::ViewChanged(view + 1, effective_epoch));
             outbox.push_back(ConsensusOutput::SendCertificate1(cert1.clone()));
             // Persist the new lock; `release_vote2` gates the phase-2 vote on it.
-            outbox.push_back(ConsensusOutput::PersistHighQc(cert1.clone()));
+            outbox.push_back(ConsensusOutput::PersistHighQc(cert1));
         }
 
         if self.certs2.contains_key(&view)
@@ -2552,7 +2554,7 @@ impl<T: NodeType> Consensus<T> {
             Vote2Data {
                 leaf_commit: proposal_commit,
                 epoch: proposal_epoch,
-                block_number: proposal.block_header.block_number(),
+                block_number: block,
             },
             view,
             &self.public_key,
@@ -2777,6 +2779,28 @@ impl<T: NodeType> Consensus<T> {
         }
 
         missing
+    }
+
+    /// The epoch a proposal parented at `parent` belongs to.
+    ///
+    /// A block following the last block of an epoch starts the next one, and
+    /// its leader is drawn from that epoch's stake table.
+    fn next_proposal_epoch(&self, parent: &Proposal<T>) -> EpochNumber {
+        if is_last_block(parent.block_header.block_number(), *self.epoch_height) {
+            parent.epoch + 1
+        } else {
+            parent.epoch
+        }
+    }
+
+    /// Raise the epoch cursor to `epoch` and return the epoch now in effect.
+    ///
+    /// The cursor never moves back: certificates from the outgoing epoch keep
+    /// arriving after a node has taken the epoch change.
+    fn enter_epoch(&mut self, epoch: EpochNumber) -> EpochNumber {
+        let e = self.current_epoch.unwrap_or(epoch).max(epoch);
+        self.current_epoch = Some(e);
+        e
     }
 }
 

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -933,25 +933,44 @@ impl<T: NodeType> Consensus<T> {
                 .entry(view)
                 .or_insert(proposal.justify_qc.view_number());
         }
-        // `Coordinator::start` enters `current_view + 1`, so parking the cursor
-        // at the high QC makes the node re-enter at `high_qc + 1`.
+        // `Coordinator::start` enters the view after this one, so parking the
+        // cursor at the high QC makes the node re-enter at `high_qc + 1`.
         let resume_view = self.stored_high_qc.unwrap_or(anchor_view + 1);
         if resume_view > self.current_view {
             self.current_view = resume_view;
         }
     }
 
-    /// The block request a restarted node makes for the view after
-    /// `current_view`, if it leads that view.
+    /// Enter `view` at startup and return the epoch now in effect.
     ///
-    /// The proposal builds on the parent at `current_view`, so its epoch
+    /// The seeds leave the cursor on the last view the node knows about, and
+    /// startup enters the one after it. Advancing the cursor here is what lets
+    /// the rest of the node read `current_view` as the view it is on: while
+    /// the two disagreed, a timeout for the entered view looked like one for a
+    /// later view, and every stale-view filter and view window was off by one
+    /// until the first certificate arrived.
+    pub fn enter_view(&mut self, view: ViewNumber, epoch: EpochNumber) -> EpochNumber {
+        if view > self.current_view {
+            self.current_view = view;
+        }
+        self.enter_epoch(epoch)
+    }
+
+    /// The block request the node makes for the view it enters at startup, if
+    /// it leads that view. A fresh node parents it on genesis, a restarted one
+    /// on its anchor.
+    ///
+    /// The proposal builds on the parent at `parent_view`, so its epoch
     /// follows the parent's height: a parent that is the last block of an
     /// epoch puts the proposal in the next one. Without a parent proposal,
     /// which happens when the node resumes past its anchor, the timeout
     /// path takes over instead.
-    pub fn restart_block_request(&self) -> Option<BlockAndHeaderRequest<T>> {
-        let view = self.current_view + 1;
-        let parent = self.proposals.get(&self.current_view)?;
+    pub fn startup_block_request(
+        &self,
+        parent_view: ViewNumber,
+    ) -> Option<BlockAndHeaderRequest<T>> {
+        let view = parent_view + 1;
+        let parent = self.proposals.get(&parent_view)?;
         let epoch = self.next_proposal_epoch(parent);
         self.is_leader(view, epoch).then(|| BlockAndHeaderRequest {
             view,

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -388,9 +388,9 @@ impl<T: NodeType> Consensus<T> {
 
     /// Seed a parent certificate and proposal so the leader of the *next* view
     /// can propose without any external bootstrap injection.
-    /// Sets the locked certificate and current epoch. After calling this, a
-    /// subsequent `apply` that triggers `maybe_propose` will find the
-    /// parent cert and proposal it needs.
+    /// Sets the locked certificate and raises the current epoch to the
+    /// proposal's. After calling this, a subsequent `apply` that triggers
+    /// `maybe_propose` will find the parent cert and proposal it needs.
     ///
     /// `reconstructed` are `(view, V2 commitment)` pairs to record as
     /// already reconstructed blocks. During normal operation this set is

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -1922,13 +1922,8 @@ impl<T: NodeType> Consensus<T> {
             return;
         };
 
-        let first_proposal_of_epoch =
-            is_last_block(header.block_number().saturating_sub(1), *self.epoch_height);
-        let proposal_epoch = if first_proposal_of_epoch {
-            proposal.epoch + 1
-        } else {
-            proposal.epoch
-        };
+        let proposal_epoch = self.next_proposal_epoch(proposal);
+        let first_proposal_of_epoch = proposal_epoch > proposal.epoch;
         if !self.is_leader(view, proposal_epoch) {
             warn!(epoch = %proposal_epoch, "not the leader for this view, we should not have a header");
             return;
@@ -2771,7 +2766,7 @@ impl<T: NodeType> Consensus<T> {
         // number, so we can only evaluate them once we have the header.
         if let Some(header) = header {
             let first_proposal_of_epoch =
-                is_last_block(header.block_number().saturating_sub(1), *self.epoch_height);
+                self.next_proposal_epoch(parent_proposal) > parent_proposal.epoch;
 
             if parent_proposal.epoch > EpochNumber::genesis()
                 && is_epoch_transition(header.block_number(), *self.epoch_height)

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -30,7 +30,7 @@ use tokio::{select, sync::oneshot};
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    block::{BlockAndHeaderRequest, BlockBuilder, BlockBuilderConfig},
+    block::{BlockBuilder, BlockBuilderConfig},
     cert_verifier::CertVerifiers,
     client::{ClientApi, ClientRequest, CoordinatorClient, QueryError},
     consensus::{Consensus, ConsensusInput, ConsensusOutput, GC_MARGIN_VIEWS, PreCutoverSeed},
@@ -369,8 +369,7 @@ where
             return;
         }
 
-        let cur_view = self.consensus.current_view();
-        let next_view = cur_view + 1;
+        let next_view = self.consensus.current_view() + 1;
         let epoch = self
             .consensus
             .current_epoch()
@@ -404,22 +403,9 @@ where
         self.outbox
             .push_back(ConsensusOutput::ViewChanged(next_view, epoch));
 
-        if let Some(leader) = self.leader(next_view, epoch)
-            && leader == self.public_key
-        {
-            // No parent proposal when restarting past the anchor view: the
-            // node cannot propose off the anchor for a later view; the
-            // timeout path takes over instead.
-            if let Some(parent_proposal) = self.consensus.proposal_at(cur_view).cloned() {
-                self.outbox
-                    .push_back(ConsensusOutput::RequestBlockAndHeader(
-                        BlockAndHeaderRequest {
-                            view: next_view,
-                            epoch,
-                            parent_proposal,
-                        },
-                    ));
-            }
+        if let Some(request) = self.consensus.restart_block_request() {
+            self.outbox
+                .push_back(ConsensusOutput::RequestBlockAndHeader(request));
         }
     }
 

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -175,6 +175,8 @@ where
         consensus_metrics: ConsensusMetricsValue,
         /// Locked QC persisted on a prior run; restored so the lock survives restart.
         locked_qc: Option<Certificate1<T>>,
+        /// Cert2 of the decided anchor, persisted on a prior run.
+        anchor_cert2: Option<Certificate2<T>>,
     ) -> Self {
         let mut consensus = Consensus::new(
             membership_coordinator.clone(),
@@ -278,6 +280,9 @@ where
         );
         if let Some(state_cert) = initializer.state_cert().cloned() {
             consensus.seed_state_cert(state_cert);
+        }
+        if let Some(anchor_cert2) = anchor_cert2 {
+            consensus.seed_cert2(anchor_cert2);
         }
 
         let participation = ParticipationTracker::new(&membership_coordinator, anchor_epoch);

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -374,7 +374,8 @@ where
             return;
         }
 
-        let next_view = self.consensus.current_view() + 1;
+        let parent_view = self.consensus.current_view();
+        let next_view = parent_view + 1;
         let epoch = self
             .consensus
             .current_epoch()
@@ -405,10 +406,11 @@ where
             });
         }
 
+        let epoch = self.consensus.enter_view(next_view, epoch);
         self.outbox
             .push_back(ConsensusOutput::ViewChanged(next_view, epoch));
 
-        if let Some(request) = self.consensus.restart_block_request() {
+        if let Some(request) = self.consensus.startup_block_request(parent_view) {
             self.outbox
                 .push_back(ConsensusOutput::RequestBlockAndHeader(request));
         }

--- a/crates/hotshot/new-protocol/src/storage.rs
+++ b/crates/hotshot/new-protocol/src/storage.rs
@@ -412,7 +412,8 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
 
 #[async_trait]
 impl<T: NodeType> NewProtocolStorage<T> for TestStorage<T> {
-    async fn append_cert2(&self, _view: ViewNumber, _cert: Certificate2<T>) -> anyhow::Result<()> {
+    async fn append_cert2(&self, view: ViewNumber, cert: Certificate2<T>) -> anyhow::Result<()> {
+        self.store_cert2(view, cert).await;
         Ok(())
     }
 

--- a/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
@@ -212,6 +212,13 @@ pub async fn build_test_coordinator(
         consensus.seed_state_cert(state_cert);
     }
 
+    // Likewise for the anchor's Cert2 (in production `load_cert2`): the leader
+    // of the first view of a new epoch needs the boundary block's Cert2, and no
+    // node votes phase 2 on the anchor again to rebuild it.
+    if let Some(cert2) = storage.cert2_cloned(anchor_view).await {
+        consensus.seed_cert2(cert2);
+    }
+
     let genesis_wrapper = QuorumProposalWrapper::<TestTypes> {
         proposal: QuorumProposal2 {
             block_header: genesis_leaf.block_header().clone(),

--- a/crates/hotshot/new-protocol/src/tests/common/runner.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/runner.rs
@@ -120,6 +120,18 @@ pub struct TestRunner {
     #[builder(default)]
     persistent_storage: bool,
 
+    /// Apply a node change scheduled for view `v` only once every live node
+    /// has decided `v` or a later view, instead of as soon as the first one
+    /// has. Narrows the persisted state the nodes restart from; tests that
+    /// need an exact state check `restart_anchors`.
+    #[builder(default)]
+    node_changes_after_all_decided: bool,
+
+    /// The persisted anchor view of each node at the moment a node change
+    /// restarted it, in the order the changes were applied.
+    #[builder(skip)]
+    restart_anchors: Vec<(usize, Option<ViewNumber>)>,
+
     /// Per-node storage, created at the start of `run()`.  Exposed so tests
     /// can inspect persisted state (e.g. the action log) after a run.
     #[builder(skip)]
@@ -303,6 +315,10 @@ impl TestRunner {
 
     pub fn node_storages(&self) -> &[TestStorage<TestTypes>] {
         &self.node_storages
+    }
+
+    pub fn restart_anchors(&self) -> &[(usize, Option<ViewNumber>)] {
+        &self.restart_anchors
     }
 
     fn target_for(&self, idx: usize) -> usize {
@@ -519,10 +535,19 @@ impl TestRunner {
 
             // Apply pending node changes when progress reaches their view.
             if !self.node_changes.is_empty() {
-                let views_to_apply: Vec<u64> = pending_changes
-                    .range(..=max_decided_view)
-                    .map(|(&v, _)| v)
-                    .collect();
+                let gate = if self.node_changes_after_all_decided {
+                    node_commits
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, _)| !currently_down.contains(i))
+                        .map(|(_, commits)| commits.keys().next_back().map_or(0, |v| **v))
+                        .min()
+                        .unwrap_or(0)
+                } else {
+                    max_decided_view
+                };
+                let views_to_apply: Vec<u64> =
+                    pending_changes.range(..=gate).map(|(&v, _)| v).collect();
                 for view in views_to_apply {
                     let changes = pending_changes.remove(&view).unwrap();
                     for change in &changes {
@@ -548,6 +573,11 @@ impl TestRunner {
                                 if let NodeAction::RestartAt(addr) = &change.action {
                                     parties[change.idx].2 = addr.clone();
                                 }
+                                let anchor = self.node_storages[change.idx]
+                                    .anchor_leaf()
+                                    .await
+                                    .map(|(leaf, _)| leaf.view_number());
+                                self.restart_anchors.push((change.idx, anchor));
                                 // Create a fresh coordinator; it resumes
                                 // from the persisted anchor when storage is
                                 // persistent, from genesis otherwise.

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -1156,11 +1156,17 @@ impl ConsensusHarness {
         self.drain_outbox(&mut outbox).await;
     }
 
-    /// Mirror `Coordinator::start` after a restart: issue the block request
-    /// for the view after the anchor, if this node leads it, and drain the
-    /// responses so a proposal can come out the other end.
-    pub async fn start_after_restart(&mut self) {
-        let Some(request) = self.consensus.restart_block_request() else {
+    /// Mirror `Coordinator::start`: enter the view after the one the seeds
+    /// parked the cursor on, issue the block request for it if this node leads
+    /// it, and drain the responses so a proposal can come out the other end.
+    pub async fn start(&mut self) {
+        let parent_view = self.consensus.current_view();
+        let epoch = self
+            .consensus
+            .current_epoch()
+            .unwrap_or(EpochNumber::genesis());
+        self.consensus.enter_view(parent_view + 1, epoch);
+        let Some(request) = self.consensus.startup_block_request(parent_view) else {
             return;
         };
         let mut outbox = Outbox::new();

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -1075,12 +1075,13 @@ impl ConsensusHarness {
     /// Build a harness whose consensus has been restarted from a persisted
     /// decided anchor, mirroring `Coordinator::maker`: `Consensus::new` is
     /// given the anchor leaf, the undecided proposals above it are re-seeded
-    /// and marked reconstructed, and the anchor is installed as the parent via
-    /// `seed_parent`.
+    /// and marked reconstructed, the anchor is installed as the parent via
+    /// `seed_parent`, and its Cert2, where storage kept one, via `seed_cert2`.
     pub async fn restarted_from(
         node_index: u64,
         anchor_proposal: Proposal<TestTypes>,
         anchor_cert1: Certificate1<TestTypes>,
+        anchor_cert2: Option<Certificate2<TestTypes>>,
         undecided_proposals: impl IntoIterator<Item = Proposal<TestTypes>>,
     ) -> Self {
         let epoch_height = 10;
@@ -1113,6 +1114,9 @@ impl ConsensusHarness {
         consensus.seed_proposals(undecided_proposals);
         consensus.seed_parent(anchor_cert1, anchor_proposal, reconstructed);
         consensus.resume_from_restart(anchor_view, anchor_view + 1, anchor_view);
+        if let Some(anchor_cert2) = anchor_cert2 {
+            consensus.seed_cert2(anchor_cert2);
+        }
 
         Self {
             consensus,
@@ -1149,6 +1153,18 @@ impl ConsensusHarness {
     pub async fn apply(&mut self, input: ConsensusInput<TestTypes>) {
         let mut outbox = Outbox::new();
         self.apply_recorded(input, &mut outbox);
+        self.drain_outbox(&mut outbox).await;
+    }
+
+    /// Mirror `Coordinator::start` after a restart: issue the block request
+    /// for the view after the anchor, if this node leads it, and drain the
+    /// responses so a proposal can come out the other end.
+    pub async fn start_after_restart(&mut self) {
+        let Some(request) = self.consensus.restart_block_request() else {
+            return;
+        };
+        let mut outbox = Outbox::new();
+        outbox.push_back(ConsensusOutput::RequestBlockAndHeader(request));
         self.drain_outbox(&mut outbox).await;
     }
 

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -1453,9 +1453,14 @@ async fn test_restart_does_not_redecide_anchor() {
         "anchor must be a non-genesis view to exercise the chain-walk bound"
     );
 
-    let mut harness =
-        ConsensusHarness::restarted_from(0, anchor.proposal.data.clone(), anchor.cert1.clone(), [])
-            .await;
+    let mut harness = ConsensusHarness::restarted_from(
+        0,
+        anchor.proposal.data.clone(),
+        anchor.cert1.clone(),
+        Some(anchor.cert2.clone()),
+        [],
+    )
+    .await;
     assert_eq!(
         harness.consensus.last_decided_view(),
         anchor_view,
@@ -1506,6 +1511,7 @@ async fn test_no_revote2_for_restart_barred_views() {
         0,
         anchor.proposal.data.clone(),
         anchor.cert1.clone(),
+        Some(anchor.cert2.clone()),
         [voted.proposal.data.clone()],
     )
     .await;
@@ -1549,6 +1555,7 @@ async fn test_revote2_after_restart_without_cert2() {
         0,
         anchor.proposal.data.clone(),
         anchor.cert1.clone(),
+        Some(anchor.cert2.clone()),
         [voted.proposal.data.clone()],
     )
     .await;
@@ -1580,9 +1587,14 @@ async fn test_no_redecide_below_restart_anchor() {
     let anchor = &test_data.views[2];
     let anchor_view = anchor.view_number;
 
-    let mut harness =
-        ConsensusHarness::restarted_from(0, anchor.proposal.data.clone(), anchor.cert1.clone(), [])
-            .await;
+    let mut harness = ConsensusHarness::restarted_from(
+        0,
+        anchor.proposal.data.clone(),
+        anchor.cert1.clone(),
+        Some(anchor.cert2.clone()),
+        [],
+    )
+    .await;
     // Make the pre-anchor proposal available so only the floor stands between
     // the replayed certificates and a duplicate decide.
     harness

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -10,9 +10,13 @@ use hotshot_types::{
 
 use super::common::{
     assertions::{is_send_epoch_change, is_view_changed},
-    utils::{ConsensusHarness, TEST_DRB_RESULT, TestData},
+    utils::{
+        ConsensusHarness, TEST_DRB_RESULT, TestData, build_timeout_cert_signed_by, mock_membership,
+    },
 };
 use crate::{
+    block::BlockAndHeaderRequest,
+    cert_verifier::ValidCert,
     consensus::{ConsensusInput, ConsensusOutput},
     helpers::proposal_commitment,
     message::{EpochChangeError, EpochChangeMessage, Proposal, ProposalMessage},
@@ -258,6 +262,122 @@ async fn test_handle_epoch_change_replay_of_crossed_boundary() {
     assert!(
         !any(harness.outputs(), is_view_changed),
         "replayed epoch change for a crossed boundary must not change the view"
+    );
+}
+
+/// A timeout certificate from the outgoing epoch names the leader of the
+/// epoch its proposal opens.
+///
+/// The quorum sits at the first view of the new epoch while still in the old
+/// one: the boundary block belongs to the outgoing epoch, so `cert1` alone
+/// carries a node to view 11 in epoch 1, and only the epoch change (`cert1`
+/// and `cert2` together) moves it on to epoch 2. If the first leader of the
+/// new epoch is slow, those nodes time out view 11 and sign with epoch 1
+/// before the epoch change reaches them. The block proposed after their
+/// certificate follows the boundary block, so it belongs to epoch 2 and its
+/// leader must come from epoch 2's stake table. A node that has already taken
+/// the epoch change must also not drop back an epoch on that certificate.
+///
+/// The harness runs node 2, which leads view 12, so the block request that
+/// follows the certificate is exercised as well.
+#[tokio::test]
+async fn test_timeout_certificate_from_the_outgoing_epoch() {
+    let mut harness = ConsensusHarness::new(2).await;
+    let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 2).0;
+
+    // Decide views 1 to 9, then take the epoch 1 -> 2 change at the boundary
+    // view 10, which puts the node at view 11 in epoch 2. The boundary block
+    // is reconstructed beforehand so that the epoch change also moves the
+    // lock to view 10.
+    run_views_full(&mut harness, &test_data, &node_key, 0..9).await;
+    let boundary = &test_data.views[9];
+    harness.apply(boundary.block_reconstructed_input()).await;
+    let epoch_change = EpochChangeMessage::validated(
+        boundary.cert1.clone(),
+        boundary.cert2.clone(),
+        boundary.proposal.data.clone(),
+    );
+    harness
+        .apply(ConsensusInput::EpochChange(epoch_change))
+        .await;
+    assert_eq!(
+        harness.consensus.locked_view(),
+        Some(ViewNumber::new(10)),
+        "the epoch change should have moved the lock to the boundary block"
+    );
+    assert_eq!(
+        harness.consensus.current_epoch(),
+        Some(EpochNumber::new(2)),
+        "the epoch change and the lock update should leave the node in epoch 2"
+    );
+
+    // The quorum still in epoch 1 times out view 11.
+    let timeout_cert = {
+        let membership = mock_membership();
+        let epoch_membership = membership
+            .membership_for_epoch(Some(EpochNumber::new(1)))
+            .expect("epoch 1 membership");
+        let signers: Vec<u64> = (0..10).collect();
+        build_timeout_cert_signed_by(
+            ViewNumber::new(11),
+            EpochNumber::new(1),
+            &epoch_membership,
+            &signers,
+        )
+    };
+    let outputs_before = harness.outputs().len();
+    harness
+        .apply(ConsensusInput::TimeoutCertificate(ValidCert::new(
+            timeout_cert,
+            EpochNumber::new(1),
+        )))
+        .await;
+    let outputs = harness.outputs().iter().skip(outputs_before);
+
+    assert_eq!(
+        harness.consensus.current_view(),
+        ViewNumber::new(12),
+        "the timeout certificate should have carried the node past view 11"
+    );
+    assert_eq!(
+        harness.consensus.current_epoch(),
+        Some(EpochNumber::new(2)),
+        "an epoch 1 timeout certificate must not lower the epoch cursor"
+    );
+
+    // The proposal for view 12 follows the boundary block, so it belongs to
+    // epoch 2: the certificate goes to epoch 2's leader, and this node, being
+    // that leader, requests an epoch 2 block on the boundary proposal.
+    let next_view = ViewNumber::new(12);
+    let next_epoch = EpochNumber::new(2);
+    assert_eq!(
+        harness.consensus.leader_of(next_view, next_epoch).as_ref(),
+        Some(&node_key),
+        "node 2 should lead view 12 in epoch 2"
+    );
+    let mut sent_to = Vec::new();
+    let mut requested = Vec::new();
+    for output in outputs {
+        match output {
+            ConsensusOutput::SendTimeoutCertificate(_, view, epoch) => {
+                sent_to.push((*view, *epoch))
+            },
+            ConsensusOutput::RequestBlockAndHeader(BlockAndHeaderRequest {
+                view,
+                epoch,
+                parent_proposal,
+            }) => requested.push((*view, *epoch, parent_proposal.view_number)),
+            _ => {},
+        }
+    }
+    assert_eq!(sent_to, vec![(next_view, next_epoch)]);
+    // `maybe_propose` requests again while the header is outstanding; the
+    // block builder dedups.
+    requested.dedup();
+    assert_eq!(
+        requested,
+        vec![(next_view, next_epoch, boundary.proposal.data.view_number)]
     );
 }
 

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -381,6 +381,148 @@ async fn test_timeout_certificate_from_the_outgoing_epoch() {
     );
 }
 
+/// A timeout certificate from an epoch the lock has not reached is relayed
+/// to that epoch's leader, not to the leader of the lock's epoch.
+///
+/// The lock only says which epoch a proposal built on it belongs to. When
+/// it lags the certificate by whole epochs, that epoch is behind the one
+/// the network is in. This holds on main too, which relayed with the
+/// certificate's epoch; the test keeps the derivation from the lock from
+/// regressing it.
+#[tokio::test]
+async fn test_timeout_certificate_ahead_of_a_stale_lock() {
+    let mut harness = ConsensusHarness::new(0).await;
+    let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+
+    // Decide views 1 to 5, leaving the lock at view 5 in epoch 1.
+    run_views_full(&mut harness, &test_data, &node_key, 0..5).await;
+    assert_eq!(harness.consensus.locked_view(), Some(ViewNumber::new(5)));
+
+    // An epoch 2 quorum times out view 21.
+    let timeout_cert = {
+        let membership = mock_membership();
+        let epoch_membership = membership
+            .membership_for_epoch(Some(EpochNumber::new(2)))
+            .expect("epoch 2 membership");
+        let signers: Vec<u64> = (0..10).collect();
+        build_timeout_cert_signed_by(
+            ViewNumber::new(21),
+            EpochNumber::new(2),
+            &epoch_membership,
+            &signers,
+        )
+    };
+    let outputs_before = harness.outputs().len();
+    harness
+        .apply(ConsensusInput::TimeoutCertificate(ValidCert::new(
+            timeout_cert,
+            EpochNumber::new(2),
+        )))
+        .await;
+    let outputs = harness.outputs().iter().skip(outputs_before);
+
+    assert_eq!(harness.consensus.current_view(), ViewNumber::new(22));
+    assert_eq!(harness.consensus.current_epoch(), Some(EpochNumber::new(2)));
+
+    let next_view = ViewNumber::new(22);
+    let next_epoch = EpochNumber::new(2);
+    assert_ne!(
+        harness.consensus.leader_of(next_view, next_epoch).as_ref(),
+        Some(&node_key),
+        "node 0 should not lead view 22 in epoch 2"
+    );
+    let mut sent_to = Vec::new();
+    let mut requested = 0;
+    for output in outputs {
+        match output {
+            ConsensusOutput::SendTimeoutCertificate(_, view, epoch) => {
+                sent_to.push((*view, *epoch))
+            },
+            ConsensusOutput::RequestBlockAndHeader(_) => requested += 1,
+            _ => {},
+        }
+    }
+    assert_eq!(sent_to, vec![(next_view, next_epoch)]);
+    assert_eq!(requested, 0);
+}
+
+/// A node that took the epoch change without reconstructing the boundary
+/// block relays an old-epoch timeout certificate to the new epoch's leader
+/// and requests no block of its own.
+///
+/// Its lock stays on the block before the boundary, so a proposal on it
+/// would belong to the old epoch, while its cursor already says the network
+/// is in the new one. No proposal on that lock can be accepted, so the node
+/// relays and leaves proposing to a node whose lock reached the boundary.
+/// Node 2 leads view 12, so the missing request is the skip, not a failed
+/// leader check.
+#[tokio::test]
+async fn test_timeout_certificate_with_the_lock_before_the_boundary() {
+    let mut harness = ConsensusHarness::new(2).await;
+    let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 2).0;
+
+    // Decide views 1 to 9 and take the epoch change without the boundary
+    // block reconstructed, so the lock stays at view 9.
+    run_views_full(&mut harness, &test_data, &node_key, 0..9).await;
+    let boundary = &test_data.views[9];
+    let epoch_change = EpochChangeMessage::validated(
+        boundary.cert1.clone(),
+        boundary.cert2.clone(),
+        boundary.proposal.data.clone(),
+    );
+    harness
+        .apply(ConsensusInput::EpochChange(epoch_change))
+        .await;
+    assert_eq!(harness.consensus.locked_view(), Some(ViewNumber::new(9)));
+    assert_eq!(harness.consensus.current_epoch(), Some(EpochNumber::new(2)));
+
+    // The quorum still in epoch 1 times out view 11.
+    let timeout_cert = {
+        let membership = mock_membership();
+        let epoch_membership = membership
+            .membership_for_epoch(Some(EpochNumber::new(1)))
+            .expect("epoch 1 membership");
+        let signers: Vec<u64> = (0..10).collect();
+        build_timeout_cert_signed_by(
+            ViewNumber::new(11),
+            EpochNumber::new(1),
+            &epoch_membership,
+            &signers,
+        )
+    };
+    let outputs_before = harness.outputs().len();
+    harness
+        .apply(ConsensusInput::TimeoutCertificate(ValidCert::new(
+            timeout_cert,
+            EpochNumber::new(1),
+        )))
+        .await;
+    let outputs = harness.outputs().iter().skip(outputs_before);
+
+    let next_view = ViewNumber::new(12);
+    let next_epoch = EpochNumber::new(2);
+    assert_eq!(
+        harness.consensus.leader_of(next_view, next_epoch).as_ref(),
+        Some(&node_key),
+        "node 2 should lead view 12 in epoch 2"
+    );
+    let mut sent_to = Vec::new();
+    let mut requested = 0;
+    for output in outputs {
+        match output {
+            ConsensusOutput::SendTimeoutCertificate(_, view, epoch) => {
+                sent_to.push((*view, *epoch))
+            },
+            ConsensusOutput::RequestBlockAndHeader(_) => requested += 1,
+            _ => {},
+        }
+    }
+    assert_eq!(sent_to, vec![(next_view, next_epoch)]);
+    assert_eq!(requested, 0, "a lock behind the boundary must not request");
+}
+
 /// A node restarted with the boundary block as its anchor proposes the first
 /// block of the next epoch, so its block request carries the next epoch and
 /// its leadership is judged by the next epoch's stake table.

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -21,8 +21,8 @@ use crate::{
     helpers::proposal_commitment,
     message::{EpochChangeError, EpochChangeMessage, Proposal, ProposalMessage},
     tests::common::assertions::{
-        any, count_matching, has_request_drb_for_epoch, is_proposal, is_request_block_and_header,
-        is_vote1,
+        any, count_matching, has_request_drb_for_epoch, is_proposal, is_proposal_for_view,
+        is_request_block_and_header, is_vote1,
     },
 };
 
@@ -538,6 +538,7 @@ async fn test_restart_on_the_boundary_block_requests_in_the_next_epoch() {
             node_index,
             boundary.proposal.data.clone(),
             boundary.cert1.clone(),
+            Some(boundary.cert2.clone()),
             [],
         )
     };
@@ -570,6 +571,47 @@ async fn test_restart_on_the_boundary_block_requests_in_the_next_epoch() {
         "node 0 should not lead view 11 in epoch 2"
     );
     assert_eq!(follower.consensus.restart_block_request(), None);
+}
+
+/// A node restarted on the boundary block proposes the first block of the
+/// next epoch only when the anchor's Cert2 comes back with it.
+///
+/// That proposal carries the boundary block's Cert2 as its
+/// `next_epoch_justify_qc`. Nothing rebuilds the certificate after the
+/// restart: the anchor sits at the decide floor, so the node never votes
+/// phase 2 on it again, and peers stop relaying a Cert2 once its view is
+/// decided. Without the seeded certificate the leader is stuck for good, and
+/// so is every later leader, since each proposes on the same boundary parent.
+#[tokio::test]
+async fn test_restart_on_the_boundary_block_proposes_with_the_anchor_cert2() {
+    let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
+    let boundary = &test_data.views[9];
+    // Node 1 leads view 11 in epoch 2.
+    let restarted = |anchor_cert2| {
+        ConsensusHarness::restarted_from(
+            1,
+            boundary.proposal.data.clone(),
+            boundary.cert1.clone(),
+            anchor_cert2,
+            [],
+        )
+    };
+
+    let mut seeded = restarted(Some(boundary.cert2.clone())).await;
+    seeded.start_after_restart().await;
+    assert!(
+        any(seeded.outputs(), |output| is_proposal_for_view(output, 11)),
+        "the restored Cert2 should let node 1 propose the first block of epoch 2"
+    );
+
+    let mut unseeded = restarted(None).await;
+    unseeded.start_after_restart().await;
+    assert!(
+        !any(unseeded.outputs(), |output| is_proposal_for_view(
+            output, 11
+        )),
+        "without the anchor's Cert2 there is no next_epoch_justify_qc to propose with"
+    );
 }
 
 /// Verify that exactly one SendEpochChange is emitted when processing

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -542,19 +542,33 @@ async fn test_restart_on_the_boundary_block_requests_in_the_next_epoch() {
         )
     };
 
+    let key = |node_index| BLSPubKey::generated_from_seed_indexed([0; 32], node_index).0;
+    let next_view = ViewNumber::new(11);
+    let next_epoch = EpochNumber::new(2);
+
     let leader = restarted(1).await;
     assert_eq!(leader.consensus.current_view(), ViewNumber::new(10));
     assert_eq!(leader.consensus.current_epoch(), Some(EpochNumber::new(1)));
     assert_eq!(
+        leader.consensus.leader_of(next_view, next_epoch).as_ref(),
+        Some(&key(1)),
+        "node 1 should lead view 11 in epoch 2"
+    );
+    assert_eq!(
         leader.consensus.restart_block_request(),
         Some(BlockAndHeaderRequest {
-            view: ViewNumber::new(11),
-            epoch: EpochNumber::new(2),
+            view: next_view,
+            epoch: next_epoch,
             parent_proposal: boundary.proposal.data.clone(),
         })
     );
 
     let follower = restarted(0).await;
+    assert_ne!(
+        follower.consensus.leader_of(next_view, next_epoch).as_ref(),
+        Some(&key(0)),
+        "node 0 should not lead view 11 in epoch 2"
+    );
     assert_eq!(follower.consensus.restart_block_request(), None);
 }
 

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -548,6 +548,8 @@ async fn test_restart_on_the_boundary_block_requests_in_the_next_epoch() {
     let next_epoch = EpochNumber::new(2);
 
     let leader = restarted(1).await;
+    // The seeds park the cursor on the anchor; `Coordinator::start` is what
+    // enters view 11.
     assert_eq!(leader.consensus.current_view(), ViewNumber::new(10));
     assert_eq!(leader.consensus.current_epoch(), Some(EpochNumber::new(1)));
     assert_eq!(
@@ -556,7 +558,7 @@ async fn test_restart_on_the_boundary_block_requests_in_the_next_epoch() {
         "node 1 should lead view 11 in epoch 2"
     );
     assert_eq!(
-        leader.consensus.restart_block_request(),
+        leader.consensus.startup_block_request(ViewNumber::new(10)),
         Some(BlockAndHeaderRequest {
             view: next_view,
             epoch: next_epoch,
@@ -570,7 +572,12 @@ async fn test_restart_on_the_boundary_block_requests_in_the_next_epoch() {
         Some(&key(0)),
         "node 0 should not lead view 11 in epoch 2"
     );
-    assert_eq!(follower.consensus.restart_block_request(), None);
+    assert_eq!(
+        follower
+            .consensus
+            .startup_block_request(ViewNumber::new(10)),
+        None
+    );
 }
 
 /// A node restarted on the boundary block proposes the first block of the
@@ -598,14 +605,14 @@ async fn test_restart_on_the_boundary_block_proposes_with_the_anchor_cert2() {
     };
 
     let mut seeded = restarted(Some(boundary.cert2.clone())).await;
-    seeded.start_after_restart().await;
+    seeded.start().await;
     assert!(
         any(seeded.outputs(), |output| is_proposal_for_view(output, 11)),
         "the restored Cert2 should let node 1 propose the first block of epoch 2"
     );
 
     let mut unseeded = restarted(None).await;
-    unseeded.start_after_restart().await;
+    unseeded.start().await;
     assert!(
         !any(unseeded.outputs(), |output| is_proposal_for_view(
             output, 11

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -381,6 +381,41 @@ async fn test_timeout_certificate_from_the_outgoing_epoch() {
     );
 }
 
+/// A node restarted with the boundary block as its anchor proposes the first
+/// block of the next epoch, so its block request carries the next epoch and
+/// its leadership is judged by the next epoch's stake table.
+///
+/// The anchor's epoch, and with it the epoch cursor after seeding, is the
+/// outgoing one. Node 1 leads view 11; node 0 does not.
+#[tokio::test]
+async fn test_restart_on_the_boundary_block_requests_in_the_next_epoch() {
+    let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
+    let boundary = &test_data.views[9];
+    let restarted = |node_index| {
+        ConsensusHarness::restarted_from(
+            node_index,
+            boundary.proposal.data.clone(),
+            boundary.cert1.clone(),
+            [],
+        )
+    };
+
+    let leader = restarted(1).await;
+    assert_eq!(leader.consensus.current_view(), ViewNumber::new(10));
+    assert_eq!(leader.consensus.current_epoch(), Some(EpochNumber::new(1)));
+    assert_eq!(
+        leader.consensus.restart_block_request(),
+        Some(BlockAndHeaderRequest {
+            view: ViewNumber::new(11),
+            epoch: EpochNumber::new(2),
+            parent_proposal: boundary.proposal.data.clone(),
+        })
+    );
+
+    let follower = restarted(0).await;
+    assert_eq!(follower.consensus.restart_block_request(), None);
+}
+
 /// Verify that exactly one SendEpochChange is emitted when processing
 /// views through a single epoch boundary.
 #[tokio::test]

--- a/crates/hotshot/new-protocol/src/tests/restarts.rs
+++ b/crates/hotshot/new-protocol/src/tests/restarts.rs
@@ -183,6 +183,66 @@ async fn restart_all_nodes_at_epoch_boundary() {
     }
 }
 
+/// Like [`restart_all_nodes_at_epoch_boundary`], but every node is killed
+/// only after it has decided the boundary block, so all of them restart
+/// anchored on it.
+///
+/// That pins the state the sibling test only sometimes reaches. Each node
+/// then holds the boundary block as its anchor, at its decide floor, so none
+/// of them votes phase 2 on it again, and the first block of epoch 2 can only
+/// be proposed with the Cert2 restored from storage. Without that restore
+/// the network never leaves epoch 1.
+///
+/// The runner's gate only bounds the anchors from below, and a node that
+/// decided past the boundary before it was killed would propose freely, so
+/// the test checks the anchors the runner saw rather than trust the gate.
+#[tokio::test(flavor = "multi_thread")]
+async fn restart_all_nodes_anchored_on_the_boundary() {
+    let num_nodes = 5;
+    let crash_view = 10;
+    let mut runner = TestRunner::builder()
+        .num_nodes(num_nodes)
+        .target_decisions(35)
+        .epoch_height(10)
+        .persistent_storage(true)
+        .node_changes_after_all_decided(true)
+        .tolerated_failed_views(views(1..=30))
+        .node_changes(vec![(
+            crash_view,
+            (0..num_nodes)
+                .map(|idx| NodeChange {
+                    idx,
+                    action: NodeAction::Restart,
+                })
+                .collect(),
+        )])
+        .build();
+    runner.run().await.unwrap();
+
+    let anchors: Vec<_> = runner
+        .restart_anchors()
+        .iter()
+        .map(|(_, anchor)| anchor.map(|v| *v))
+        .collect();
+    assert_eq!(
+        anchors,
+        vec![Some(crash_view); num_nodes],
+        "every node must have restarted anchored on the boundary block"
+    );
+
+    for (idx, storage) in runner.node_storages().iter().enumerate() {
+        let (anchor, _) = storage
+            .anchor_leaf()
+            .await
+            .unwrap_or_else(|| panic!("node {idx} has no persisted anchor"));
+        assert!(
+            *anchor.view_number() > crash_view,
+            "node {idx} anchor stuck at view {} — it did not leave epoch 1 after the restart",
+            anchor.view_number()
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // View divergence between cohorts
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The last block of an epoch belongs to the outgoing epoch. A node that holds only its Cert1 sits at the first view of the next epoch while still in the old one, and only the epoch change moves it on. If the first leader of the new epoch misses its view, those nodes time out and sign with the old epoch, and an old-epoch timeout certificate reaches nodes that have already taken the epoch change.

### Timeout certificate: leader and block request

`handle_timeout_certificate` used the certificate's epoch to choose the leader of the next view and to tag the block request. The proposal builds on the lock, so its epoch follows the lock's height, and at the boundary the two differ. The chosen leader built a header and then `maybe_propose` refused it, since the height puts the block in an epoch that node does not lead once stake tables differ. The next view timed out the same way. The timeout path now derives the epoch from the lock's proposal through `next_proposal_epoch`, the helper the proposal path already used.

### Epoch cursor

`current_epoch` was written ungated by the timeout certificate and by a late lock update, so a node that had taken the epoch change dropped back. The cursor feeds the timer through `ViewChanged`, so the node's next timeout vote carried the old epoch too. Every write now goes through `enter_epoch`, which only raises the cursor.

### Restart

`Coordinator::start` used the cursor for the same leader check and request epoch, with the same failure when the anchor is a boundary block. The decision moves into `Consensus::restart_block_request` and derives the epoch from the parent like every other request site.

### Tests

- `test_timeout_certificate_from_the_outgoing_epoch`: node 2 takes the epoch change, then receives an epoch-1 timeout certificate for view 11. Asserts the cursor stays at 2 and that the sent certificate and the block request carry epoch 2 with the boundary proposal as parent.
- `test_restart_on_the_boundary_block_requests_in_the_next_epoch`: a node restarted on the boundary block requests an epoch-2 block for view 11 if it leads that view, and nothing otherwise.

### Where to focus

- The residual disagreement in `handle_timeout_certificate`: nodes whose locks straddle the boundary can name different leaders for one view. This costs one more timeout and is accepted; see the comment there.
- The mock membership has one committee for every epoch, so the timeout test checks the epoch tag but cannot detect a leader picked from the wrong stake table.

### Known, not addressed here

When every node restarts anchored on a boundary block, persisted Cert2s are not restored and the network cannot leave the epoch. `restart_all_nodes_at_epoch_boundary` passes only when the runner kills nodes before a quorum has decided that block, which makes it flaky. Reproduced identically with and without this branch.