### PR TITLE
fix(ci): regenerate allocator patches against current sources

### DIFF
--- a/.github/workflows/build-allocators.yml
+++ b/.github/workflows/build-allocators.yml
@@ -44,12 +44,16 @@ jobs:
             platform: linux/arm64
           - allocator: jemalloc
             dep: tikv-jemallocator --features profiling
+            sym: _rjem_
           - allocator: mimalloc
             dep: mimalloc
+            sym: mi_malloc
           - allocator: snmalloc
             dep: snmalloc-rs
+            sym: snmalloc|sn_rust_
           - allocator: tcmalloc
             dep: tcmalloc-better --features extension
+            sym: tcmalloc
     steps:
       - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
@@ -77,8 +81,12 @@ jobs:
       - name: Sanity-check allocator linkage
         run: |
           for bin in target/release/espresso-node target/release/espresso-node-sqlite; do
-            count=$(nm "$bin" | grep -icE '_rjem_|mi_malloc|snmalloc|sn_rust_|tcmalloc' || true)
+            count=$(nm "$bin" | grep -icE '${{ matrix.sym }}' || true)
             echo "$bin: $count ${{ matrix.allocator }} symbols"
+            if [ "$count" -eq 0 ]; then
+              echo "::error::$bin has no ${{ matrix.allocator }} symbols"
+              exit 1
+            fi
           done
 
       - name: Setup Docker BuildKit (buildx)

--- a/.github/workflows/build-allocators.yml
+++ b/.github/workflows/build-allocators.yml
@@ -61,8 +61,10 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
+          # libprotobuf-dev ships the well-known .proto files espresso-api's codegen imports.
+          # protobuf-compiler only recommends it, and --no-install-recommends drops it.
           sudo apt-get install -y --no-install-recommends \
-            protobuf-compiler cmake clang libclang-dev
+            protobuf-compiler libprotobuf-dev cmake clang libclang-dev
 
       - name: Add allocator crate
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -120,3 +120,17 @@ jobs:
       # their own change.
       - name: Run the script tests
         run: just py::test
+
+  allocator-patches:
+    name: allocator patches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # build-allocators.yml only triggers on changes to the patches themselves, so a PR editing
+      # the files they patch breaks them silently and the failure surfaces on a release tag build.
+      - name: Check the allocator patches still apply
+        run: |
+          for p in build-support/allocator-patches/*.patch; do
+            git apply --check "$p" || { echo "::error file=$p::patch no longer applies; regenerate it"; exit 1; }
+          done

--- a/build-support/allocator-patches/jemalloc.patch
+++ b/build-support/allocator-patches/jemalloc.patch
@@ -1,5 +1,4 @@
 diff --git a/crates/espresso/node-sqlite/src/main.rs b/crates/espresso/node-sqlite/src/main.rs
-index 1943a65ceef..851350306c7 100644
 --- a/crates/espresso/node-sqlite/src/main.rs
 +++ b/crates/espresso/node-sqlite/src/main.rs
 @@ -1 +1,4 @@
@@ -8,7 +7,6 @@ index 1943a65ceef..851350306c7 100644
 +
  pub fn main() -> anyhow::Result<()> {
 diff --git a/crates/espresso/node/src/main.rs b/crates/espresso/node/src/main.rs
-index 95da67efcd8..19877e6149e 100644
 --- a/crates/espresso/node/src/main.rs
 +++ b/crates/espresso/node/src/main.rs
 @@ -1 +1,4 @@

--- a/build-support/allocator-patches/jemalloc.patch
+++ b/build-support/allocator-patches/jemalloc.patch
@@ -1,22 +1,18 @@
 diff --git a/crates/espresso/node-sqlite/src/main.rs b/crates/espresso/node-sqlite/src/main.rs
-index c7d35e2730..1b14bfa1c3 100644
+index 1943a65ceef..851350306c7 100644
 --- a/crates/espresso/node-sqlite/src/main.rs
 +++ b/crates/espresso/node-sqlite/src/main.rs
-@@ -1,3 +1,6 @@
+@@ -1 +1,4 @@
 +#[global_allocator]
 +static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 +
  pub fn main() -> anyhow::Result<()> {
-     let migrated_envs = espresso_utils::env_compat::migrate_legacy_env_vars();
-     tokio::runtime::Runtime::new()?.block_on(espresso_node::main(migrated_envs))
 diff --git a/crates/espresso/node/src/main.rs b/crates/espresso/node/src/main.rs
-index 5e7c3062c1..d920a5b3a7 100644
+index 95da67efcd8..19877e6149e 100644
 --- a/crates/espresso/node/src/main.rs
 +++ b/crates/espresso/node/src/main.rs
-@@ -1,3 +1,6 @@
+@@ -1 +1,4 @@
 +#[global_allocator]
 +static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 +
  // NOTE: due to nextest eagerly compiling binaries we allow the build if we're
- // not building with --release (without debug_assertions). There is
- // unfortunately no good way to detect if a build is performed by nextest

--- a/build-support/allocator-patches/mimalloc.patch
+++ b/build-support/allocator-patches/mimalloc.patch
@@ -1,5 +1,4 @@
 diff --git a/crates/espresso/node-sqlite/src/main.rs b/crates/espresso/node-sqlite/src/main.rs
-index 1943a65ceef..74cc02f5f97 100644
 --- a/crates/espresso/node-sqlite/src/main.rs
 +++ b/crates/espresso/node-sqlite/src/main.rs
 @@ -1 +1,4 @@
@@ -8,7 +7,6 @@ index 1943a65ceef..74cc02f5f97 100644
 +
  pub fn main() -> anyhow::Result<()> {
 diff --git a/crates/espresso/node/src/main.rs b/crates/espresso/node/src/main.rs
-index 95da67efcd8..09824416021 100644
 --- a/crates/espresso/node/src/main.rs
 +++ b/crates/espresso/node/src/main.rs
 @@ -1 +1,4 @@

--- a/build-support/allocator-patches/mimalloc.patch
+++ b/build-support/allocator-patches/mimalloc.patch
@@ -1,22 +1,18 @@
 diff --git a/crates/espresso/node-sqlite/src/main.rs b/crates/espresso/node-sqlite/src/main.rs
-index c7d35e2730..d1af0f1d97 100644
+index 1943a65ceef..74cc02f5f97 100644
 --- a/crates/espresso/node-sqlite/src/main.rs
 +++ b/crates/espresso/node-sqlite/src/main.rs
-@@ -1,3 +1,6 @@
+@@ -1 +1,4 @@
 +#[global_allocator]
 +static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 +
  pub fn main() -> anyhow::Result<()> {
-     let migrated_envs = espresso_utils::env_compat::migrate_legacy_env_vars();
-     tokio::runtime::Runtime::new()?.block_on(espresso_node::main(migrated_envs))
 diff --git a/crates/espresso/node/src/main.rs b/crates/espresso/node/src/main.rs
-index 5e7c3062c1..23995dfa84 100644
+index 95da67efcd8..09824416021 100644
 --- a/crates/espresso/node/src/main.rs
 +++ b/crates/espresso/node/src/main.rs
-@@ -1,3 +1,6 @@
+@@ -1 +1,4 @@
 +#[global_allocator]
 +static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 +
  // NOTE: due to nextest eagerly compiling binaries we allow the build if we're
- // not building with --release (without debug_assertions). There is
- // unfortunately no good way to detect if a build is performed by nextest

--- a/build-support/allocator-patches/snmalloc.patch
+++ b/build-support/allocator-patches/snmalloc.patch
@@ -1,5 +1,4 @@
 diff --git a/crates/espresso/node-sqlite/src/main.rs b/crates/espresso/node-sqlite/src/main.rs
-index 1943a65ceef..df53c5a0187 100644
 --- a/crates/espresso/node-sqlite/src/main.rs
 +++ b/crates/espresso/node-sqlite/src/main.rs
 @@ -1 +1,4 @@
@@ -8,7 +7,6 @@ index 1943a65ceef..df53c5a0187 100644
 +
  pub fn main() -> anyhow::Result<()> {
 diff --git a/crates/espresso/node/src/main.rs b/crates/espresso/node/src/main.rs
-index 95da67efcd8..836388c0b40 100644
 --- a/crates/espresso/node/src/main.rs
 +++ b/crates/espresso/node/src/main.rs
 @@ -1 +1,4 @@

--- a/build-support/allocator-patches/snmalloc.patch
+++ b/build-support/allocator-patches/snmalloc.patch
@@ -1,22 +1,18 @@
 diff --git a/crates/espresso/node-sqlite/src/main.rs b/crates/espresso/node-sqlite/src/main.rs
-index c7d35e2730..bd1d4cad36 100644
+index 1943a65ceef..df53c5a0187 100644
 --- a/crates/espresso/node-sqlite/src/main.rs
 +++ b/crates/espresso/node-sqlite/src/main.rs
-@@ -1,3 +1,6 @@
+@@ -1 +1,4 @@
 +#[global_allocator]
 +static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 +
  pub fn main() -> anyhow::Result<()> {
-     let migrated_envs = espresso_utils::env_compat::migrate_legacy_env_vars();
-     tokio::runtime::Runtime::new()?.block_on(espresso_node::main(migrated_envs))
 diff --git a/crates/espresso/node/src/main.rs b/crates/espresso/node/src/main.rs
-index 5e7c3062c1..0e319293c2 100644
+index 95da67efcd8..836388c0b40 100644
 --- a/crates/espresso/node/src/main.rs
 +++ b/crates/espresso/node/src/main.rs
-@@ -1,3 +1,6 @@
+@@ -1 +1,4 @@
 +#[global_allocator]
 +static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 +
  // NOTE: due to nextest eagerly compiling binaries we allow the build if we're
- // not building with --release (without debug_assertions). There is
- // unfortunately no good way to detect if a build is performed by nextest

--- a/build-support/allocator-patches/tcmalloc.patch
+++ b/build-support/allocator-patches/tcmalloc.patch
@@ -1,5 +1,4 @@
 diff --git a/crates/espresso/node-sqlite/src/main.rs b/crates/espresso/node-sqlite/src/main.rs
-index 1943a65ceef..a7efb22abdd 100644
 --- a/crates/espresso/node-sqlite/src/main.rs
 +++ b/crates/espresso/node-sqlite/src/main.rs
 @@ -1 +1,4 @@
@@ -8,7 +7,6 @@ index 1943a65ceef..a7efb22abdd 100644
 +
  pub fn main() -> anyhow::Result<()> {
 diff --git a/crates/espresso/node/src/main.rs b/crates/espresso/node/src/main.rs
-index 95da67efcd8..53eb5574b54 100644
 --- a/crates/espresso/node/src/main.rs
 +++ b/crates/espresso/node/src/main.rs
 @@ -1 +1,4 @@
@@ -17,7 +15,6 @@ index 95da67efcd8..53eb5574b54 100644
 +
  // NOTE: due to nextest eagerly compiling binaries we allow the build if we're
 diff --git a/crates/espresso/node/src/run.rs b/crates/espresso/node/src/run.rs
-index f1cd787454b..7ffbd2c827e 100644
 --- a/crates/espresso/node/src/run.rs
 +++ b/crates/espresso/node/src/run.rs
 @@ -18,2 +18,4 @@ use crate::{default_telemetry_endpoint, keyset::KeySet};

--- a/build-support/allocator-patches/tcmalloc.patch
+++ b/build-support/allocator-patches/tcmalloc.patch
@@ -1,35 +1,27 @@
 diff --git a/crates/espresso/node-sqlite/src/main.rs b/crates/espresso/node-sqlite/src/main.rs
-index c7d35e2730..6fc7823a12 100644
+index 1943a65ceef..a7efb22abdd 100644
 --- a/crates/espresso/node-sqlite/src/main.rs
 +++ b/crates/espresso/node-sqlite/src/main.rs
-@@ -1,3 +1,6 @@
+@@ -1 +1,4 @@
 +#[global_allocator]
 +static ALLOC: tcmalloc_better::TCMalloc = tcmalloc_better::TCMalloc;
 +
  pub fn main() -> anyhow::Result<()> {
-     let migrated_envs = espresso_utils::env_compat::migrate_legacy_env_vars();
-     tokio::runtime::Runtime::new()?.block_on(espresso_node::main(migrated_envs))
 diff --git a/crates/espresso/node/src/main.rs b/crates/espresso/node/src/main.rs
-index 5e7c3062c1..c4b826bb12 100644
+index 95da67efcd8..53eb5574b54 100644
 --- a/crates/espresso/node/src/main.rs
 +++ b/crates/espresso/node/src/main.rs
-@@ -1,3 +1,6 @@
+@@ -1 +1,4 @@
 +#[global_allocator]
 +static ALLOC: tcmalloc_better::TCMalloc = tcmalloc_better::TCMalloc;
 +
  // NOTE: due to nextest eagerly compiling binaries we allow the build if we're
- // not building with --release (without debug_assertions). There is
- // unfortunately no good way to detect if a build is performed by nextest
 diff --git a/crates/espresso/node/src/run.rs b/crates/espresso/node/src/run.rs
-index 95801578b6..ae440b0293 100644
+index f1cd787454b..7ffbd2c827e 100644
 --- a/crates/espresso/node/src/run.rs
 +++ b/crates/espresso/node/src/run.rs
-@@ -18,6 +18,8 @@ use super::{
- use crate::{default_telemetry_endpoint, keyset::KeySet};
- 
+@@ -18,2 +18,4 @@ use crate::{default_telemetry_endpoint, keyset::KeySet};
  pub async fn main(migrated_envs: Vec<(&str, &str)>) -> anyhow::Result<()> {
 +    // Spawn tcmalloc's periodic memory-release thread.
 +    tcmalloc_better::TCMalloc::process_background_actions_thread();
-     let opt = Options::parse();
- 
-     // Genesis carries the chain ID, which selects the default telemetry
+     espresso_types::assert_node_feature();


### PR DESCRIPTION
`node-sqlite/main.rs` and `node/run.rs` drifted, so every allocator build failed at git apply. Regenerated with -U1 context to reduce future drift breakage.

