### PR TITLE
chore(deps): replace backoff with backon in the query service

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -28,4 +28,13 @@ ignore = [
     # hyper 1.x stack here already uses. The vulnerable 0.3 copy comes via Push-CDN -> warp ->
     # hyper 0.14 and serves only the CDN metrics endpoint; no patched 0.3.x release exists.
     "RUSTSEC-2026-0258",
+    # `LruCache::pop()` leaves a dangling node when a stored key's `Drop` panics. Our direct `lru`
+    # is 0.18.2 (patched); the only affected copy is lru 0.7.8 pinned by memoize, whose single use
+    # here (`advz_scheme`) is keyed on `usize`. `usize` has no `Drop`, so the panic that arms this
+    # cannot occur.
+    "RUSTSEC-2026-0253",
+    # smartstring is unmaintained (repo archived 2026-05-03), no patched release exists. Reached
+    # only via routefinder -> tide-disco, the legacy HTTP stack being retired; it goes away with
+    # the last tide-disco consumer.
+    "RUSTSEC-2026-0249",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,23 +2286,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "getrandom 0.2.17",
- "instant",
- "rand 0.8.6",
-]
-
-[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand 2.4.1",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -6618,7 +6609,7 @@ dependencies = [
  "async-trait",
  "atomic_store",
  "axum 0.8.9",
- "backoff",
+ "backon",
  "backtrace-on-stack-overflow",
  "bincode",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1012,14 +1012,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -1780,7 +1780,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite 0.2.17",
@@ -1919,7 +1919,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite 0.2.17",
 ]
@@ -1943,7 +1943,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-lite 2.6.1",
  "rustix 1.1.4",
 ]
@@ -3104,9 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "circular-buffer"
-version = "0.1.9"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67261db007b5f4cf8cba393c1a5c511a5cc072339ce16e12aeba1d7b9b77946"
+checksum = "662f6b21c6e889ee4e3f449e197c40f03603472fcd40c709093d386e3dca07cf"
 
 [[package]]
 name = "clang-sys"
@@ -4105,7 +4105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4436,7 +4436,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4715,7 +4715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5102,7 +5102,7 @@ dependencies = [
  "jf-advz",
  "jf-merkle-tree-compat",
  "jf-utils",
- "lru 0.12.5",
+ "lru 0.18.2",
  "moka",
  "num-traits",
  "parking_lot",
@@ -5250,11 +5250,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite 0.2.17",
 ]
@@ -5265,7 +5264,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite 0.2.17",
 ]
 
@@ -6186,7 +6185,7 @@ dependencies = [
  "hotshot-types",
  "hotshot-utils",
  "libp2p-identity",
- "lru 0.12.5",
+ "lru 0.18.2",
  "num_enum",
  "parking_lot",
  "rand 0.8.6",
@@ -6245,7 +6244,7 @@ dependencies = [
  "hotshot-task-impls",
  "hotshot-testing",
  "hotshot-types",
- "lru 0.12.5",
+ "lru 0.18.2",
  "num_cpus",
  "serde",
  "sha2 0.10.9",
@@ -6284,7 +6283,7 @@ dependencies = [
  "hotshot-testing",
  "hotshot-types",
  "jf-advz",
- "lru 0.12.5",
+ "lru 0.18.2",
  "num_cpus",
  "serde",
  "sha2 0.10.9",
@@ -6788,7 +6787,7 @@ dependencies = [
  "hotshot-utils",
  "http-client 0.1.0",
  "jf-advz",
- "lru 0.12.5",
+ "lru 0.18.2",
  "rand 0.8.6",
  "serde",
  "sha2 0.10.9",
@@ -6828,7 +6827,7 @@ dependencies = [
  "hotshot-utils",
  "itertools 0.14.0",
  "jf-advz",
- "lru 0.12.5",
+ "lru 0.18.2",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
@@ -7191,7 +7190,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite 0.2.17",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7592,7 +7591,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8789,15 +8788,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
@@ -9027,7 +9017,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-util",
  "parking_lot",
  "portable-atomic",
@@ -9304,7 +9294,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10654,7 +10644,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10693,7 +10683,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -11551,7 +11541,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11610,7 +11600,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12500,7 +12490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12574,7 +12564,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -13148,7 +13138,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14743,7 +14733,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "20260
 cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "20260519-keep-alive", package = "cdn-client" }
 cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "20260519-keep-alive", package = "cdn-marshal" }
 chrono = { version = "0.4", features = ["serde"] }
-circular-buffer = "0.1.9"
+circular-buffer = "2.0.1"
 clap = { version = "4.5", features = ["derive", "env", "string"] }
 clap-serde = "0.5.1"
 clap-serde-derive = "0.2.1"
@@ -333,7 +333,7 @@ light-client = { path = "light-client", features = ["clap"] }
 local-ip-address = "0.6"
 log = { version = "0.4" }
 log-panics = { version = "2.0", features = ["with-backtrace"] }
-lru = "0.12"
+lru = "0.18.2"
 memoize = { version = "0.4", features = ["full"] }
 mnemonic = "1"
 moka = { version = "0.12.12", features = ["future"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ atomic = "0.6"
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", tag = "0.1.5" }
 automod = "1.0.14"
 axum = { version = "0.8.8", features = ["ws"] }
-backoff = "0.4"
+backon = "1.6"
 base64 = "0.22"
 base64-bytes = "0.1"
 bigdecimal = "0.4.8"

--- a/hotshot-query-service/Cargo.toml
+++ b/hotshot-query-service/Cargo.toml
@@ -60,7 +60,7 @@ async-trait = { workspace = true }
 
 # Dependencies enabled by feature "file-system-data-source".
 atomic_store = { workspace = true, optional = true }
-backoff = { workspace = true }
+backon = { workspace = true }
 bincode = { workspace = true }
 chrono = { workspace = true }
 committable = { workspace = true }

--- a/hotshot-query-service/src/data_source/fetching.rs
+++ b/hotshot-query-service/src/data_source/fetching.rs
@@ -64,7 +64,7 @@ use std::{
 use anyhow::{Context, bail};
 use async_lock::Semaphore;
 use async_trait::async_trait;
-use backoff::{ExponentialBackoff, ExponentialBackoffBuilder, backoff::Backoff};
+use backon::{BackoffBuilder, ExponentialBuilder};
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use futures::{
@@ -143,7 +143,7 @@ use self::{
 pub struct Builder<Types, S, P> {
     storage: S,
     provider: P,
-    backoff: ExponentialBackoffBuilder,
+    backoff: ExponentialBuilder,
     rate_limit: usize,
     range_chunk_size: usize,
     proactive_interval: Duration,
@@ -162,12 +162,14 @@ pub struct Builder<Types, S, P> {
 impl<Types, S, P> Builder<Types, S, P> {
     /// Construct a new builder with the given storage and fetcher and the default options.
     pub fn new(storage: S, provider: P) -> Self {
-        let mut default_backoff = ExponentialBackoffBuilder::default();
-        default_backoff
-            .with_initial_interval(Duration::from_secs(1))
-            .with_multiplier(2.)
-            .with_max_interval(Duration::from_secs(32))
-            .with_max_elapsed_time(Some(Duration::from_secs(64)));
+        // `without_max_times` is required: backon stops after three attempts by default, whereas
+        // retries here are bounded by elapsed time alone.
+        let default_backoff = ExponentialBuilder::default()
+            .with_min_delay(Duration::from_secs(1))
+            .with_factor(2.)
+            .with_max_delay(Duration::from_secs(32))
+            .without_max_times()
+            .with_total_delay(Some(Duration::from_secs(64)));
 
         Self {
             storage,
@@ -196,31 +198,35 @@ impl<Types, S, P> Builder<Types, S, P> {
 
     /// Set the minimum delay between retries of failed operations.
     pub fn with_min_retry_interval(mut self, interval: Duration) -> Self {
-        self.backoff.with_initial_interval(interval);
+        self.backoff = self.backoff.with_min_delay(interval);
         self
     }
 
     /// Set the maximum delay between retries of failed operations.
     pub fn with_max_retry_interval(mut self, interval: Duration) -> Self {
-        self.backoff.with_max_interval(interval);
+        self.backoff = self.backoff.with_max_delay(interval);
         self
     }
 
     /// Set the multiplier for exponential backoff when retrying failed requests.
-    pub fn with_retry_multiplier(mut self, multiplier: f64) -> Self {
-        self.backoff.with_multiplier(multiplier);
+    pub fn with_retry_multiplier(mut self, multiplier: f32) -> Self {
+        self.backoff = self.backoff.with_factor(multiplier);
         self
     }
 
-    /// Set the randomization factor for randomized backoff when retrying failed requests.
-    pub fn with_retry_randomization_factor(mut self, factor: f64) -> Self {
-        self.backoff.with_randomization_factor(factor);
+    /// Randomize retry delays.
+    ///
+    /// Replaces the former `with_retry_randomization_factor`. backon treats jitter as a switch
+    /// rather than a scaling factor, so there is no value to pass, and jitter is off until this
+    /// is called.
+    pub fn with_retry_jitter(mut self) -> Self {
+        self.backoff = self.backoff.with_jitter();
         self
     }
 
     /// Set the maximum time to retry failed operations before giving up.
     pub fn with_retry_timeout(mut self, timeout: Duration) -> Self {
-        self.backoff.with_max_elapsed_time(Some(timeout));
+        self.backoff = self.backoff.with_total_delay(Some(timeout));
         self
     }
 
@@ -412,7 +418,7 @@ where
     Payload<Types>: QueryablePayload<Types>,
     S: PruneStorage + Send + Sync + 'static,
 {
-    async fn new(storage: Arc<S>, backoff: ExponentialBackoff) -> Self {
+    async fn new(storage: Arc<S>, backoff: ExponentialBuilder) -> Self {
         let cfg = storage.get_pruning_config();
         let Some(cfg) = cfg else {
             return Self {
@@ -428,7 +434,7 @@ where
                 sleep(cfg.interval()).await;
 
                 tracing::warn!("starting pruner run {i} ");
-                Self::prune(storage.clone(), &backoff).await;
+                Self::prune(storage.clone(), backoff).await;
             }
         };
 
@@ -440,12 +446,11 @@ where
         }
     }
 
-    async fn prune(storage: Arc<S>, backoff: &ExponentialBackoff) {
+    async fn prune(storage: Arc<S>, backoff: ExponentialBuilder) {
         // We loop until the whole run pruner run is complete
         let mut pruner = S::Pruner::default();
         'run: loop {
-            let mut backoff = backoff.clone();
-            backoff.reset();
+            let mut backoff = backoff.build();
             'batch: loop {
                 match storage.prune(&mut pruner).await {
                     Ok(Some(height)) => {
@@ -458,7 +463,7 @@ where
                     },
                     Err(e) => {
                         tracing::warn!("error pruning batch: {e:#}");
-                        if let Some(delay) = backoff.next_backoff() {
+                        if let Some(delay) = backoff.next() {
                             sleep(delay).await;
                         } else {
                             tracing::error!("pruning run failed after too many errors: {e:#}");
@@ -510,7 +515,7 @@ where
         let proactive_fetching = builder.proactive_fetching;
         let proactive_interval = builder.proactive_interval;
         let proactive_range_chunk_size = builder.proactive_range_chunk_size;
-        let backoff = builder.backoff.build();
+        let backoff = builder.backoff;
         let scanner_metrics = ScannerMetrics::new(builder.storage.metrics());
         let aggregator_metrics = AggregatorMetrics::new(builder.storage.metrics());
 
@@ -984,7 +989,7 @@ where
     // Duration to sleep after each chunk fetched
     chunk_fetch_delay: Duration,
     // Exponential backoff when retrying failed operations.
-    backoff: ExponentialBackoff,
+    backoff: ExponentialBuilder,
     // Semaphore limiting the number of simultaneous DB accesses we can have from tasks spawned to
     // retry failed loads.
     retry_semaphore: Arc<Semaphore>,
@@ -1026,7 +1031,7 @@ where
 {
     pub async fn new(builder: Builder<Types, S, P>) -> anyhow::Result<Self> {
         let retry_semaphore = Arc::new(Semaphore::new(builder.rate_limit));
-        let backoff = builder.backoff.build();
+        let backoff = builder.backoff;
 
         let (payload_fetcher, payload_range_fetcher, vid_common_fetcher, vid_common_range_fetcher) =
             if builder.is_leaf_only() {
@@ -1035,30 +1040,26 @@ where
                 (
                     Some(Arc::new(fetching::Fetcher::new(
                         retry_semaphore.clone(),
-                        backoff.clone(),
+                        backoff,
                     ))),
                     Some(Arc::new(fetching::Fetcher::new(
                         retry_semaphore.clone(),
-                        backoff.clone(),
+                        backoff,
                     ))),
                     Some(Arc::new(fetching::Fetcher::new(
                         retry_semaphore.clone(),
-                        backoff.clone(),
+                        backoff,
                     ))),
                     Some(Arc::new(fetching::Fetcher::new(
                         retry_semaphore.clone(),
-                        backoff.clone(),
+                        backoff,
                     ))),
                 )
             };
-        let leaf_fetcher = fetching::Fetcher::new(retry_semaphore.clone(), backoff.clone());
-        let leaf_range_fetcher = fetching::Fetcher::new(retry_semaphore.clone(), backoff.clone());
-        let cert2_fetcher = (!builder.is_leaf_only()).then(|| {
-            Arc::new(fetching::Fetcher::new(
-                retry_semaphore.clone(),
-                backoff.clone(),
-            ))
-        });
+        let leaf_fetcher = fetching::Fetcher::new(retry_semaphore.clone(), backoff);
+        let leaf_range_fetcher = fetching::Fetcher::new(retry_semaphore.clone(), backoff);
+        let cert2_fetcher = (!builder.is_leaf_only())
+            .then(|| Arc::new(fetching::Fetcher::new(retry_semaphore.clone(), backoff)));
 
         let leaf_only = builder.leaf_only;
         let sync_status_metrics =
@@ -1130,12 +1131,12 @@ where
         let (send, recv) = oneshot::channel();
 
         let fetcher = self.clone();
-        let mut backoff = fetcher.backoff.clone();
+        let backoff = fetcher.backoff;
         let span = tracing::warn_span!("get retry", ?req);
         spawn(
             async move {
-                backoff.reset();
-                let mut delay = backoff.next_backoff().unwrap_or(Duration::from_secs(1));
+                let mut backoff = backoff.build();
+                let mut delay = backoff.next().unwrap_or(Duration::from_secs(1));
                 loop {
                     let res = {
                         // Limit the number of simultaneous retry tasks hitting the database. When
@@ -1167,7 +1168,7 @@ where
                                 "unable to fetch object, will retry: {err:#}"
                             );
                             sleep(delay).await;
-                            if let Some(next_delay) = backoff.next_backoff() {
+                            if let Some(next_delay) = backoff.next() {
                                 delay = next_delay;
                             }
                         },
@@ -1386,13 +1387,13 @@ where
 
         {
             let fetcher = self.clone();
-            let mut backoff = fetcher.backoff.clone();
+            let backoff = fetcher.backoff;
             let chunk = chunk.clone();
             let span = tracing::warn_span!("get_chunk retry", ?chunk);
             spawn(
                 async move {
-                    backoff.reset();
-                    let mut delay = backoff.next_backoff().unwrap_or(Duration::from_secs(1));
+                    let mut backoff = backoff.build();
+                    let mut delay = backoff.next().unwrap_or(Duration::from_secs(1));
                     loop {
                         let res = {
                             // Limit the number of simultaneous retry tasks hitting the database.
@@ -1428,7 +1429,7 @@ where
                                     "unable to fetch chunk, will retry: {err:#}"
                                 );
                                 sleep(delay).await;
-                                if let Some(next_delay) = backoff.next_backoff() {
+                                if let Some(next_delay) = backoff.next() {
                                     delay = next_delay;
                                 }
                             },
@@ -1884,8 +1885,7 @@ where
         };
 
         // Store the object in local storage, so we can avoid fetching it in the future.
-        let mut backoff = self.backoff.clone();
-        backoff.reset();
+        let mut backoff = self.backoff.build();
         loop {
             let Err(err) = try_store().await else {
                 break;
@@ -1898,7 +1898,7 @@ where
                 "failed to store fetched object: {err:#}"
             );
 
-            let Some(delay) = backoff.next_backoff() else {
+            let Some(delay) = backoff.next() else {
                 break;
             };
             tracing::info!(?delay, "retrying failed operation");

--- a/hotshot-query-service/src/fetching.rs
+++ b/hotshot-query-service/src/fetching.rs
@@ -30,7 +30,7 @@ use std::{
 
 use anyhow::ensure;
 use async_lock::{Mutex, Semaphore};
-use backoff::{ExponentialBackoff, backoff::Backoff};
+use backon::{BackoffBuilder, ExponentialBuilder};
 use derivative::Derivative;
 use derive_more::Into;
 use serde::{Deserialize, Serialize};
@@ -67,12 +67,12 @@ pub trait LocalCallback<T>: Debug + Ord {
 pub struct Fetcher<T, C> {
     #[derivative(Debug = "ignore")]
     in_progress: Arc<Mutex<HashMap<T, BTreeSet<C>>>>,
-    backoff: ExponentialBackoff,
+    backoff: ExponentialBuilder,
     permit: Arc<Semaphore>,
 }
 
 impl<T, C> Fetcher<T, C> {
-    pub fn new(permit: Arc<Semaphore>, backoff: ExponentialBackoff) -> Self {
+    pub fn new(permit: Arc<Semaphore>, backoff: ExponentialBuilder) -> Self {
         Self {
             in_progress: Default::default(),
             permit,
@@ -122,7 +122,7 @@ impl<T, C> Fetcher<T, C> {
     {
         let in_progress = self.in_progress.clone();
         let permit = self.permit.clone();
-        let mut backoff = self.backoff.clone();
+        let backoff = self.backoff;
 
         spawn(async move {
             tracing::info!("spawned active fetch for {req:?}");
@@ -148,8 +148,8 @@ impl<T, C> Fetcher<T, C> {
             }
 
             // Now we are responsible for fetching the object, reach out to the provider.
-            backoff.reset();
-            let mut delay = backoff.next_backoff().unwrap_or(Duration::from_secs(1));
+            let mut backoff = backoff.build();
+            let mut delay = backoff.next().unwrap_or(Duration::from_secs(1));
             let res = loop {
                 // Acquire a permit from the semaphore to rate limit the number of concurrent fetch requests
                 let permit = permit.acquire().await;
@@ -176,7 +176,7 @@ impl<T, C> Fetcher<T, C> {
                 drop(permit);
                 sleep(delay).await;
 
-                if let Some(next_delay) = backoff.next_backoff() {
+                if let Some(next_delay) = backoff.next() {
                     delay = next_delay;
                 }
             };

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -1234,7 +1234,7 @@ mod test {
             // Randomize retries a lot. This will temporarlly separate competing transactions write
             // transactions with high probability, so that one of them quickly gets exclusive access
             // to the database.
-            .with_retry_randomization_factor(3.)
+            .with_retry_jitter()
             .build()
             .await
             .unwrap();

--- a/node-metrics/src/service/data_state/mod.rs
+++ b/node-metrics/src/service/data_state/mod.rs
@@ -6,7 +6,7 @@ use std::{collections::HashSet, iter::zip, sync::Arc};
 use alloy::primitives::Address;
 use async_lock::RwLock;
 use bitvec::vec::BitVec;
-use circular_buffer::CircularBuffer;
+use circular_buffer::FixedCircularBuffer;
 use espresso_types::{Header, Payload, SeqTypes, v0_3::AuthenticatedValidator};
 use futures::{Sink, SinkExt, Stream, StreamExt, channel::mpsc::SendError};
 use hotshot_query_service::{
@@ -43,8 +43,8 @@ pub const MAX_VOTERS_HISTORY: usize = 100;
 /// the service.
 #[cfg_attr(test, derive(Default))]
 pub struct DataState {
-    latest_blocks: CircularBuffer<MAX_HISTORY, BlockDetail<SeqTypes>>,
-    latest_voters: CircularBuffer<MAX_VOTERS_HISTORY, BitVec<u16>>,
+    latest_blocks: FixedCircularBuffer<BlockDetail<SeqTypes>, MAX_HISTORY>,
+    latest_voters: FixedCircularBuffer<BitVec<u16>, MAX_VOTERS_HISTORY>,
     stake_table: Vec<PeerConfig<SeqTypes>>,
     // Do we need any other data at the moment?
     node_identity: Vec<NodeIdentity>,
@@ -53,8 +53,8 @@ pub struct DataState {
 
 impl DataState {
     pub fn new(
-        latest_blocks: CircularBuffer<MAX_HISTORY, BlockDetail<SeqTypes>>,
-        latest_voters: CircularBuffer<MAX_VOTERS_HISTORY, BitVec<u16>>,
+        latest_blocks: FixedCircularBuffer<BlockDetail<SeqTypes>, MAX_HISTORY>,
+        latest_voters: FixedCircularBuffer<BitVec<u16>, MAX_VOTERS_HISTORY>,
         stake_table: Vec<PeerConfig<SeqTypes>>,
         validators: IndexMap<Address, AuthenticatedValidator<BLSPubKey>>,
     ) -> Self {


### PR DESCRIPTION
Stacked on #4917. Review that one first, and retarget this to `main` once it merges.

`backoff` 0.4 is unmaintained, RUSTSEC-2025-0012. `backon` is maintained and covers
the same exponential retry behaviour.

**Where to focus.** The two crates model retries differently, and that shapes the
whole diff. `backoff` hands out a resettable object with `next_backoff()`, while
`backon` builds a fresh `Duration` iterator from a `Copy` builder. So every retry
site now stores the builder and calls `build()` where it used to call `reset()`.
There are four such sites, three fetch retry loops and the pruner loop, and each
one starts its sequence from the same state as before.

Two behavioural details are worth a careful look.

`backon` stops after three attempts by default, where `backoff` retried until its
elapsed-time budget ran out. The constructed builder calls `without_max_times()` so
retries stay bounded by elapsed time alone. Without that line the fetcher would
quietly give up after three tries, which matters on the catchup path.

`with_max_elapsed_time` becomes `with_total_delay`. `backoff` bounded total elapsed
time including the operation itself, `backon` bounds the sum of the sleeps. For the
64 second default and the retry patterns here the difference is small, but it is not
an exact equivalence.

**One API change.** `with_retry_randomization_factor(f64)` becomes
`with_retry_jitter()` with no argument. `backon` treats jitter as a switch rather
than a scaling factor, so keeping the float would have meant accepting a value and
ignoring it. The only caller is a test in this crate, and the crate is
`publish = false`.

**What this does and does not clear.** It clears RUSTSEC-2025-0012 and closes #2743.
It does not clear RUSTSEC-2024-0384 for `instant`, #2269, which I expected it to.
`backoff` was one parent, but `instant` also arrives through
`fastrand` 1.9, `futures-lite` 1.13, `async-h1`, `tide` and `maud` from `tide-disco`,
so it stays until the builder is retired.

`cargo audit` exits 0. Allowed warnings drop from 17 to 16. `cargo clippy -p
hotshot-query-service --all-targets -- -D warnings` is clean, and the crate and its
tests compile.

Closes #2743
