### PR TITLE
fix(deployer): skip re-init when upgrading already-V2 EspToken

### DIFF
--- a/contracts/rust/deployer/src/lib.rs
+++ b/contracts/rust/deployer/src/lib.rs
@@ -3136,6 +3136,16 @@ mod tests {
         .await
     }
 
+    // We expect no init data for the second upgrade because the proxy was already initialized
+    #[test_log::test(tokio::test)]
+    async fn test_upgrade_esp_token_v2_twice_multisig_owner() -> Result<()> {
+        test_upgrade_esp_token_v2_multisig_owner_helper(UpgradeTestOptions {
+            is_mock: false,
+            upgrade_count: UpgradeCount::Twice,
+        })
+        .await
+    }
+
     // This test is used to test the upgrade of the EspTokenProxy via the multisig wallet
     // It only tests the upgrade proposal via the typescript script and thus requires the upgrade proposal to be sent to a real network
     // However, the contracts are deployed on anvil, so the test will pass even if the upgrade proposal is not executed

--- a/contracts/rust/deployer/src/proposals/multisig.rs
+++ b/contracts/rust/deployer/src/proposals/multisig.rs
@@ -337,19 +337,24 @@ pub async fn upgrade_esp_token_v2_multisig_owner(
         .deploy(Contract::EspTokenV2, EspTokenV2::deploy_builder(&provider))
         .await?;
 
-    let reward_claim_addr = contracts
-        .address(Contract::RewardClaimProxy)
-        .ok_or_else(|| anyhow!("RewardClaimProxy not found"))?;
-    let proxy_as_v2 = EspTokenV2::new(proxy_addr, &provider);
-    let init_data = proxy_as_v2
-        .initializeV2(reward_claim_addr)
-        .calldata()
-        .to_owned();
-
-    tracing::info!(
-        %reward_claim_addr,
-        "Data to be signed: Function: initializeV2 Arguments:"
-    );
+    // We expect no init data for the second upgrade because the proxy was already initialized
+    let init_data = if crate::already_initialized(&provider, proxy_addr, 2).await? {
+        tracing::info!("EspTokenProxy already initialized at V2, skipping initializeV2()");
+        vec![].into()
+    } else {
+        let reward_claim_addr = contracts
+            .address(Contract::RewardClaimProxy)
+            .ok_or_else(|| anyhow!("RewardClaimProxy not found"))?;
+        let proxy_as_v2 = EspTokenV2::new(proxy_addr, &provider);
+        tracing::info!(
+            %reward_claim_addr,
+            "Data to be signed: Function: initializeV2 Arguments:"
+        );
+        proxy_as_v2
+            .initializeV2(reward_claim_addr)
+            .calldata()
+            .to_owned()
+    };
 
     encode_upgrade_calldata(proxy_addr, esp_token_v2_addr, init_data)
 }


### PR DESCRIPTION
Fixes #3812: upgrading an EspToken proxy that's already on V2 currently reverts with a cryptic InvalidInitialization error. This adds a version check before calling initializeV2() in upgrade_esp_token_v2_multisig_owner()  mirroring the existing pattern used for LightClient upgrades  so that if the proxy is already initialized at V2, the upgrade calldata is built without re-running initializeV2(), instead of reverting. Also adds test_upgrade_esp_token_v2_twice_multisig_owner as a regression test, mirroring the existing test_upgrade_light_client_to_v2_twice_multisig_owner.