### PR TITLE
chore(genesis): set mainnet base version to v6

### DIFF
--- a/data/genesis/mainnet.toml
+++ b/data/genesis/mainnet.toml
@@ -1,4 +1,4 @@
-base_version = "0.5"
+base_version = "0.6"
 upgrade_version = "0.6"
 genesis_version = "0.2"
 epoch_height = 40000
@@ -12,7 +12,7 @@ capacity = 200
 [chain_config]
 chain_id = 1
 base_fee = "1 wei"
-max_block_size = "5mb"
+max_block_size = "10mb"
 fee_recipient = "0x0000000000000000000000000000000000000000"
 fee_contract = "0x9fce21c3f7600aa63392a5f5713986b39bb98884"
 stake_table_contract = "0xcef474d372b5b09defe2af187bf17338dc704451"
@@ -29,19 +29,3 @@ fee_contract = "0x9fce21c3f7600aa63392a5f5713986b39bb98884"
 
 [l1_finalized]
 number = 21116303
-
-[[upgrade]]
-version = "0.6"
-start_voting_view = 0
-stop_voting_view = 999999999
-start_proposing_view = 0
-stop_proposing_view = 1
-
-[upgrade.new_protocol]
-[upgrade.new_protocol.chain_config]
-chain_id = 1
-base_fee = "1 wei"
-max_block_size = "10mb"
-fee_recipient = "0x0000000000000000000000000000000000000000"
-fee_contract = "0x9fce21c3f7600aa63392a5f5713986b39bb98884"
-stake_table_contract = "0xcef474d372b5b09defe2af187bf17338dc704451"


### PR DESCRIPTION
Post fast-finality state for mainnet: base_version 0.6, the completed 0.6 upgrade removed, and the top-level chain_config carrying what the upgrade's new_protocol chain_config set (max_block_size 10mb).

Prepared ahead of the upgrade; do not merge until mainnet runs 0.6.
