### PR TITLE
chore(genesis): add mainnet 0.6 upgrade proposer genesis

### DIFF
--- a/data/genesis/mainnet-proposer.toml
+++ b/data/genesis/mainnet-proposer.toml
@@ -1,0 +1,56 @@
+base_version = "0.5"
+upgrade_version = "0.6"
+genesis_version = "0.2"
+epoch_height = 40000
+drb_difficulty = 25000000000
+drb_upgrade_difficulty = 25000000000
+epoch_start_block = 10960201
+
+[stake_table]
+capacity = 200
+
+[chain_config]
+chain_id = 1
+base_fee = "1 wei"
+max_block_size = "5mb"
+fee_recipient = "0x0000000000000000000000000000000000000000"
+fee_contract = "0x9fce21c3f7600aa63392a5f5713986b39bb98884"
+stake_table_contract = "0xcef474d372b5b09defe2af187bf17338dc704451"
+
+[header]
+timestamp = "1970-01-01T00:00:00Z"
+
+[header.chain_config]
+chain_id = 1
+base_fee = "1 wei"
+max_block_size = "1mb"
+fee_recipient = "0x0000000000000000000000000000000000000000"
+fee_contract = "0x9fce21c3f7600aa63392a5f5713986b39bb98884"
+
+[l1_finalized]
+number = 21116303
+
+# Proposer variant of mainnet.toml: identical except for the proposing window
+# below. Run on a single Espresso-operated node to propose the 0.6 upgrade.
+# The window (plus the 130-view upgrade finish offset) must stay inside one
+# epoch, well clear of the epoch transition (epoch_height = 40000 blocks).
+# Target: epoch 574 (blocks 22920001-22960000) on 2026-09-09. The window opens
+# ~15:10 UTC and runs until ~570 views before the earliest possible view of
+# the epoch's last block (hard floor: current view + blocks remaining,
+# measured at view 23815888 / block 22942888), so a proposal sent in the
+# window's last view still finishes inside epoch 574.
+[[upgrade]]
+version = "0.6"
+start_voting_view = 0
+stop_voting_view = 999999999
+start_proposing_view = 23821800
+stop_proposing_view = 23832300
+
+[upgrade.new_protocol]
+[upgrade.new_protocol.chain_config]
+chain_id = 1
+base_fee = "1 wei"
+max_block_size = "10mb"
+fee_recipient = "0x0000000000000000000000000000000000000000"
+fee_contract = "0x9fce21c3f7600aa63392a5f5713986b39bb98884"
+stake_table_contract = "0xcef474d372b5b09defe2af187bf17338dc704451"


### PR DESCRIPTION
## Summary

Adds `data/genesis/mainnet-proposer.toml`: a copy of `mainnet.toml` whose only functional difference is a real
`start_proposing_view` / `stop_proposing_view` window for the 0.5 -> 0.6 new-protocol upgrade. It is meant to run on a
single Espresso-operated node (set `ESPRESSO_NODE_GENESIS_FILE=genesis/mainnet-proposer.toml`); every other node keeps
the voting-only `mainnet.toml` shipped in release `20260828`, which is what mainnet is running today.

This mirrors the `staging-proposer.toml` pattern used for previous upgrades. The upgrade hash is a version constant
(`SequencerVersions::UPGRADE_HASH`), so voters on `mainnet.toml` accept a proposal from this file.

## Window: 2026-09-09, from ~11:10 EDT until shortly before the epoch 574 -> 575 transition

| Field | Value |
|---|---|
| `start_proposing_view` | 23821800, ETA 2026-09-09 15:08 UTC (11:08 EDT) |
| `stop_proposing_view` | 23832300, ETA 2026-09-09 18:39 UTC (14:39 EDT) |
| Window length | 10500 views (~3.5 h) |
| Epoch 574 blocks | 22920001-22960000 (mainnet is already in epoch 574) |
| Epoch 574 last-block view, hard floor | 23833000 = view 23815888 at block 22942888 + 17112 remaining blocks |
| Epoch 574 last-block view, estimate | ~23833436, ETA 2026-09-09 19:02 UTC (15:02 EDT) |
| Margin after `stop + 130` (finish offset), vs. hard floor | 570 views |
| Margin after `stop + 130`, vs. estimate | 1006 views |

- The upgrade fires at the first view >= `start_proposing_view` where the proposer node is leader, so it most likely
  happens soon after ~11:10 EDT; the long tail exists so a slow deploy or a failed first attempt still lands today.
- The hard floor is exact: every block consumes at least one view, so the epoch's last block cannot have a view below
  23833000. Even a proposal sent in the window's final view completes 570 views before that, above the
  100-view minimum buffer. The epoch root (block 22959995) and transition blocks (22959997-22960000) sit only 5 views under the floor.
- Wall-clock ETAs are soft: block time since 01:05 UTC averaged 1.240 s and views/block 1.0254. View numbers are
  what keep the window safe, not the clock.

## Review focus

- The two view numbers in `data/genesis/mainnet-proposer.toml`; everything else matches `mainnet.toml` apart from the
  explanatory comment.
- `test_committed_genesis_files_validate` parses every file in `data/genesis/`, so the new file is covered (passes locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

