### PR TITLE
feat(new-protocol): cliquenet observer peers for non-staked query nodes (release)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -43,6 +43,11 @@ slow-timeout = { period = "2m", terminate-after = 15 }
 threads-required = 'num-cpus'
 
 [[profile.default.overrides]]
+filter = 'test(test_new_protocol_observer_query_node)'
+slow-timeout = { period = "2m", terminate-after = 15 }
+threads-required = 'num-cpus'
+
+[[profile.default.overrides]]
 filter = 'test(slow_test_restart_new_protocol)'
 slow-timeout = { period = "2m", terminate-after = 5 }
 threads-required = 'num-cpus'

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -5780,6 +5780,230 @@ mod test {
         Ok(())
     }
 
+    /// A non-staked observer fed by nodes 0 and 1 over cliquenet decides the
+    /// chain live and serves it from its own query API; payloads and VID common
+    /// still come from node 0 over HTTP. The query service only stores new
+    /// heights from decides, so the observer's archive reaching the tip proves
+    /// it decides from the forwarded feed, not from backfill.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_new_protocol_observer_query_node() -> anyhow::Result<()> {
+        const NUM_NODES: usize = 5;
+        const EPOCH_HEIGHT: u64 = 10;
+        const EPOCHS_TO_FOLLOW: u64 = 3;
+        const NEW_PROTOCOL: Upgrade = Upgrade::trivial(NEW_PROTOCOL_VERSION);
+        const FOLLOW_TIMEOUT: Duration = Duration::from_secs(240);
+
+        let network_config = TestConfigBuilder::default()
+            .epoch_height(EPOCH_HEIGHT)
+            .epoch_start_block(0)
+            .observer(&[0, 1])
+            .build();
+
+        let api_port = reserve_tcp_port().expect("No ports free for query service");
+        let observer_port = reserve_tcp_port().expect("No ports free for query service");
+        let api_url: Url = format!("http://localhost:{api_port}").parse()?;
+        let observer_url: Url = format!("http://localhost:{observer_port}").parse()?;
+
+        let storage = join_all((0..NUM_NODES).map(|_| SqlDataSource::create_storage())).await;
+        let persistence: [_; NUM_NODES] = storage
+            .iter()
+            .map(<SqlDataSource as TestableSequencerDataSource>::persistence_options)
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+        let observer_storage = SqlDataSource::create_storage().await;
+
+        let config = TestNetworkConfigBuilder::<NUM_NODES, _, _>::with_num_nodes()
+            .api_config(
+                Options::with_port(api_port)
+                    .catchup(Default::default())
+                    .light_client(Default::default())
+                    .query_sql(Query::default(), tmp_options(&storage[0])),
+            )
+            .network_config(network_config)
+            .persistences(persistence)
+            .catchups(std::array::from_fn(|_| {
+                StatePeers::<SequencerApiVersion>::from_urls(
+                    vec![api_url.clone()],
+                    Default::default(),
+                    Duration::from_secs(2),
+                    &NoMetrics,
+                )
+            }))
+            .pos_hook(
+                DelegationConfig::MultipleDelegators,
+                StakeTableContractVersion::V3,
+                NEW_PROTOCOL,
+            )
+            .await?
+            .build();
+
+        let genesis_state = config.states()[0].clone();
+        let network = TestNetwork::new(config, NEW_PROTOCOL).await;
+
+        let observer_key = network
+            .cfg
+            .observer()
+            .expect("observer configured")
+            .public_key();
+        assert!(
+            !network
+                .cfg
+                .known_nodes_with_stake()
+                .iter()
+                .any(|peer| peer.stake_table_entry.stake_key == observer_key),
+            "the observer must not be in the stake table"
+        );
+
+        let observer = {
+            let cfg = network.cfg.clone();
+            let peer_url = api_url.clone();
+            let db = tmp_options(&observer_storage);
+            let ctx = Options::with_port(observer_port)
+                .query_sql(
+                    Query {
+                        peers: vec![peer_url.clone()],
+                        ..Default::default()
+                    },
+                    db.clone(),
+                )
+                .serve(move |metrics, consumer, storage| {
+                    async move {
+                        Ok(cfg
+                            .init_observer_node(
+                                genesis_state,
+                                db,
+                                Some(StatePeers::<SequencerApiVersion>::from_urls(
+                                    vec![peer_url],
+                                    Default::default(),
+                                    Duration::from_secs(2),
+                                    &NoMetrics,
+                                )),
+                                storage,
+                                &*metrics,
+                                test_helpers::STAKE_TABLE_CAPACITY_FOR_TEST,
+                                consumer,
+                                NEW_PROTOCOL,
+                                Default::default(),
+                            )
+                            .await)
+                    }
+                    .boxed()
+                })
+                .await
+                .expect("observer should start");
+            ctx.start_consensus().await;
+            ctx
+        };
+
+        let api_client: Client<ClientErr, SequencerApiVersion> = Client::new(api_url);
+        let observer_client: Client<ClientErr, SequencerApiVersion> = Client::new(observer_url);
+        assert!(
+            api_client.connect(Some(Duration::from_secs(60))).await,
+            "node 0 query API did not come up"
+        );
+        assert!(
+            observer_client.connect(Some(Duration::from_secs(60))).await,
+            "observer query API did not come up"
+        );
+
+        let mut events = network.server.event_stream();
+        wait_for_epochs(&mut events, EPOCH_HEIGHT, EPOCHS_TO_FOLLOW).await;
+
+        let tip = network.server.decided_leaf().await.height();
+        timeout(FOLLOW_TIMEOUT, async {
+            while observer.decided_leaf().await.height() < tip {
+                sleep(Duration::from_secs(1)).await;
+            }
+        })
+        .await
+        .context("observer did not decide up to the validators' tip")?;
+        test_helpers::assert_nodes_agree(&[&observer, &network.server], tip).await;
+
+        // `node/block-height` counts blocks, so `tip` is stored at `tip + 1`.
+        timeout(
+            FOLLOW_TIMEOUT,
+            wait_until_block_height(&observer_client, "node/block-height", tip + 1),
+        )
+        .await
+        .context("observer's archive did not reach the validators' tip")?;
+
+        // Cert2s are only stored at the heights they finalize; scan back for one.
+        let mut finalized_height = None;
+        for height in (1..tip).rev() {
+            if api_client
+                .get::<espresso_types::Certificate2<SeqTypes>>(&format!(
+                    "availability/cert2/{height}"
+                ))
+                .send()
+                .await
+                .is_ok()
+            {
+                finalized_height = Some(height);
+                break;
+            }
+        }
+        let finalized_height =
+            finalized_height.context("no cert2 stored on a new protocol chain")?;
+
+        let theirs: LeafQueryData<SeqTypes> = api_client
+            .get(&format!("availability/leaf/{finalized_height}"))
+            .send()
+            .await?;
+        let ours: LeafQueryData<SeqTypes> = observer_client
+            .get(&format!("availability/leaf/{finalized_height}"))
+            .send()
+            .await?;
+        assert_eq!(
+            ours.hash(),
+            theirs.hash(),
+            "observer's leaf diverges from node 0"
+        );
+        assert_eq!(ours.header().version(), NEW_PROTOCOL_VERSION);
+
+        let cert2 = timeout(FOLLOW_TIMEOUT, async {
+            loop {
+                match observer_client
+                    .get::<espresso_types::Certificate2<SeqTypes>>(&format!(
+                        "availability/cert2/{finalized_height}"
+                    ))
+                    .send()
+                    .await
+                {
+                    Ok(cert2) => break cert2,
+                    Err(err) => tracing::info!(finalized_height, %err, "cert2 not stored yet"),
+                }
+                sleep(Duration::from_secs(2)).await;
+            }
+        })
+        .await
+        .context("observer did not store the cert2")?;
+        assert_eq!(cert2.data.block_number, finalized_height);
+
+        let block = timeout(FOLLOW_TIMEOUT, async {
+            loop {
+                match observer_client
+                    .get::<BlockQueryData<SeqTypes>>(&format!(
+                        "availability/block/{finalized_height}"
+                    ))
+                    .send()
+                    .await
+                {
+                    Ok(block) => break block,
+                    Err(err) => {
+                        tracing::info!(finalized_height, %err, "payload not backfilled yet")
+                    },
+                }
+                sleep(Duration::from_secs(2)).await;
+            }
+        })
+        .await
+        .context("observer did not backfill the payload")?;
+        assert_eq!(block.hash(), theirs.block_hash());
+
+        Ok(())
+    }
+
     /// A query node whose database is wiped has to rebuild itself from its peer
     /// and rejoin consensus.
     ///

--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -215,6 +215,11 @@ where
             }
         }
 
+        let catchup_responders = coordinator_network
+            .sender()
+            .is_observer()
+            .then(|| coordinator_network.sender().static_peer_keys());
+
         // Restore the persisted lock so the new protocol resumes with the lock
         // it actually held, not the older decided-anchor QC.
         let locked_qc = persistence
@@ -291,6 +296,7 @@ where
                 memberships: membership_coordinator,
                 consensus_handle: consensus_handle.clone(),
                 public_key: validator_config.public_key,
+                static_responders: catchup_responders,
             },
             DataSource {
                 node_state: instance_state.clone(),

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -156,6 +156,8 @@ pub struct NetworkParams {
     pub cliquenet_bind_addr: NetAddr,
     /// Cliquenet address to advertise to other nodes (registered in the stake table).
     pub cliquenet_advertise_addr: Option<NetAddr>,
+    /// Config-pinned cliquenet peers.
+    pub cliquenet_peer_policy: PeerPolicy<PubKey>,
     /// X25519 secret key.
     pub x25519_secret_key: x25519::SecretKey,
     /// The address to send to other Libp2p nodes to contact us. Required for orchestrator
@@ -848,6 +850,7 @@ where
         let metrics = clone_box(&*metrics);
         let secret_key = network_params.x25519_secret_key.into();
         let bind_addr = network_params.cliquenet_bind_addr.clone();
+        let peer_policy = network_params.cliquenet_peer_policy.clone();
         let name = format!("espresso-{}", genesis.chain_config.chain_id);
         move |upgrade| Cliquenet::create(
             name,
@@ -855,7 +858,7 @@ where
             secret_key,
             bind_addr,
             [],
-            PeerPolicy::default(),
+            peer_policy,
             upgrade,
             metrics,
         )

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -852,16 +852,18 @@ where
         let bind_addr = network_params.cliquenet_bind_addr.clone();
         let peer_policy = network_params.cliquenet_peer_policy.clone();
         let name = format!("espresso-{}", genesis.chain_config.chain_id);
-        move |upgrade| Cliquenet::create(
-            name,
-            pub_key,
-            secret_key,
-            bind_addr,
-            [],
-            peer_policy,
-            upgrade,
-            metrics,
-        )
+        move |upgrade| {
+            Cliquenet::create(
+                name,
+                pub_key,
+                secret_key,
+                bind_addr,
+                [],
+                peer_policy,
+                upgrade,
+                metrics,
+            )
+        }
     };
 
     let network = Arc::new(combined_network);
@@ -1165,6 +1167,52 @@ pub mod testing {
         upgrades: BTreeMap<Version, Upgrade>,
         coordinator_addrs: Vec<NetAddr>,
         contracts: Option<Contracts>,
+        observer: Option<ObserverConfig>,
+    }
+
+    /// A non-staked node fed by the validators at `upstreams`.
+    #[derive(Clone)]
+    pub struct ObserverConfig {
+        priv_key: BLSPrivKey,
+        state_key_pair: StateKeyPair,
+        addr: NetAddr,
+        upstreams: Vec<usize>,
+    }
+
+    impl ObserverConfig {
+        pub fn public_key(&self) -> PubKey {
+            PubKey::from_private(&self.priv_key)
+        }
+
+        pub fn x25519_keypair(&self) -> x25519::Keypair {
+            x25519::Keypair::derive_from::<PubKey>(&self.priv_key)
+                .expect("x25519 keypair derivation should succeed")
+        }
+
+        pub fn addr(&self) -> &NetAddr {
+            &self.addr
+        }
+
+        pub fn peer(&self) -> (PubKey, PeerConnectInfo) {
+            (
+                self.public_key(),
+                PeerConnectInfo {
+                    x25519_key: self.x25519_keypair().public_key(),
+                    p2p_addr: self.addr.clone(),
+                },
+            )
+        }
+    }
+
+    struct NodeIdentity {
+        node_id: u64,
+        public_key: PubKey,
+        private_key: BLSPrivKey,
+        state_key_pair: StateKeyPair,
+        stake_value: U256,
+        is_da: bool,
+        coordinator_addr: NetAddr,
+        peer_policy: PeerPolicy<PubKey>,
     }
 
     /// Picks the key sets at `indices` out of the full deterministic sequence,
@@ -1418,6 +1466,22 @@ pub mod testing {
             self
         }
 
+        /// Add a non-staked observer fed by the validators at `upstreams`;
+        /// start it with [`TestConfig::init_observer_node`].
+        pub fn observer(mut self, upstreams: &[usize]) -> Self {
+            let index = NUM_NODES as u64;
+            let (_, priv_key) =
+                <PubKey as SignatureKey>::generated_from_seed_indexed([0; 32], index);
+            let port = reserve_tcp_port().expect("OS should have ephemeral ports available");
+            self.observer = Some(ObserverConfig {
+                priv_key,
+                state_key_pair: StateKeyPair::generate_from_seed_indexed([0; 32], index),
+                addr: NetAddr::Inet(Ipv4Addr::LOCALHOST.into(), port),
+                upstreams: upstreams.to_vec(),
+            });
+            self
+        }
+
         pub fn build(self) -> TestConfig<NUM_NODES> {
             TestConfig {
                 config: self.config,
@@ -1433,6 +1497,7 @@ pub mod testing {
                 anvil_provider: self.anvil_provider,
                 coordinator_addrs: self.coordinator_addrs,
                 contracts: self.contracts,
+                observer: self.observer,
             }
         }
 
@@ -1551,6 +1616,7 @@ pub mod testing {
                 upgrades: Default::default(),
                 coordinator_addrs,
                 contracts: None,
+                observer: None,
             }
         }
     }
@@ -1572,9 +1638,14 @@ pub mod testing {
         coordinator_addrs: Vec<NetAddr>,
         /// Contracts deployed by [`TestConfigBuilder::set_upgrades_with`], if any.
         contracts: Option<Contracts>,
+        observer: Option<ObserverConfig>,
     }
 
     impl<const NUM_NODES: usize> TestConfig<NUM_NODES> {
+        pub fn observer(&self) -> Option<&ObserverConfig> {
+            self.observer.as_ref()
+        }
+
         pub fn num_nodes(&self) -> usize {
             self.priv_keys.len()
         }
@@ -1680,6 +1751,110 @@ pub mod testing {
         pub async fn init_node<P: PersistenceOptions>(
             &self,
             i: usize,
+            state: ValidatedState,
+            persistence_opt: P,
+            state_peers: Option<impl StateCatchup + 'static>,
+            storage: Option<RequestResponseStorage>,
+            metrics: &dyn Metrics,
+            stake_table_capacity: usize,
+            event_consumer: impl EventConsumer + 'static,
+            upgrade: versions::Upgrade,
+            upgrades: BTreeMap<Version, Upgrade>,
+        ) -> SequencerContext<network::Memory, P::Persistence> {
+            let my_peer_config = &self.config.known_nodes_with_stake[i];
+            let identity = NodeIdentity {
+                node_id: i as u64,
+                public_key: my_peer_config.stake_table_entry.stake_key,
+                private_key: self.priv_keys[i].clone(),
+                state_key_pair: self.state_key_pairs[i].clone(),
+                stake_value: my_peer_config.stake_table_entry.stake_amount,
+                is_da: self.config.known_da_nodes.contains(my_peer_config),
+                coordinator_addr: self.coordinator_addrs[i].clone(),
+                peer_policy: PeerPolicy::StakeTable {
+                    observers: self
+                        .observer
+                        .iter()
+                        .filter(|observer| observer.upstreams.contains(&i))
+                        .map(ObserverConfig::peer)
+                        .collect(),
+                },
+            };
+            self.init_node_with(
+                identity,
+                state,
+                persistence_opt,
+                state_peers,
+                storage,
+                metrics,
+                stake_table_capacity,
+                event_consumer,
+                upgrade,
+                upgrades,
+            )
+            .await
+        }
+
+        /// Start the observer added with [`TestConfigBuilder::observer`].
+        #[allow(clippy::too_many_arguments)]
+        pub async fn init_observer_node<P: PersistenceOptions>(
+            &self,
+            state: ValidatedState,
+            persistence_opt: P,
+            state_peers: Option<impl StateCatchup + 'static>,
+            storage: Option<RequestResponseStorage>,
+            metrics: &dyn Metrics,
+            stake_table_capacity: usize,
+            event_consumer: impl EventConsumer + 'static,
+            upgrade: versions::Upgrade,
+            upgrades: BTreeMap<Version, Upgrade>,
+        ) -> SequencerContext<network::Memory, P::Persistence> {
+            let observer = self
+                .observer
+                .as_ref()
+                .expect("no observer configured; use TestConfigBuilder::observer");
+            let upstreams = observer
+                .upstreams
+                .iter()
+                .map(|&j| {
+                    let peer = &self.config.known_nodes_with_stake[j];
+                    (
+                        peer.stake_table_entry.stake_key,
+                        peer.connect_info
+                            .clone()
+                            .expect("validators have cliquenet connect info"),
+                    )
+                })
+                .collect();
+            let identity = NodeIdentity {
+                node_id: self.num_nodes() as u64,
+                public_key: observer.public_key(),
+                private_key: observer.priv_key.clone(),
+                state_key_pair: observer.state_key_pair.clone(),
+                // Nominal, as on a production non-staked node.
+                stake_value: U256::ONE,
+                is_da: false,
+                coordinator_addr: observer.addr.clone(),
+                peer_policy: PeerPolicy::StaticOnly { upstreams },
+            };
+            self.init_node_with(
+                identity,
+                state,
+                persistence_opt,
+                state_peers,
+                storage,
+                metrics,
+                stake_table_capacity,
+                event_consumer,
+                upgrade,
+                upgrades,
+            )
+            .await
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn init_node_with<P: PersistenceOptions>(
+            &self,
+            identity: NodeIdentity,
             mut state: ValidatedState,
             mut persistence_opt: P,
             state_peers: Option<impl StateCatchup + 'static>,
@@ -1691,38 +1866,35 @@ pub mod testing {
             upgrades: BTreeMap<Version, Upgrade>,
         ) -> SequencerContext<network::Memory, P::Persistence> {
             let config = self.config.clone();
-            let my_peer_config = &config.known_nodes_with_stake[i];
-            let is_da = config.known_da_nodes.contains(my_peer_config);
 
             // The new-protocol (cliquenet) coordinator network identifies this
             // node by an x25519 key derived from its BLS key, reachable at its
             // pre-assigned coordinator address. These must match what is
             // registered on-chain for this validator (see `staking_priv_keys`),
             // so peers can resolve and dial each other from the stake table.
-            let x25519_keypair = x25519::Keypair::derive_from::<PubKey>(&self.priv_keys[i])
+            let x25519_keypair = x25519::Keypair::derive_from::<PubKey>(&identity.private_key)
                 .expect("x25519 keypair derivation should succeed");
-            let coordinator_addr = self.coordinator_addrs[i].clone();
 
             // Create our own (private, local) validator config
             let validator_config = ValidatorConfig {
-                public_key: my_peer_config.stake_table_entry.stake_key,
-                private_key: self.priv_keys[i].clone(),
-                stake_value: my_peer_config.stake_table_entry.stake_amount,
-                state_public_key: self.state_key_pairs[i].ver_key(),
-                state_private_key: self.state_key_pairs[i].sign_key(),
-                is_da,
+                public_key: identity.public_key,
+                private_key: identity.private_key.clone(),
+                stake_value: identity.stake_value,
+                state_public_key: identity.state_key_pair.ver_key(),
+                state_private_key: identity.state_key_pair.sign_key(),
+                is_da: identity.is_da,
                 x25519_keypair: Some(x25519_keypair.clone()),
-                p2p_addr: Some(coordinator_addr.clone()),
+                p2p_addr: Some(identity.coordinator_addr.clone()),
             };
 
-            let topics = if is_da {
+            let topics = if identity.is_da {
                 vec![Topic::Global, Topic::Da]
             } else {
                 vec![Topic::Global]
             };
 
             let network = Arc::new(MemoryNetwork::new(
-                &my_peer_config.stake_table_entry.stake_key,
+                &identity.public_key,
                 &self.master_map,
                 &topics,
                 None,
@@ -1796,7 +1968,7 @@ pub mod testing {
             );
 
             let node_state = NodeState::new(
-                i as u64,
+                identity.node_id,
                 chain_config,
                 l1_client,
                 Arc::new(catchup_providers.clone()),
@@ -1811,14 +1983,16 @@ pub mod testing {
             .with_epoch_start_block(config.epoch_start_block);
 
             tracing::info!(
-                i,
-                key = %my_peer_config.stake_table_entry.stake_key,
-                state_key = %my_peer_config.state_ver_key,
+                node_id = identity.node_id,
+                key = %identity.public_key,
+                state_key = %identity.state_key_pair.ver_key(),
                 "starting node",
             );
 
             let coordinator_network = {
-                let pub_key = my_peer_config.stake_table_entry.stake_key;
+                let pub_key = identity.public_key;
+                let coordinator_addr = identity.coordinator_addr;
+                let peer_policy = identity.peer_policy;
                 move |upgrade| {
                     Cliquenet::create(
                         "test-coordinator",
@@ -1826,7 +2000,7 @@ pub mod testing {
                         x25519_keypair,
                         coordinator_addr,
                         [],
-                        PeerPolicy::default(),
+                        peer_policy,
                         upgrade,
                         Box::new(NoMetrics),
                     )

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -66,7 +66,7 @@ use hotshot::{
     types::SignatureKey,
 };
 use hotshot_libp2p_networking::network::behaviours::dht::store::persistent::DhtPersistentStorage;
-use hotshot_new_protocol::network::Cliquenet;
+use hotshot_new_protocol::network::{Cliquenet, PeerPolicy};
 use hotshot_orchestrator::client::{OrchestratorClient, get_complete_config};
 use hotshot_types::{
     ValidatorConfig,
@@ -849,7 +849,16 @@ where
         let secret_key = network_params.x25519_secret_key.into();
         let bind_addr = network_params.cliquenet_bind_addr.clone();
         let name = format!("espresso-{}", genesis.chain_config.chain_id);
-        move |upgrade| Cliquenet::create(name, pub_key, secret_key, bind_addr, [], upgrade, metrics)
+        move |upgrade| Cliquenet::create(
+            name,
+            pub_key,
+            secret_key,
+            bind_addr,
+            [],
+            PeerPolicy::default(),
+            upgrade,
+            metrics,
+        )
     };
 
     let network = Arc::new(combined_network);
@@ -1814,6 +1823,7 @@ pub mod testing {
                         x25519_keypair,
                         coordinator_addr,
                         [],
+                        PeerPolicy::default(),
                         upgrade,
                         Box::new(NoMetrics),
                     )

--- a/crates/espresso/node/src/options.rs
+++ b/crates/espresso/node/src/options.rs
@@ -13,9 +13,10 @@ use std::{
 use clap::{Args, FromArgMatches, Parser, error::ErrorKind};
 use derivative::Derivative;
 use espresso_telemetry::TelemetryOptions;
-use espresso_types::{BackoffParams, L1ClientOptions, parse_duration};
+use espresso_types::{BackoffParams, L1ClientOptions, PubKey, parse_duration};
 use espresso_utils::logging;
-use hotshot_types::addr::NetAddr;
+use hotshot_new_protocol::network::PeerPolicy;
+use hotshot_types::{PeerConnectInfo, addr::NetAddr, x25519};
 use libp2p::Multiaddr;
 use light_client::{state::LightClientOptions, storage::LightClientSqliteOptions};
 use serde::Serialize;
@@ -86,6 +87,38 @@ pub struct Options {
     /// must be registered in the stake table contract instead.
     #[clap(long, env = "ESPRESSO_NODE_CLIQUENET_ADVERTISE_ADDRESS")]
     pub cliquenet_advertise_address: Option<NetAddr>,
+
+    /// Non-staked observer nodes this validator feeds over cliquenet.
+    ///
+    /// Comma-separated list of `BLS_VER_KEY~…@X25519_PK~…@host:port`. Each observer becomes a
+    /// config-pinned peer that receives no consensus broadcasts, only the proposals,
+    /// certificates and epoch changes this node validates or forms, so it can decide blocks
+    /// without stake. The observer must list this node in `--cliquenet-upstream-peers`.
+    ///
+    /// Observers can send anything a peer can, so only list nodes operated together with this
+    /// one. Give an observer a hostname or its exact source IP: cliquenet rejects connections
+    /// from an IP other than the configured one.
+    #[clap(
+        long,
+        env = "ESPRESSO_NODE_CLIQUENET_OBSERVER_PEERS",
+        value_delimiter = ','
+    )]
+    pub cliquenet_observer_peers: Vec<CliquenetPeer>,
+
+    /// Run as a non-staked observer fed by these validators over cliquenet.
+    ///
+    /// Same format as `--cliquenet-observer-peers`. This node never dials the stake table; it
+    /// peers only with the listed validators, which must list it in
+    /// `--cliquenet-observer-peers`. Payloads and VID common still come from `--peers` over
+    /// HTTP. Incompatible with the `submit` module: an observer has no leader to forward
+    /// transactions to.
+    #[clap(
+        long,
+        env = "ESPRESSO_NODE_CLIQUENET_UPSTREAM_PEERS",
+        value_delimiter = ',',
+        conflicts_with = "cliquenet_observer_peers"
+    )]
+    pub cliquenet_upstream_peers: Vec<CliquenetPeer>,
 
     /// The address to bind to for Libp2p (in `host:port` form)
     #[clap(
@@ -369,6 +402,88 @@ pub struct Options {
 impl Options {
     pub fn modules(&self) -> Modules {
         ModuleArgs(self.modules.clone()).parse()
+    }
+
+    /// The cliquenet peers this node pins, from the observer and upstream options.
+    pub fn cliquenet_peer_policy(&self) -> PeerPolicy<PubKey> {
+        let peers = |peers: &[CliquenetPeer]| {
+            peers
+                .iter()
+                .map(|peer| (peer.key, peer.info.clone()))
+                .collect()
+        };
+        if self.cliquenet_upstream_peers.is_empty() {
+            PeerPolicy::StakeTable {
+                observers: peers(&self.cliquenet_observer_peers),
+            }
+        } else {
+            PeerPolicy::StaticOnly {
+                upstreams: peers(&self.cliquenet_upstream_peers),
+            }
+        }
+    }
+
+    /// Reject module combinations that cannot work with these options.
+    pub fn validate_modules(&self, modules: &Modules) -> anyhow::Result<()> {
+        if modules.submit.is_some() && !self.cliquenet_upstream_peers.is_empty() {
+            anyhow::bail!(
+                "the submit module cannot run on an observer node (--cliquenet-upstream-peers): \
+                 an observer has no leader to forward transactions to"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// A config-pinned cliquenet peer, written `BLS_VER_KEY~…@X25519_PK~…@host:port`.
+///
+/// `@` cannot occur in tagged base64 or in a host name, so the three parts are unambiguous.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CliquenetPeer {
+    pub key: PubKey,
+    pub info: PeerConnectInfo,
+}
+
+impl std::str::FromStr for CliquenetPeer {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.splitn(3, '@');
+        let (Some(key), Some(x25519_key), Some(addr)) = (parts.next(), parts.next(), parts.next())
+        else {
+            return Err(format!(
+                "expected BLS_VER_KEY~…@X25519_PK~…@host:port, got {s:?}"
+            ));
+        };
+        let key = key
+            .parse::<PubKey>()
+            .map_err(|err| format!("invalid BLS key {key:?}: {err}"))?;
+        let x25519_key = x25519_key
+            .parse::<x25519::PublicKey>()
+            .map_err(|err| format!("invalid x25519 key {x25519_key:?}: {err}"))?;
+        let p2p_addr = addr
+            .parse::<NetAddr>()
+            .map_err(|err| format!("invalid address {addr:?} (expected host:port): {err}"))?;
+        if p2p_addr.port() == 0 {
+            return Err(format!("address {addr:?} needs a non-zero port"));
+        }
+        Ok(Self {
+            key,
+            info: PeerConnectInfo {
+                x25519_key,
+                p2p_addr,
+            },
+        })
+    }
+}
+
+impl Display for CliquenetPeer {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}@{}@{}",
+            self.key, self.info.x25519_key, self.info.p2p_addr
+        )
     }
 }
 
@@ -1184,6 +1299,99 @@ mod tests {
                 committee: vec![peer],
             }]),
         }
+    }
+
+    fn cliquenet_peer(index: u64, addr: &str) -> CliquenetPeer {
+        let (key, _) = PubKey::generated_from_seed_indexed([0; 32], index);
+        let x25519_key = x25519::Keypair::generated_from_seed_indexed([0; 32], index)
+            .expect("valid seed")
+            .public_key();
+        CliquenetPeer {
+            key,
+            info: PeerConnectInfo {
+                x25519_key,
+                p2p_addr: addr.parse().expect("valid address"),
+            },
+        }
+    }
+
+    #[test]
+    fn cliquenet_peer_round_trips_through_display() {
+        for addr in ["127.0.0.1:9977", "observer.example.com:9977", "[::1]:9977"] {
+            let peer = cliquenet_peer(1, addr);
+            let parsed: CliquenetPeer = peer.to_string().parse().expect(addr);
+            assert_eq!(parsed, peer, "{addr}");
+        }
+    }
+
+    #[test]
+    fn cliquenet_peer_rejects_malformed_input() {
+        let peer = cliquenet_peer(1, "127.0.0.1:9977");
+        let key = peer.key.to_string();
+        let x25519_key = peer.info.x25519_key.to_string();
+        for bad in [
+            format!("{key}@{x25519_key}"),
+            format!("{x25519_key}@{key}@127.0.0.1:9977"),
+            format!("{key}@{x25519_key}@127.0.0.1"),
+            format!("{key}@{x25519_key}@127.0.0.1:0"),
+            format!("BLS_VER_KEY~nope@{x25519_key}@127.0.0.1:9977"),
+        ] {
+            assert!(bad.parse::<CliquenetPeer>().is_err(), "accepted {bad:?}");
+        }
+    }
+
+    #[test]
+    fn cliquenet_peer_options_select_policy() {
+        let a = cliquenet_peer(1, "127.0.0.1:9001").to_string();
+        let b = cliquenet_peer(2, "127.0.0.1:9002").to_string();
+        let with_submit = Modules {
+            submit: Some(api::options::Submit),
+            ..Default::default()
+        };
+
+        let opt = parse_options_with(&[]);
+        assert!(matches!(
+            opt.cliquenet_peer_policy(),
+            PeerPolicy::StakeTable { observers } if observers.is_empty()
+        ));
+        opt.validate_modules(&with_submit)
+            .expect("validators may run submit");
+
+        let opt = parse_options_with(&["--cliquenet-observer-peers", &format!("{a},{b}")]);
+        assert_eq!(opt.cliquenet_observer_peers.len(), 2);
+        assert!(matches!(
+            opt.cliquenet_peer_policy(),
+            PeerPolicy::StakeTable { observers } if observers.len() == 2
+        ));
+        opt.validate_modules(&with_submit)
+            .expect("forwarders may run submit");
+
+        let opt = parse_options_with(&["--cliquenet-upstream-peers", &a]);
+        assert!(matches!(
+            opt.cliquenet_peer_policy(),
+            PeerPolicy::StaticOnly { upstreams } if upstreams.len() == 1
+        ));
+        opt.validate_modules(&Modules::default())
+            .expect("observers may run without submit");
+        assert!(
+            opt.validate_modules(&with_submit).is_err(),
+            "observers must not run submit"
+        );
+    }
+
+    #[test]
+    fn cliquenet_observer_and_upstream_peers_conflict() {
+        let a = cliquenet_peer(1, "127.0.0.1:9001").to_string();
+        let b = cliquenet_peer(2, "127.0.0.1:9002").to_string();
+        let err = Options::try_parse_from([
+            "sequencer",
+            "--cliquenet-observer-peers",
+            &a,
+            "--cliquenet-upstream-peers",
+            &b,
+        ])
+        .expect_err("a node cannot be both forwarder and observer");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/espresso/node/src/request_response/recipient_source.rs
+++ b/crates/espresso/node/src/request_response/recipient_source.rs
@@ -20,6 +20,8 @@ pub struct RecipientSource<I: NodeImplementation<SeqTypes>> {
     pub memberships: EpochMembershipCoordinator<SeqTypes>,
     /// The public key of the node
     pub public_key: PubKey,
+    /// Replaces the stake table as the responder set; set on observer nodes.
+    pub static_responders: Option<Vec<PubKey>>,
 }
 
 /// Implement the RecipientSourceTrait, which allows the request-response protocol to derive the
@@ -30,6 +32,10 @@ where
     I::Storage: NewProtocolStorage<SeqTypes>,
 {
     async fn get_expected_responders(&self, _request: &Request) -> Result<Vec<PubKey>> {
+        if let Some(responders) = &self.static_responders {
+            return Ok(responders.clone());
+        }
+
         // Get the current epoch number
         let epoch_number = self
             .consensus_handle

--- a/crates/espresso/node/src/run.rs
+++ b/crates/espresso/node/src/run.rs
@@ -158,6 +158,8 @@ pub async fn init_with_storage<S>(
 where
     S: DataSourceOptions,
 {
+    opt.validate_modules(&modules)?;
+    let cliquenet_peer_policy = opt.cliquenet_peer_policy();
     let KeySet {
         staking,
         state,
@@ -172,6 +174,7 @@ where
         cdn_endpoint: opt.cdn_endpoint,
         cliquenet_bind_addr: opt.cliquenet_bind_address,
         cliquenet_advertise_addr: opt.cliquenet_advertise_address,
+        cliquenet_peer_policy,
         x25519_secret_key: x25519,
         libp2p_advertise_address: opt.libp2p_advertise_address,
         libp2p_bind_address: opt.libp2p_bind_address,

--- a/crates/hotshot/new-protocol/bench/src/node.rs
+++ b/crates/hotshot/new-protocol/bench/src/node.rs
@@ -16,7 +16,7 @@ use hotshot_new_protocol::{
     coordinator::{Coordinator, timer::Timer},
     epoch::EpochManager,
     helpers::proposal_commitment,
-    network::Cliquenet,
+    network::{Cliquenet, PeerPolicy},
     outbox::Outbox,
     proposal::{ProposalValidator, VidShareValidator},
     state::StateManager,
@@ -91,6 +91,7 @@ async fn create_network(
         keypair,
         bind_addr,
         parties,
+        PeerPolicy::default(),
         upgrade_lock(),
         Box::new(NoMetrics),
     )

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -823,11 +823,8 @@ where
                         ProposalMessage::validated(proposal.clone()),
                     )),
                 };
-                if let Err(err) = self
-                    .network
-                    .sender()
-                    .broadcast(self.consensus.current_view(), &message)
-                {
+                let current_view = self.consensus.current_view();
+                if let Err(err) = self.network.sender().broadcast(current_view, &message) {
                     let err = CoordinatorError::from(err).context("proposal broadcast");
                     if err.severity == Severity::Critical {
                         return Err(err);
@@ -835,6 +832,7 @@ where
                         warn!(%node, %err, "network error while broadcasting proposal")
                     }
                 }
+                self.forward_to_observers(current_view, message)?;
             },
             ConsensusOutput::SendTimeoutVote(vote, evidence) => {
                 let view = vote.view_number();
@@ -947,6 +945,13 @@ where
                     sender = %KeyPrefix::from(&sender),
                     "proposal validated"
                 );
+                let message = Message {
+                    sender: self.public_key.clone(),
+                    message_type: MessageType::Consensus(ConsensusMessage::Proposal(
+                        ProposalMessage::validated(proposal),
+                    )),
+                };
+                self.forward_to_observers(self.consensus.current_view(), message)?;
             },
             ConsensusOutput::ViewChanged(view, epoch) => {
                 let current_view = self.consensus.current_view();
@@ -1459,10 +1464,44 @@ where
             sender: self.public_key.clone(),
             message_type: MessageType::Consensus(message_type),
         };
+        let view = self.consensus.current_view();
         self.network
             .sender()
-            .broadcast(self.consensus.current_view(), &message)
-            .map_err(|e| CoordinatorError::from(e).context(ctx))
+            .broadcast(view, &message)
+            .map_err(|e| CoordinatorError::from(e).context(ctx))?;
+        self.forward_to_observers(view, message)
+    }
+
+    /// Forward to observer peers, which get no broadcasts. Cert1 goes out as
+    /// `HighQc`: the only certificate intake that advances an observer's view
+    /// and is not dropped for being more than `MAX_VIEWS_AHEAD` ahead.
+    ///
+    /// As with the proposal broadcast, only critical network errors are returned.
+    fn forward_to_observers(
+        &self,
+        view: ViewNumber,
+        message: Message<T, Validated>,
+    ) -> Result<(), CoordinatorError> {
+        let forwarded = match message.message_type {
+            MessageType::Consensus(ConsensusMessage::Certificate1(cert1, _)) => Message {
+                sender: message.sender,
+                message_type: MessageType::Consensus(ConsensusMessage::HighQc(cert1)),
+            },
+            MessageType::Consensus(
+                ConsensusMessage::Proposal(_)
+                | ConsensusMessage::Certificate2(..)
+                | ConsensusMessage::EpochChange(_),
+            ) => message,
+            _ => return Ok(()),
+        };
+        if let Err(err) = self.network.sender().send_to_observers(view, &forwarded) {
+            let err = CoordinatorError::from(err).context("forward to observers");
+            if err.severity == Severity::Critical {
+                return Err(err);
+            }
+            warn!(node = %self.node_id, %err, "network error while forwarding to observers");
+        }
+        Ok(())
     }
 
     fn unicast_to_leader(

--- a/crates/hotshot/new-protocol/src/network.rs
+++ b/crates/hotshot/new-protocol/src/network.rs
@@ -18,7 +18,7 @@ use hotshot_types::{
 };
 use hotshot_utils::anytrace;
 use parking_lot::RwLock;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::message::{Message, MessageType, Unchecked, Validated};
 
@@ -39,16 +39,57 @@ pub struct Sender<T: NodeType> {
 #[derive(Debug)]
 struct Shared<K> {
     peers: HashMap<K, PeerConnectInfo>,
+    static_peers: HashMap<K, Role>,
+    follows_stake_table: bool,
     epoch: EpochNumber,
 }
 
+/// How a node's cliquenet peer set is populated. Peers listed here are
+/// config-pinned: they survive stake-table changes and their role is fixed.
+#[derive(Debug, Clone)]
+pub enum PeerPolicy<K> {
+    /// Follow the stake table. `observers` are `Role::Passive` peers that get
+    /// only what [`Sender::send_to_observers`] and unicasts send them.
+    StakeTable {
+        observers: Vec<(K, PeerConnectInfo)>,
+    },
+    /// Never dial the stake table. `upstreams` are `Role::Active` peers, so
+    /// this node's own broadcasts reach them.
+    StaticOnly {
+        upstreams: Vec<(K, PeerConnectInfo)>,
+    },
+}
+
+impl<K> Default for PeerPolicy<K> {
+    fn default() -> Self {
+        Self::StakeTable {
+            observers: Vec::new(),
+        }
+    }
+}
+
+impl<K> PeerPolicy<K> {
+    fn follows_stake_table(&self) -> bool {
+        matches!(self, Self::StakeTable { .. })
+    }
+
+    fn static_peers(&self) -> (Role, &[(K, PeerConnectInfo)]) {
+        match self {
+            Self::StakeTable { observers } => (Role::Passive, observers),
+            Self::StaticOnly { upstreams } => (Role::Active, upstreams),
+        }
+    }
+}
+
 impl<T: NodeType> Cliquenet<T> {
+    #[allow(clippy::too_many_arguments)]
     pub async fn create<A, P, S>(
         name: S,
         signing_key: T::SignatureKey,
         keypair: Keypair,
         addr: A,
         parties: P,
+        policy: PeerPolicy<T::SignatureKey>,
         upgrade_lock: UpgradeLock<T>,
         metrics: Box<dyn Metrics>,
     ) -> Result<Self, NetworkError>
@@ -59,6 +100,8 @@ impl<T: NodeType> Cliquenet<T> {
     {
         let parties: HashMap<T::SignatureKey, PeerConnectInfo> = parties.into_iter().collect();
 
+        // Listed as parties so their inbound handshakes are accepted at once.
+        let (_, static_peers) = policy.static_peers();
         let cfg = cliquenet::Config::builder()
             .name(name)
             .keypair(keypair.into())
@@ -66,12 +109,13 @@ impl<T: NodeType> Cliquenet<T> {
             .parties(
                 parties
                     .values()
+                    .chain(static_peers.iter().map(|(_, info)| info))
                     .map(|info| (info.x25519_key.into(), info.p2p_addr.clone())),
             )
             .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build();
 
-        Self::create_with_config(signing_key, upgrade_lock, cfg, parties, metrics).await
+        Self::create_with_config(signing_key, upgrade_lock, cfg, parties, policy, metrics).await
     }
 
     pub(crate) async fn create_with_config<P>(
@@ -79,19 +123,39 @@ impl<T: NodeType> Cliquenet<T> {
         upgrade_lock: UpgradeLock<T>,
         config: cliquenet::Config,
         parties: P,
+        policy: PeerPolicy<T::SignatureKey>,
         metrics: Box<dyn Metrics>,
     ) -> Result<Self, NetworkError>
     where
         P: IntoIterator<Item = (T::SignatureKey, PeerConnectInfo)>,
     {
         let public_key = config.public_key();
+        let mut peers: HashMap<_, _> = parties.into_iter().collect();
+        let (role, static_peers) =
+            validate_static_peers(&policy, &signing_key, public_key, &peers)?;
+        peers.extend(static_peers.iter().cloned());
+
         let metrics = CliquenetMetrics::new(metrics);
         let network = cliquenet::Network::create(config.with_metrics(metrics)).await?;
-        let peers: HashMap<_, _> = parties.into_iter().collect();
 
-        info!(peers = %peers.len(), "cliquenet created");
+        info!(
+            peers = %peers.len(),
+            static_peers = %static_peers.len(),
+            %role,
+            follows_stake_table = %policy.follows_stake_table(),
+            "cliquenet created"
+        );
 
         let (send, recv) = network.split_into();
+
+        // Config parties start `Role::Active`; this assigns the static role.
+        let static_targets: Vec<(PublicKey, NetAddr)> = static_peers
+            .iter()
+            .map(|(_, info)| (info.x25519_key.into(), info.p2p_addr.clone()))
+            .collect();
+        if !static_targets.is_empty() {
+            send.add_peers(role, static_targets)?;
+        }
 
         Ok(Self {
             inner: Sender {
@@ -99,6 +163,8 @@ impl<T: NodeType> Cliquenet<T> {
                 sender: send,
                 shared: Arc::new(RwLock::new(Shared {
                     peers,
+                    static_peers: static_peers.into_iter().map(|(k, _)| (k, role)).collect(),
+                    follows_stake_table: policy.follows_stake_table(),
                     epoch: EpochNumber::new(0),
                 })),
                 upgrade_lock,
@@ -176,6 +242,10 @@ impl<T: NodeType> Cliquenet<T> {
         {
             let mut shared = self.inner.shared.write();
             for k in ps {
+                if shared.static_peers.contains_key(k) {
+                    warn!(peer = %k, "not removing static peer");
+                    continue;
+                }
                 if let Some(info) = shared.peers.remove(k) {
                     targets.push(info.x25519_key.into())
                 }
@@ -206,6 +276,8 @@ impl<T: NodeType> Cliquenet<T> {
     ///
     /// We keep validators that were in `e-1` but not in `e` for one additional
     /// epoch and eagerly connect to new validators of `e+1`.
+    ///
+    /// Config-pinned peers are left untouched.
     pub fn apply_epoch(
         &mut self,
         epoch: EpochNumber,
@@ -214,6 +286,12 @@ impl<T: NodeType> Cliquenet<T> {
         let ours = self.inner.shared.read().epoch;
         if epoch <= ours {
             info!(%epoch, %ours, "epoch already seen");
+            return Ok(());
+        }
+
+        if !self.inner.shared.read().follows_stake_table {
+            info!(%epoch, "static peers only; not dialing the stake table");
+            self.inner.shared.write().epoch = epoch;
             return Ok(());
         }
 
@@ -261,24 +339,34 @@ impl<T: NodeType> Cliquenet<T> {
         let mut to_add: Vec<(T::SignatureKey, PeerConnectInfo)> = Vec::new();
         let mut to_del: Vec<(T::SignatureKey, PeerConnectInfo)> = Vec::new();
 
-        for k in &wanted {
-            if let Some(Some(new_info)) = merged_infos.get(k) {
-                if Some(new_info) != self.inner.shared.read().peers.get(k) {
-                    info!(%epoch, peer = %k, "adding/updating network peer");
-                    to_add.push((k.clone(), new_info.clone()));
-                } else {
-                    info!(%epoch, peer = %k, "peer unchanged");
+        {
+            let shared = self.inner.shared.read();
+            for k in &wanted {
+                if shared.static_peers.contains_key(k) {
+                    info!(%epoch, peer = %k, "keeping static peer's configured connection info");
+                    continue;
                 }
-            } else {
-                info!(%epoch, peer = %k, "ignoring peer without connection info");
+                if let Some(Some(new_info)) = merged_infos.get(k) {
+                    if Some(new_info) != shared.peers.get(k) {
+                        info!(%epoch, peer = %k, "adding/updating network peer");
+                        to_add.push((k.clone(), new_info.clone()));
+                    } else {
+                        info!(%epoch, peer = %k, "peer unchanged");
+                    }
+                } else {
+                    info!(%epoch, peer = %k, "ignoring peer without connection info");
+                }
             }
-        }
 
-        // Remove peers that have left both the current and previous epochs.
-        for (k, info) in &self.inner.shared.read().peers {
-            if !(retained.contains(k) || wanted.contains(k)) {
-                info!(%epoch, peer = %k, "removing network peer");
-                to_del.push((k.clone(), info.clone()));
+            // Remove peers that have left both the current and previous epochs.
+            for (k, info) in &shared.peers {
+                if shared.static_peers.contains_key(k) {
+                    continue;
+                }
+                if !(retained.contains(k) || wanted.contains(k)) {
+                    info!(%epoch, peer = %k, "removing network peer");
+                    to_del.push((k.clone(), info.clone()));
+                }
             }
         }
 
@@ -400,6 +488,44 @@ impl<T: NodeType> Sender<T> {
         Ok(())
     }
 
+    /// Send to every `Role::Passive` static peer; a no-op when there are none.
+    pub fn send_to_observers(
+        &self,
+        v: ViewNumber,
+        m: &Message<T, Validated>,
+    ) -> Result<(), NetworkError> {
+        let targets: Vec<PublicKey> = {
+            let shared = self.shared.read();
+            shared
+                .static_peers
+                .iter()
+                .filter(|(_, role)| **role == Role::Passive)
+                .filter_map(|(k, _)| shared.peers.get(k))
+                .map(|info| info.x25519_key.into())
+                .collect()
+        };
+        if targets.is_empty() {
+            return Ok(());
+        }
+        let bytes = self.serialize(m)?;
+        self.sender.multicast(Slot::new(*v), targets, bytes)?;
+        Ok(())
+    }
+
+    /// True under [`PeerPolicy::StaticOnly`].
+    pub fn is_observer(&self) -> bool {
+        !self.shared.read().follows_stake_table
+    }
+
+    pub fn static_peer_keys(&self) -> Vec<T::SignatureKey> {
+        self.shared.read().static_peers.keys().cloned().collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn peers(&self) -> HashMap<T::SignatureKey, PeerConnectInfo> {
+        self.shared.read().peers.clone()
+    }
+
     fn serialize(&self, m: &Message<T, Validated>) -> Result<Vec<u8>, NetworkError> {
         if let MessageType::External(bytes) = &m.message_type {
             return Ok(bytes.clone());
@@ -422,6 +548,45 @@ pub enum NetworkError {
         msg: Option<x25519::PublicKey>,
         src: x25519::PublicKey,
     },
+
+    #[error("invalid static peer configuration: {0}")]
+    StaticPeers(String),
+}
+
+/// Reject static peers that are this node (that would change our own role) or
+/// share an x25519 key with another peer (indistinguishable on receive).
+fn validate_static_peers<K: Clone + Eq + std::hash::Hash + std::fmt::Display>(
+    policy: &PeerPolicy<K>,
+    signing_key: &K,
+    public_key: PublicKey,
+    parties: &HashMap<K, PeerConnectInfo>,
+) -> Result<(Role, Vec<(K, PeerConnectInfo)>), NetworkError> {
+    let (role, static_peers) = policy.static_peers();
+    let mut seen_keys: HashSet<&K> = HashSet::new();
+    let mut seen_x25519: HashSet<PublicKey> = parties
+        .iter()
+        .filter(|(k, _)| !static_peers.iter().any(|(s, _)| s == *k))
+        .map(|(_, info)| info.x25519_key.into())
+        .collect();
+    for (k, info) in static_peers {
+        let x: PublicKey = info.x25519_key.into();
+        if k == signing_key || x == public_key {
+            return Err(NetworkError::StaticPeers(format!(
+                "static peer {k} is this node"
+            )));
+        }
+        if !seen_keys.insert(k) {
+            return Err(NetworkError::StaticPeers(format!(
+                "static peer {k} listed more than once"
+            )));
+        }
+        if !seen_x25519.insert(x) {
+            return Err(NetworkError::StaticPeers(format!(
+                "x25519 key {x} of static peer {k} is already used by another peer"
+            )));
+        }
+    }
+    Ok((role, static_peers.to_vec()))
 }
 
 impl NetworkError {

--- a/crates/hotshot/new-protocol/src/tests.rs
+++ b/crates/hotshot/new-protocol/src/tests.rs
@@ -8,6 +8,7 @@ mod epoch_change;
 mod failures;
 mod integration;
 mod legacy_cutover;
+mod network;
 mod restarts;
 mod safety;
 mod stake_table_changes;

--- a/crates/hotshot/new-protocol/src/tests.rs
+++ b/crates/hotshot/new-protocol/src/tests.rs
@@ -9,6 +9,7 @@ mod failures;
 mod integration;
 mod legacy_cutover;
 mod network;
+mod observer;
 mod restarts;
 mod safety;
 mod stake_table_changes;

--- a/crates/hotshot/new-protocol/src/tests/common/harness.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/harness.rs
@@ -20,7 +20,7 @@ use crate::{
     helpers::test_upgrade_lock,
     logging::KeyPrefix,
     message::Message,
-    network::Cliquenet,
+    network::{Cliquenet, PeerPolicy},
     outbox::Outbox,
     proposal::{ProposalValidator, VidShareValidator},
     state::StateManager,
@@ -117,6 +117,7 @@ impl TestHarness {
             keypair,
             addr,
             vec![],
+            PeerPolicy::default(),
             upgrade_lock.clone(),
             Box::new(NoMetrics),
         )

--- a/crates/hotshot/new-protocol/src/tests/common/runner.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/runner.rs
@@ -136,6 +136,12 @@ pub struct TestRunner {
     #[builder(default)]
     node_decision_targets: BTreeMap<usize, usize>,
 
+    /// Observer nodes, keyed by index, with the validators that feed them.
+    /// Observers are kept out of every stake table. Incompatible with
+    /// `down_nodes`.
+    #[builder(default)]
+    observer_nodes: BTreeMap<usize, Vec<usize>>,
+
     /// View-triggered node changes.  Each entry is `(view, changes)`.
     /// Changes are applied when any node first decides a leaf at or past
     /// the specified view.
@@ -305,6 +311,81 @@ impl TestRunner {
         }
     }
 
+    fn upstreams_of(&self, idx: usize) -> Option<&[usize]> {
+        self.observer_nodes.get(&idx).map(Vec::as_slice)
+    }
+
+    fn observers_of(&self, idx: usize) -> Vec<usize> {
+        self.observer_nodes
+            .iter()
+            .filter(|(_, upstreams)| upstreams.contains(&idx))
+            .map(|(observer, _)| *observer)
+            .collect()
+    }
+
+    fn exclude_observers_from_stake_table(&mut self) {
+        if self.observer_nodes.is_empty() {
+            return;
+        }
+        match &self.stake_table_schedule {
+            Some(schedule) => {
+                let committees = std::iter::once(&schedule.initial)
+                    .chain(schedule.changes.iter().map(|(_, committee)| committee));
+                for committee in committees {
+                    for observer in self.observer_nodes.keys() {
+                        assert!(
+                            !committee.contains(observer),
+                            "observer {observer} must not be in any stake table"
+                        );
+                    }
+                }
+            },
+            None => {
+                self.stake_table_schedule = Some(StakeTableSchedule {
+                    initial: (0..self.num_nodes)
+                        .filter(|i| !self.observer_nodes.contains_key(i))
+                        .collect(),
+                    changes: vec![],
+                });
+            },
+        }
+    }
+
+    async fn create_network(
+        &self,
+        i: usize,
+        parties: &[(Keypair, BLSPubKey, NetAddr)],
+    ) -> Cliquenet<TestTypes> {
+        let peer = |j: usize| {
+            let (kp, pk, addr) = &parties[j];
+            (
+                *pk,
+                PeerConnectInfo {
+                    x25519_key: kp.public_key(),
+                    p2p_addr: addr.clone(),
+                },
+            )
+        };
+        let (dynamic, policy) = match self.upstreams_of(i) {
+            Some(upstreams) => (
+                vec![],
+                PeerPolicy::StaticOnly {
+                    upstreams: upstreams.iter().map(|&j| peer(j)).collect(),
+                },
+            ),
+            None => (
+                (0..self.num_nodes)
+                    .filter(|j| self.upstreams_of(*j).is_none())
+                    .map(peer)
+                    .collect(),
+                PeerPolicy::StakeTable {
+                    observers: self.observers_of(i).into_iter().map(peer).collect(),
+                },
+            ),
+        };
+        create_network(i, parties, dynamic, policy, &self.upgrade_lock).await
+    }
+
     pub async fn run(&mut self) -> Result<(), TestError> {
         crate::logging::init_test_logging();
 
@@ -313,6 +394,12 @@ impl TestRunner {
             "stake table schedules are incompatible with down_nodes: failed_views_from_down_nodes \
              assumes the full committee leads"
         );
+        assert!(
+            self.observer_nodes.is_empty() || self.down_nodes.is_empty(),
+            "observer nodes are incompatible with down_nodes: failed_views_from_down_nodes \
+             assumes the full committee leads"
+        );
+        self.exclude_observers_from_stake_table();
 
         self.node_storages = (0..self.num_nodes)
             .map(|_| TestStorage::default())
@@ -355,7 +442,7 @@ impl TestRunner {
                 node_handles.push(None);
                 continue;
             }
-            let network = create_network(i, &parties, &self.upgrade_lock).await;
+            let network = self.create_network(i, &parties).await;
 
             let (membership, storage, client, external_events_tx) =
                 self.make_membership(*public_key, self.node_storages[i].clone(), &connect_infos);
@@ -489,8 +576,7 @@ impl TestRunner {
                                 // Create a fresh coordinator; it resumes
                                 // from the persisted anchor when storage is
                                 // persistent, from genesis otherwise.
-                                let net =
-                                    create_network(change.idx, &parties, &self.upgrade_lock).await;
+                                let net = self.create_network(change.idx, &parties).await;
                                 if !self.persistent_storage {
                                     self.node_storages[change.idx] = TestStorage::default();
                                 }
@@ -664,44 +750,32 @@ impl TestRunner {
 async fn create_network(
     i: usize,
     parties: &[(Keypair, BLSPubKey, NetAddr)],
+    dynamic: Vec<(BLSPubKey, PeerConnectInfo)>,
+    policy: PeerPolicy<BLSPubKey>,
     lock: &UpgradeLock<TestTypes>,
 ) -> Cliquenet<TestTypes> {
-    let peer_infos: Vec<(BLSPubKey, PeerConnectInfo)> = parties
-        .iter()
-        .map(|(kp, pk, addr)| {
-            (
-                *pk,
-                PeerConnectInfo {
-                    x25519_key: kp.public_key(),
-                    p2p_addr: addr.clone(),
-                },
-            )
-        })
-        .collect();
-
+    let static_infos: Vec<&PeerConnectInfo> = match &policy {
+        PeerPolicy::StakeTable { observers } => observers.iter().map(|(_, info)| info).collect(),
+        PeerPolicy::StaticOnly { upstreams } => upstreams.iter().map(|(_, info)| info).collect(),
+    };
     let config = cliquenet::Config::builder()
         .name("test")
         .keypair(parties[i].0.clone().into())
         .bind(parties[i].2.clone())
         .random_connect_delay(false)
         .parties(
-            peer_infos
+            dynamic
                 .iter()
-                .map(|(_, info)| (info.x25519_key.into(), info.p2p_addr.clone())),
+                .map(|(_, info)| info)
+                .chain(static_infos)
+                .map(|info| (info.x25519_key.into(), info.p2p_addr.clone())),
         )
         .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
 
     let met = Box::new(NoMetrics);
 
-    Cliquenet::create_with_config(
-        parties[i].1,
-        lock.clone(),
-        config,
-        peer_infos.clone(),
-        PeerPolicy::default(),
-        met,
-    )
+    Cliquenet::create_with_config(parties[i].1, lock.clone(), config, dynamic, policy, met)
         .await
         .unwrap()
 }

--- a/crates/hotshot/new-protocol/src/tests/common/runner.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/runner.rs
@@ -39,7 +39,7 @@ use crate::{
     consensus::{ConsensusInput, ConsensusOutput, PreCutoverSeed},
     coordinator::{Coordinator, error::Severity},
     helpers::test_upgrade_lock,
-    network::Cliquenet,
+    network::{Cliquenet, PeerPolicy},
     tests::common::{
         coordinator_builder::build_test_coordinator,
         utils::{
@@ -694,7 +694,14 @@ async fn create_network(
 
     let met = Box::new(NoMetrics);
 
-    Cliquenet::create_with_config(parties[i].1, lock.clone(), config, peer_infos.clone(), met)
+    Cliquenet::create_with_config(
+        parties[i].1,
+        lock.clone(),
+        config,
+        peer_infos.clone(),
+        PeerPolicy::default(),
+        met,
+    )
         .await
         .unwrap()
 }

--- a/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
@@ -58,7 +58,7 @@ use crate::{
     coordinator::{Coordinator, error::Severity, timer::Timer},
     cutover::{extract_pre_cutover_seed, forward_legacy_high_qc, forward_legacy_timeout_votes},
     helpers::test_upgrade_lock,
-    network::Cliquenet,
+    network::{Cliquenet, PeerPolicy},
     outbox::Outbox,
     tests::common::{utils::mock_membership_with_client, views},
 };
@@ -215,9 +215,16 @@ async fn build_new_protocol_network(
         .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
     let met = Box::new(NoMetrics);
-    Cliquenet::create_with_config(parties[i].1, lock.clone(), config, peer_infos.clone(), met)
-        .await
-        .expect("cliquenet creation should succeed")
+    Cliquenet::create_with_config(
+        parties[i].1,
+        lock.clone(),
+        config,
+        peer_infos.clone(),
+        PeerPolicy::default(),
+        met,
+    )
+    .await
+    .expect("cliquenet creation should succeed")
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/hotshot/new-protocol/src/tests/network.rs
+++ b/crates/hotshot/new-protocol/src/tests/network.rs
@@ -1,0 +1,304 @@
+//! Config-pinned cliquenet peers ([`PeerPolicy`]).
+
+use std::{net::Ipv4Addr, time::Duration};
+
+use hotshot::types::BLSPubKey;
+use hotshot_example_types::{node_types::TestTypes, storage_types::TestStorage};
+use hotshot_types::{
+    PeerConnectInfo,
+    addr::NetAddr,
+    data::{EpochNumber, ViewNumber},
+    traits::{metrics::NoMetrics, signature_key::SignatureKey},
+    x25519::Keypair,
+};
+use tokio::time::{sleep, timeout};
+
+use crate::{
+    helpers::test_upgrade_lock,
+    message::{BlockMessage, Message, MessageType, TransactionMessage, Unchecked, Validated},
+    network::{Cliquenet, NetworkError, PeerPolicy},
+    tests::common::utils::{StakeTableSchedule, mock_membership_with_client_and_schedule},
+};
+
+const SETTLE: Duration = Duration::from_secs(2);
+const RECV_TIMEOUT: Duration = Duration::from_secs(10);
+const SILENCE: Duration = Duration::from_millis(500);
+
+/// Keys from the mock membership's seed, so index `i` is member `i` there.
+struct Node {
+    public_key: BLSPubKey,
+    keypair: Keypair,
+    addr: NetAddr,
+}
+
+impl Node {
+    fn new(index: usize) -> Self {
+        let (public_key, private_key) =
+            BLSPubKey::generated_from_seed_indexed([0u8; 32], index as u64);
+        let keypair = Keypair::derive_from::<BLSPubKey>(&private_key).unwrap();
+        let port = test_utils::reserve_tcp_port().expect("OS should have ephemeral ports");
+        Self {
+            public_key,
+            keypair,
+            addr: NetAddr::Inet(Ipv4Addr::LOCALHOST.into(), port),
+        }
+    }
+
+    fn peer(&self) -> (BLSPubKey, PeerConnectInfo) {
+        (
+            self.public_key,
+            PeerConnectInfo {
+                x25519_key: self.keypair.public_key(),
+                p2p_addr: self.addr.clone(),
+            },
+        )
+    }
+
+    async fn network(
+        &self,
+        parties: Vec<(BLSPubKey, PeerConnectInfo)>,
+        policy: PeerPolicy<BLSPubKey>,
+    ) -> Result<Cliquenet<TestTypes>, NetworkError> {
+        Cliquenet::create(
+            "observer-test",
+            self.public_key,
+            self.keypair.clone(),
+            self.addr.clone(),
+            parties,
+            policy,
+            test_upgrade_lock(),
+            Box::new(NoMetrics),
+        )
+        .await
+    }
+}
+
+fn message(from: &Node, view: u64) -> Message<TestTypes, Validated> {
+    Message {
+        sender: from.public_key,
+        message_type: MessageType::Block(BlockMessage::Transactions(TransactionMessage {
+            view: ViewNumber::new(view),
+            transactions: vec![],
+        })),
+    }
+}
+
+fn view_of(m: &Message<TestTypes, Unchecked>) -> u64 {
+    match &m.message_type {
+        MessageType::Block(BlockMessage::Transactions(t)) => *t.view,
+        other => panic!("unexpected message {other:?}"),
+    }
+}
+
+async fn recv(net: &mut Cliquenet<TestTypes>) -> Message<TestTypes, Unchecked> {
+    timeout(RECV_TIMEOUT, net.receive())
+        .await
+        .expect("timed out waiting for message")
+        .expect("receive failed")
+}
+
+async fn assert_silent(net: &mut Cliquenet<TestTypes>, what: &str) {
+    if let Ok(m) = timeout(SILENCE, net.receive()).await {
+        panic!("{what}: unexpectedly received {m:?}");
+    }
+}
+
+/// F peers with V via the stake table and pins O as a Passive observer; O
+/// peers only with F.
+struct Mesh {
+    f: Node,
+    v: Node,
+    o: Node,
+    net_f: Cliquenet<TestTypes>,
+    net_v: Cliquenet<TestTypes>,
+    net_o: Cliquenet<TestTypes>,
+}
+
+impl Mesh {
+    async fn connect() -> Self {
+        crate::logging::init_test_logging();
+        let f = Node::new(0);
+        let v = Node::new(1);
+        let o = Node::new(2);
+        let net_f = f
+            .network(
+                vec![v.peer()],
+                PeerPolicy::StakeTable {
+                    observers: vec![o.peer()],
+                },
+            )
+            .await
+            .unwrap();
+        let net_v = v
+            .network(vec![f.peer()], PeerPolicy::default())
+            .await
+            .unwrap();
+        let net_o = o
+            .network(
+                vec![],
+                PeerPolicy::StaticOnly {
+                    upstreams: vec![f.peer()],
+                },
+            )
+            .await
+            .unwrap();
+        sleep(SETTLE).await;
+        Self {
+            f,
+            v,
+            o,
+            net_f,
+            net_v,
+            net_o,
+        }
+    }
+}
+
+#[tokio::test]
+async fn observer_receives_forwarded_messages_only() {
+    let mut mesh = Mesh::connect().await;
+    let view = ViewNumber::new(1);
+
+    mesh.net_f
+        .sender()
+        .broadcast(view, &message(&mesh.f, 1))
+        .unwrap();
+    let got = recv(&mut mesh.net_v).await;
+    assert_eq!(got.sender, mesh.f.public_key);
+    assert_eq!(view_of(&got), 1);
+    // A broadcast is also delivered to the sender itself.
+    assert_eq!(view_of(&recv(&mut mesh.net_f).await), 1);
+    assert_silent(&mut mesh.net_o, "observer got a broadcast").await;
+
+    mesh.net_f
+        .sender()
+        .send_to_observers(view, &message(&mesh.f, 2))
+        .unwrap();
+    let got = recv(&mut mesh.net_o).await;
+    assert_eq!(got.sender, mesh.f.public_key);
+    assert_eq!(view_of(&got), 2);
+    assert_silent(&mut mesh.net_v, "validator got an observer message").await;
+
+    mesh.net_v
+        .sender()
+        .send_to_observers(view, &message(&mesh.v, 3))
+        .unwrap();
+    assert_silent(
+        &mut mesh.net_f,
+        "send_to_observers without observers sent something",
+    )
+    .await;
+    assert_silent(
+        &mut mesh.net_o,
+        "send_to_observers without observers sent something",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn observer_messages_are_accepted_by_upstream() {
+    let mut mesh = Mesh::connect().await;
+    let view = ViewNumber::new(1);
+
+    mesh.net_o
+        .sender()
+        .broadcast(view, &message(&mesh.o, 4))
+        .unwrap();
+    let got = recv(&mut mesh.net_f).await;
+    assert_eq!(got.sender, mesh.o.public_key);
+    assert_eq!(view_of(&got), 4);
+
+    mesh.net_o
+        .sender()
+        .unicast(view, &mesh.f.public_key, &message(&mesh.o, 5))
+        .unwrap();
+    let got = recv(&mut mesh.net_f).await;
+    assert_eq!(view_of(&got), 5);
+
+    assert_silent(&mut mesh.net_v, "validator got an observer broadcast").await;
+}
+
+#[tokio::test]
+async fn apply_epoch_keeps_static_peers() {
+    let mut mesh = Mesh::connect().await;
+
+    let schedule = StakeTableSchedule {
+        initial: vec![0, 1],
+        changes: vec![],
+    };
+    let infos = [mesh.f.peer().1, mesh.v.peer().1];
+    let (coord, ..) = mock_membership_with_client_and_schedule(
+        2,
+        10,
+        mesh.f.public_key,
+        TestStorage::default(),
+        &schedule,
+        &infos,
+    );
+
+    mesh.net_f.apply_epoch(EpochNumber::new(1), &coord).unwrap();
+    let mut peers: Vec<_> = mesh.net_f.sender().peers().into_keys().collect();
+    peers.sort();
+    // Stake-table peers (including this node itself) plus the static observer.
+    let mut expected = vec![mesh.f.public_key, mesh.v.public_key, mesh.o.public_key];
+    expected.sort();
+    assert_eq!(peers, expected, "static observer must survive apply_epoch");
+
+    mesh.net_o.apply_epoch(EpochNumber::new(1), &coord).unwrap();
+    let peers = mesh.net_o.sender().peers();
+    assert_eq!(peers.len(), 1);
+    assert!(peers.contains_key(&mesh.f.public_key));
+    assert!(!peers.contains_key(&mesh.v.public_key));
+
+    mesh.net_f.remove_peers(vec![&mesh.o.public_key]).unwrap();
+    assert!(mesh.net_f.sender().peers().contains_key(&mesh.o.public_key));
+
+    let view = ViewNumber::new(2);
+    mesh.net_f
+        .sender()
+        .send_to_observers(view, &message(&mesh.f, 6))
+        .unwrap();
+    assert_eq!(view_of(&recv(&mut mesh.net_o).await), 6);
+}
+
+#[tokio::test]
+async fn rejects_self_and_duplicate_static_peers() {
+    crate::logging::init_test_logging();
+    let me = Node::new(0);
+    let other = Node::new(1);
+
+    let err = me
+        .network(
+            vec![],
+            PeerPolicy::StakeTable {
+                observers: vec![me.peer()],
+            },
+        )
+        .await
+        .expect_err("own key must be rejected");
+    assert!(matches!(err, NetworkError::StaticPeers(_)), "{err}");
+
+    let err = me
+        .network(
+            vec![],
+            PeerPolicy::StaticOnly {
+                upstreams: vec![other.peer(), other.peer()],
+            },
+        )
+        .await
+        .expect_err("duplicate key must be rejected");
+    assert!(matches!(err, NetworkError::StaticPeers(_)), "{err}");
+
+    // Also among the parties: the static entry wins and is not a duplicate.
+    let net = me
+        .network(
+            vec![other.peer()],
+            PeerPolicy::StakeTable {
+                observers: vec![other.peer()],
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(net.sender().static_peer_keys(), vec![other.public_key]);
+    assert!(!net.sender().is_observer());
+}

--- a/crates/hotshot/new-protocol/src/tests/observer.rs
+++ b/crates/hotshot/new-protocol/src/tests/observer.rs
@@ -1,0 +1,66 @@
+//! Observer nodes: never staked, fed by upstream validators over
+//! config-pinned cliquenet peers.
+
+use std::collections::BTreeMap;
+
+use crate::tests::common::runner::{NodeAction, NodeChange, TestRunner};
+
+async fn assert_observer_followed(runner: &TestRunner, idx: usize, min_height: u64) {
+    let storage = &runner.node_storages()[idx];
+    let actions = storage.action_log().await;
+    assert!(
+        actions.is_empty(),
+        "observer {idx} took consensus actions: {actions:?}"
+    );
+    let (anchor, _) = storage
+        .anchor_leaf()
+        .await
+        .expect("observer should have decided");
+    assert!(
+        anchor.height() >= min_height,
+        "observer {idx} stalled at block {}",
+        anchor.height()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn observer_follows_chain_across_epochs() {
+    let mut runner = TestRunner::builder()
+        .num_nodes(5)
+        .observer_nodes(BTreeMap::from([(4, vec![0, 1])]))
+        .epoch_height(10)
+        .target_decisions(35)
+        .build();
+    runner.run().await.unwrap();
+    assert_observer_followed(&runner, 4, 35).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn observer_follows_single_upstream() {
+    let mut runner = TestRunner::builder()
+        .num_nodes(4)
+        .observer_nodes(BTreeMap::from([(3, vec![0])]))
+        .target_decisions(20)
+        .build();
+    runner.run().await.unwrap();
+    assert_observer_followed(&runner, 3, 20).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn observer_restart_resumes_following() {
+    let mut runner = TestRunner::builder()
+        .num_nodes(5)
+        .observer_nodes(BTreeMap::from([(4, vec![0, 1, 2])]))
+        .persistent_storage(true)
+        .target_decisions(30)
+        .node_changes(vec![(
+            12,
+            vec![NodeChange {
+                idx: 4,
+                action: NodeAction::Restart,
+            }],
+        )])
+        .build();
+    runner.run().await.unwrap();
+    assert_observer_followed(&runner, 4, 30).await;
+}


### PR DESCRIPTION
Release-branch (`release-20260819`, which the `20260910` release is tagged on) version of the cliquenet observer change. The same change rebased onto `main` is #4935; review there first, this one is the backport-shaped counterpart.

Supersedes #4934, which GitHub closed when its head branch was renamed to `release-cliquenet-follower`.

## Why

After 0.6 all consensus traffic runs over cliquenet, whose peer set comes only from the stake table. A non-staked node receives nothing, so its query service is fed purely by HTTP backfill from `--peers`, and the active fetcher can only fill heights below the highest header it already has: without decides the watermark never rises. Our mainnet query nodes are not staked.

## What

Validators can pin "observer" nodes as `Role::Passive` cliquenet peers and forward them validated proposals, cert1 (as `HighQc`), cert2 and epoch changes. An observer decides every block live, without stake, voting, or any wire or protocol change. The consensus state machine already follows without stake (`staked_in_epoch` gates only vote1/vote2, and a parked proposal is adopted when its cert2 arrives); this PR adds the network plumbing and the explicit relay.

Only nodes that set the new options change behaviour. Other operators need no code, config or coordination.

Commits, in review order:

1. `network.rs`: `PeerPolicy` (`StakeTable { observers }` / `StaticOnly { upstreams }`), static peers exempt from `apply_epoch` eviction and `remove_peers`, `send_to_observers`, own-key and duplicate-key validation at startup.
2. `coordinator.rs`: `forward_to_observers` on `SendProposal`, `ProposalValidated` and the `broadcast` helper; `TestRunner` observer support and three runner tests.
3. node: `--cliquenet-observer-peers` / `--cliquenet-upstream-peers` (`BLS_VER_KEY~…@X25519_PK~…@host:port`), `NetworkParams`, observer catchup responders, refuse the `submit` module on observers.
4. Sequencer end-to-end test with a served observer query node.

## Where to focus

- `validate_static_peers` and the two skip points in `apply_epoch` (`network.rs`). Config parties always start `Active`, so `create_with_config` assigns the role right after creation.
- `forward_to_observers`: cert1 goes out as `HighQc` because that is the only certificate intake that advances an observer's view, and the only one not dropped when more than `MAX_VIEWS_AHEAD` ahead. Cert1/Cert2 handlers do not move the view. Like the proposal broadcast, it warns on regular network errors and returns only critical ones.
- `CliquenetPeer::from_str` and the submit-module refusal (`options.rs`).

## Not in this PR

Payloads and VID common still arrive over HTTP from `--peers`. Forwarding them (as `MessageType::External` bytes) is a follow-up, as are deduping duplicate proposal validations on observers with several upstreams and role promotion if a static peer later joins the stake table.

## Testing

- new-protocol: 4 network-layer tests and 3 `TestRunner` observer tests (across epochs, single upstream, restart from persisted anchor); full suite passes.
- node: 4 option-parsing tests; `test_new_protocol_observer_query_node` (5 validators + observer, 3 epochs, payload via HTTP fallback) passes 3/3 with retries disabled.
- Negative control: with `forward_to_observers` stubbed out, the single-upstream runner test does not complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

